### PR TITLE
feat(fmt): add comma for list of things longer than 2

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,7 +29,11 @@ pub fn build(b: *std.Build) void {
     const dependencies_opts = .{ .target = target, .optimize = optimize };
 
     // This array can be passed to add the dependencies to lib, executable, tests, etc using `addModule` function.
-    const deps = build_helpers.generateModuleDependencies(b, &external_dependencies, dependencies_opts) catch unreachable;
+    const deps = build_helpers.generateModuleDependencies(
+        b,
+        &external_dependencies,
+        dependencies_opts,
+    ) catch unreachable;
 
     // **************************************************************
     // *               CAIRO-ZIG AS A MODULE                        *
@@ -52,7 +56,10 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     // Add dependency modules to the library.
-    for (deps) |mod| lib.addModule(mod.name, mod.module);
+    for (deps) |mod| lib.addModule(
+        mod.name,
+        mod.module,
+    );
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
     // running `zig build`).
@@ -70,7 +77,10 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     // Add dependency modules to the executable.
-    for (deps) |mod| exe.addModule(mod.name, mod.module);
+    for (deps) |mod| exe.addModule(
+        mod.name,
+        mod.module,
+    );
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default
     // step when running `zig build`).
@@ -96,7 +106,10 @@ pub fn build(b: *std.Build) void {
     // This creates a build step. It will be visible in the `zig build --help` menu,
     // and can be selected like this: `zig build run`
     // This will evaluate the `run` step rather than the default, which is "install".
-    const run_step = b.step("run", "Run the app");
+    const run_step = b.step(
+        "run",
+        "Run the app",
+    );
     run_step.dependOn(&run_cmd.step);
 
     // Creates a step for unit testing. This only builds the test executable
@@ -107,14 +120,20 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     // Add dependency modules to the tests.
-    for (deps) |mod| unit_tests.addModule(mod.name, mod.module);
+    for (deps) |mod| unit_tests.addModule(
+        mod.name,
+        mod.module,
+    );
 
     const run_unit_tests = b.addRunArtifact(unit_tests);
 
     // Similar to creating the run step earlier, this exposes a `test` step to
     // the `zig build --help` menu, providing a way for the user to request
     // running the unit tests.
-    const test_step = b.step("test", "Run unit tests");
+    const test_step = b.step(
+        "test",
+        "Run unit tests",
+    );
     test_step.dependOn(&lib.step);
     test_step.dependOn(&run_unit_tests.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,10 @@ const package_path = "src/lib.zig";
 
 // List of external dependencies that this package requires.
 const external_dependencies = [_]build_helpers.Dependency{
-    .{ .name = "zig-cli", .module_name = "zig-cli" },
+    .{
+        .name = "zig-cli",
+        .module_name = "zig-cli",
+    },
 };
 
 // Although this function looks imperative, note that its job is to
@@ -26,7 +29,10 @@ pub fn build(b: *std.Build) void {
     // **************************************************************
     // *            HANDLE DEPENDENCY MODULES                       *
     // **************************************************************
-    const dependencies_opts = .{ .target = target, .optimize = optimize };
+    const dependencies_opts = .{
+        .target = target,
+        .optimize = optimize,
+    };
 
     // This array can be passed to add the dependencies to lib, executable, tests, etc using `addModule` function.
     const deps = build_helpers.generateModuleDependencies(

--- a/build_helpers.zig
+++ b/build_helpers.zig
@@ -13,16 +13,27 @@ pub const Dependency = struct {
 /// * `dependencies_opts` - The options to use when generating the dependency modules.
 /// # Returns
 /// A new array of Build.ModuleDependency.
-pub fn generateModuleDependencies(b: *std.Build, external_dependencies: []const Dependency, dependencies_opts: anytype) ![]std.Build.ModuleDependency {
+pub fn generateModuleDependencies(
+    b: *std.Build,
+    external_dependencies: []const Dependency,
+    dependencies_opts: anytype,
+) ![]std.Build.ModuleDependency {
     var dependency_modules = std.ArrayList(*std.build.Module).init(b.allocator);
     defer _ = dependency_modules.deinit();
 
     // Populate dependency modules.
     for (external_dependencies) |dep| {
-        const module = b.dependency(dep.name, dependencies_opts).module(dep.module_name);
+        const module = b.dependency(
+            dep.name,
+            dependencies_opts,
+        ).module(dep.module_name);
         _ = dependency_modules.append(module) catch unreachable;
     }
-    return try toModuleDependencyArray(b.allocator, dependency_modules.items, external_dependencies);
+    return try toModuleDependencyArray(
+        b.allocator,
+        dependency_modules.items,
+        external_dependencies,
+    );
 }
 
 /// Convert an array of Build.Module pointers to an array of Build.ModuleDependency.
@@ -32,11 +43,18 @@ pub fn generateModuleDependencies(b: *std.Build, external_dependencies: []const 
 /// * `ext_deps` - The array of external dependencies.
 /// # Returns
 /// A new array of Build.ModuleDependency.
-fn toModuleDependencyArray(allocator: std.mem.Allocator, modules: []const *std.Build.Module, ext_deps: []const Dependency) ![]std.Build.ModuleDependency {
+fn toModuleDependencyArray(
+    allocator: std.mem.Allocator,
+    modules: []const *std.Build.Module,
+    ext_deps: []const Dependency,
+) ![]std.Build.ModuleDependency {
     var deps = std.ArrayList(std.Build.ModuleDependency).init(allocator);
     defer deps.deinit();
 
-    for (modules, 0..) |module_ptr, i| {
+    for (
+        modules,
+        0..,
+    ) |module_ptr, i| {
         try deps.append(.{
             .name = ext_deps[i].name,
             .module = module_ptr,

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -64,7 +64,10 @@ var app = &cli.App{
 
 /// Run the CLI app.
 pub fn run() !void {
-    return cli.run(app, gpa_allocator);
+    return cli.run(
+        app,
+        gpa_allocator,
+    );
 }
 
 // ************************************************************
@@ -73,21 +76,33 @@ pub fn run() !void {
 
 // execute entrypoint
 fn execute(_: []const []const u8) !void {
-    std.log.debug("Running Cairo VM...\n", .{});
+    std.log.debug(
+        "Running Cairo VM...\n",
+        .{},
+    );
 
     // Create a new VM instance.
     var vm = try vm_core.CairoVM.init(&gpa_allocator);
     defer vm.deinit(); // <-- This ensures that resources are freed when exiting the scope
 
-    const address_1 = relocatable.Relocatable.new(0, 0);
+    const address_1 = relocatable.Relocatable.new(
+        0,
+        0,
+    );
     const encoded_instruction = relocatable.fromU64(0x14A7800080008000);
 
     // Write a value to memory.
-    try vm.segments.memory.set(address_1, encoded_instruction);
+    try vm.segments.memory.set(
+        address_1,
+        encoded_instruction,
+    );
 
     // Run a step.
     vm.step() catch |err| {
-        std.debug.print("Error: {}\n", .{err});
+        std.debug.print(
+            "Error: {}\n",
+            .{err},
+        );
         return;
     };
 }

--- a/src/math/fields/fields.zig
+++ b/src/math/fields/fields.zig
@@ -2,7 +2,10 @@ const std = @import("std");
 const builtin = @import("builtin");
 const ArrayList = std.ArrayList;
 
-pub fn Field(comptime F: type, comptime mod: u256) type {
+pub fn Field(
+    comptime F: type,
+    comptime mod: u256,
+) type {
     return struct {
         pub const BitSize = @bitSizeOf(u256) - @clz(mod);
         pub const BytesSize = @sizeOf(u256);
@@ -12,7 +15,10 @@ pub fn Field(comptime F: type, comptime mod: u256) type {
         const Self = @This();
         const base_zero = val: {
             var bz: F.MontgomeryDomainFieldElement = undefined;
-            F.fromBytes(&bz, [_]u8{0} ** BytesSize);
+            F.fromBytes(
+                &bz,
+                [_]u8{0} ** BytesSize,
+            );
             break :val Self{ .fe = bz };
         };
 
@@ -20,12 +26,23 @@ pub fn Field(comptime F: type, comptime mod: u256) type {
 
         pub fn fromInteger(num: u256) Self {
             var lbe: [BytesSize]u8 = [_]u8{0} ** BytesSize;
-            std.mem.writeInt(u256, lbe[0..], num % Modulo, std.builtin.Endian.Little);
+            std.mem.writeInt(
+                u256,
+                lbe[0..],
+                num % Modulo,
+                std.builtin.Endian.Little,
+            );
 
             var nonMont: F.NonMontgomeryDomainFieldElement = undefined;
-            F.fromBytes(&nonMont, lbe);
+            F.fromBytes(
+                &nonMont,
+                lbe,
+            );
             var mont: F.MontgomeryDomainFieldElement = undefined;
-            F.toMontgomery(&mont, nonMont);
+            F.toMontgomery(
+                &mont,
+                nonMont,
+            );
 
             return Self{ .fe = mont };
         }
@@ -46,20 +63,35 @@ pub fn Field(comptime F: type, comptime mod: u256) type {
         pub fn fromBytes(bytes: [BytesSize]u8) Self {
             var non_mont: F.NonMontgomeryDomainFieldElement = undefined;
             inline for (0..4) |i| {
-                non_mont[i] = std.mem.readIntSlice(u64, bytes[i * 8 .. (i + 1) * 8], std.builtin.Endian.Little);
+                non_mont[i] = std.mem.readIntSlice(
+                    u64,
+                    bytes[i * 8 .. (i + 1) * 8],
+                    std.builtin.Endian.Little,
+                );
             }
             var ret: Self = undefined;
-            F.toMontgomery(&ret.fe, non_mont);
+            F.toMontgomery(
+                &ret.fe,
+                non_mont,
+            );
 
             return ret;
         }
 
         pub fn toBytes(self: Self) [BytesSize]u8 {
             var non_mont: F.NonMontgomeryDomainFieldElement = undefined;
-            F.fromMontgomery(&non_mont, self.fe);
+            F.fromMontgomery(
+                &non_mont,
+                self.fe,
+            );
             var ret: [BytesSize]u8 = undefined;
             inline for (0..4) |i| {
-                std.mem.writeIntSlice(u64, ret[i * 8 .. (i + 1) * 8], non_mont[i], std.builtin.Endian.Little);
+                std.mem.writeIntSlice(
+                    u64,
+                    ret[i * 8 .. (i + 1) * 8],
+                    non_mont[i],
+                    std.builtin.Endian.Little,
+                );
             }
 
             return ret;
@@ -72,38 +104,78 @@ pub fn Field(comptime F: type, comptime mod: u256) type {
 
         pub fn fromMontgomery(self: Self) F.NonMontgomeryDomainFieldElement {
             var nonMont: F.NonMontgomeryDomainFieldElement = undefined;
-            F.fromMontgomery(&nonMont, self.fe);
+            F.fromMontgomery(
+                &nonMont,
+                self.fe,
+            );
             return nonMont;
         }
-        pub fn add(self: Self, other: Self) Self {
+        pub fn add(
+            self: Self,
+            other: Self,
+        ) Self {
             var ret: F.NonMontgomeryDomainFieldElement = undefined;
-            F.add(&ret, self.fe, other.fe);
+            F.add(
+                &ret,
+                self.fe,
+                other.fe,
+            );
             return Self{ .fe = ret };
         }
 
-        pub fn sub(self: Self, other: Self) Self {
+        pub fn sub(
+            self: Self,
+            other: Self,
+        ) Self {
             var ret: F.MontgomeryDomainFieldElement = undefined;
-            F.sub(&ret, self.fe, other.fe);
+            F.sub(
+                &ret,
+                self.fe,
+                other.fe,
+            );
             return Self{ .fe = ret };
         }
 
-        pub fn mul(self: Self, other: Self) Self {
+        pub fn mul(
+            self: Self,
+            other: Self,
+        ) Self {
             var ret: F.MontgomeryDomainFieldElement = undefined;
-            F.mul(&ret, self.fe, other.fe);
+            F.mul(
+                &ret,
+                self.fe,
+                other.fe,
+            );
             return Self{ .fe = ret };
         }
 
         pub fn mulBy5(self: Self) Self {
             var ret: F.MontgomeryDomainFieldElement = undefined;
-            F.add(&ret, self.fe, self.fe);
-            F.add(&ret, ret, ret);
-            F.add(&ret, ret, self.fe);
+            F.add(
+                &ret,
+                self.fe,
+                self.fe,
+            );
+            F.add(
+                &ret,
+                ret,
+                ret,
+            );
+            F.add(
+                &ret,
+                ret,
+                self.fe,
+            );
             return Self{ .fe = ret };
         }
 
         pub fn neg(self: Self) Self {
             var ret: F.MontgomeryDomainFieldElement = undefined;
-            F.sub(&ret, base_zero.fe, self.fe);
+            F.sub(
+                &ret,
+                base_zero.fe,
+                self.fe,
+            );
             return Self{ .fe = ret };
         }
 
@@ -119,7 +191,10 @@ pub fn Field(comptime F: type, comptime mod: u256) type {
             return self.mul(self);
         }
 
-        pub fn pow2(self: Self, comptime exponent: u8) Self {
+        pub fn pow2(
+            self: Self,
+            comptime exponent: u8,
+        ) Self {
             var ret = self;
             inline for (exponent) |_| {
                 ret = ret.mul(ret);
@@ -127,7 +202,10 @@ pub fn Field(comptime F: type, comptime mod: u256) type {
             return ret;
         }
 
-        pub fn pow(self: Self, exponent: u256) Self {
+        pub fn pow(
+            self: Self,
+            exponent: u256,
+        ) Self {
             var res = one();
             var exp = exponent;
             var base = self;
@@ -141,18 +219,30 @@ pub fn Field(comptime F: type, comptime mod: u256) type {
             return res;
         }
 
-        pub fn batchInv(out: []Self, in: []const Self) !void {
+        pub fn batchInv(
+            out: []Self,
+            in: []const Self,
+        ) !void {
             std.debug.assert(out.len == in.len);
 
             var acc = one();
             for (0..in.len) |i| {
                 out[i] = acc;
-                acc = mul(acc, in[i]);
+                acc = mul(
+                    acc,
+                    in[i],
+                );
             }
             acc = acc.inv() orelse return error.CantInvertZeroElement;
             for (0..in.len) |i| {
-                out[in.len - i - 1] = mul(out[in.len - i - 1], acc);
-                acc = mul(acc, in[in.len - i - 1]);
+                out[in.len - i - 1] = mul(
+                    out[in.len - i - 1],
+                    acc,
+                );
+                acc = mul(
+                    acc,
+                    in[in.len - i - 1],
+                );
             }
         }
 
@@ -186,23 +276,43 @@ pub fn Field(comptime F: type, comptime mod: u256) type {
             return Self.fromInteger(@intCast(t));
         }
 
-        pub fn div(self: Self, den: Self) !Self {
+        pub fn div(
+            self: Self,
+            den: Self,
+        ) !Self {
             const den_inv = den.inv() orelse return error.DivisionByZero;
             return self.mul(den_inv);
         }
 
-        pub fn equal(self: Self, other: Self) bool {
-            return std.mem.eql(u64, &self.fe, &other.fe);
+        pub fn equal(
+            self: Self,
+            other: Self,
+        ) bool {
+            return std.mem.eql(
+                u64,
+                &self.fe,
+                &other.fe,
+            );
         }
 
         pub fn toInteger(self: Self) u256 {
             var non_mont: F.NonMontgomeryDomainFieldElement = undefined;
-            F.fromMontgomery(&non_mont, self.fe);
+            F.fromMontgomery(
+                &non_mont,
+                self.fe,
+            );
 
             var bytes: [BytesSize]u8 = [_]u8{0} ** BytesSize;
-            F.toBytes(&bytes, non_mont);
+            F.toBytes(
+                &bytes,
+                non_mont,
+            );
 
-            return std.mem.readInt(u256, &bytes, std.builtin.Endian.Little);
+            return std.mem.readInt(
+                u256,
+                &bytes,
+                std.builtin.Endian.Little,
+            );
         }
 
         // Try to convert the field element into a u64.
@@ -210,12 +320,18 @@ pub fn Field(comptime F: type, comptime mod: u256) type {
         pub fn tryIntoU64(self: Self) !u64 {
             const asU256 = self.toInteger();
             // Check if the value is small enough to fit into a u64
-            if (asU256 > @as(u256, std.math.maxInt(u64))) {
+            if (asU256 > @as(
+                u256,
+                std.math.maxInt(u64),
+            )) {
                 return error.ValueTooLarge;
             }
 
             // Otherwise, it's safe to cast
-            return @as(u64, @intCast(asU256));
+            return @as(
+                u64,
+                @intCast(asU256),
+            );
         }
 
         pub fn legendre(a: Self) i2 {

--- a/src/math/fields/stark_felt_252_gen_fp.zig
+++ b/src/math/fields/stark_felt_252_gen_fp.zig
@@ -20,14 +20,25 @@
 const std = @import("std");
 const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
-inline fn cast(comptime DestType: type, target: anytype) DestType {
+inline fn cast(
+    comptime DestType: type,
+    target: anytype,
+) DestType {
     @setEvalBranchQuota(10000);
     if (@typeInfo(@TypeOf(target)) == .Int) {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            const T = std.meta.Int(source.signedness, dest.bits);
-            return @bitCast(@as(T, @truncate(target)));
+            const T = std.meta.Int(
+                source.signedness,
+                dest.bits,
+            );
+            return @bitCast(
+                @as(
+                    T,
+                    @truncate(target),
+                ),
+            );
         }
     }
     return target;
@@ -54,12 +65,33 @@ pub const NonMontgomeryDomainFieldElement = [4]u64;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-inline fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
+inline fn addcarryxU64(
+    out1: *u64,
+    out2: *u1,
+    arg1: u1,
+    arg2: u64,
+    arg3: u64,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = ((cast(u128, arg1) + cast(u128, arg2)) + cast(u128, arg3));
-    const x2 = cast(u64, (x1 & cast(u128, 0xffffffffffffffff)));
-    const x3 = cast(u1, (x1 >> 64));
+    const x1 = ((cast(
+        u128,
+        arg1,
+    ) + cast(
+        u128,
+        arg2,
+    )) + cast(
+        u128,
+        arg3,
+    ));
+    const x2 = cast(u64, (x1 & cast(
+        u128,
+        0xffffffffffffffff,
+    )));
+    const x3 = cast(
+        u1,
+        (x1 >> 64),
+    );
     out1.* = x2;
     out2.* = x3;
 }
@@ -77,14 +109,41 @@ inline fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) vo
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-inline fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
+inline fn subborrowxU64(
+    out1: *u64,
+    out2: *u1,
+    arg1: u1,
+    arg2: u64,
+    arg3: u64,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = ((cast(i128, arg2) - cast(i128, arg1)) - cast(i128, arg3));
-    const x2 = cast(i1, (x1 >> 64));
-    const x3 = cast(u64, (x1 & cast(i128, 0xffffffffffffffff)));
+    const x1 = ((cast(
+        i128,
+        arg2,
+    ) - cast(
+        i128,
+        arg1,
+    )) - cast(
+        i128,
+        arg3,
+    ));
+    const x2 = cast(
+        i1,
+        (x1 >> 64),
+    );
+    const x3 = cast(u64, (x1 & cast(
+        i128,
+        0xffffffffffffffff,
+    )));
     out1.* = x3;
-    out2.* = cast(u1, (cast(i2, 0x0) - cast(i2, x2)));
+    out2.* = cast(u1, (cast(
+        i2,
+        0x0,
+    ) - cast(
+        i2,
+        x2,
+    )));
 }
 
 /// The function mulxU64 is a multiplication, returning the full double-width result.
@@ -99,12 +158,29 @@ inline fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) v
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
-inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
+inline fn mulxU64(
+    out1: *u64,
+    out2: *u64,
+    arg1: u64,
+    arg2: u64,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (cast(u128, arg1) * cast(u128, arg2));
-    const x2 = cast(u64, (x1 & cast(u128, 0xffffffffffffffff)));
-    const x3 = cast(u64, (x1 >> 64));
+    const x1 = (cast(
+        u128,
+        arg1,
+    ) * cast(
+        u128,
+        arg2,
+    ));
+    const x2 = cast(u64, (x1 & cast(
+        u128,
+        0xffffffffffffffff,
+    )));
+    const x3 = cast(
+        u64,
+        (x1 >> 64),
+    );
     out1.* = x2;
     out2.* = x3;
 }
@@ -120,11 +196,25 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 ///   arg3: [0x0 ~> 0xffffffffffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
-inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
+inline fn cmovznzU64(
+    out1: *u64,
+    arg1: u1,
+    arg2: u64,
+    arg3: u64,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));
-    const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
+    const x2 = cast(u64, (cast(i128, cast(i1, (cast(
+        i2,
+        0x0,
+    ) - cast(
+        i2,
+        x1,
+    )))) & cast(
+        i128,
+        0xffffffffffffffff,
+    )));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;
 }
@@ -138,7 +228,11 @@ inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
 ///   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) * eval (from_montgomery arg2)) mod m
 ///   0 ≤ eval out1 < m
 ///
-pub fn mul(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldElement, arg2: MontgomeryDomainFieldElement) void {
+pub fn mul(
+    out1: *MontgomeryDomainFieldElement,
+    arg1: MontgomeryDomainFieldElement,
+    arg2: MontgomeryDomainFieldElement,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (arg1[1]);
@@ -147,247 +241,690 @@ pub fn mul(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldEleme
     const x4 = (arg1[0]);
     var x5: u64 = undefined;
     var x6: u64 = undefined;
-    mulxU64(&x5, &x6, x4, (arg2[3]));
+    mulxU64(
+        &x5,
+        &x6,
+        x4,
+        (arg2[3]),
+    );
     var x7: u64 = undefined;
     var x8: u64 = undefined;
-    mulxU64(&x7, &x8, x4, (arg2[2]));
+    mulxU64(
+        &x7,
+        &x8,
+        x4,
+        (arg2[2]),
+    );
     var x9: u64 = undefined;
     var x10: u64 = undefined;
-    mulxU64(&x9, &x10, x4, (arg2[1]));
+    mulxU64(
+        &x9,
+        &x10,
+        x4,
+        (arg2[1]),
+    );
     var x11: u64 = undefined;
     var x12: u64 = undefined;
-    mulxU64(&x11, &x12, x4, (arg2[0]));
+    mulxU64(
+        &x11,
+        &x12,
+        x4,
+        (arg2[0]),
+    );
     var x13: u64 = undefined;
     var x14: u1 = undefined;
-    addcarryxU64(&x13, &x14, 0x0, x12, x9);
+    addcarryxU64(
+        &x13,
+        &x14,
+        0x0,
+        x12,
+        x9,
+    );
     var x15: u64 = undefined;
     var x16: u1 = undefined;
-    addcarryxU64(&x15, &x16, x14, x10, x7);
+    addcarryxU64(
+        &x15,
+        &x16,
+        x14,
+        x10,
+        x7,
+    );
     var x17: u64 = undefined;
     var x18: u1 = undefined;
-    addcarryxU64(&x17, &x18, x16, x8, x5);
-    const x19 = (cast(u64, x18) + x6);
+    addcarryxU64(
+        &x17,
+        &x18,
+        x16,
+        x8,
+        x5,
+    );
+    const x19 = (cast(
+        u64,
+        x18,
+    ) + x6);
     var x20: u64 = undefined;
     var x21: u64 = undefined;
-    mulxU64(&x20, &x21, x11, 0xffffffffffffffff);
+    mulxU64(
+        &x20,
+        &x21,
+        x11,
+        0xffffffffffffffff,
+    );
     var x22: u64 = undefined;
     var x23: u64 = undefined;
-    mulxU64(&x22, &x23, x20, 0x800000000000011);
+    mulxU64(
+        &x22,
+        &x23,
+        x20,
+        0x800000000000011,
+    );
     var x24: u64 = undefined;
     var x25: u1 = undefined;
-    addcarryxU64(&x24, &x25, 0x0, x11, x20);
+    addcarryxU64(
+        &x24,
+        &x25,
+        0x0,
+        x11,
+        x20,
+    );
     var x26: u64 = undefined;
     var x27: u1 = undefined;
-    addcarryxU64(&x26, &x27, x25, x13, cast(u64, 0x0));
+    addcarryxU64(&x26, &x27, x25, x13, cast(
+        u64,
+        0x0,
+    ));
     var x28: u64 = undefined;
     var x29: u1 = undefined;
-    addcarryxU64(&x28, &x29, x27, x15, cast(u64, 0x0));
+    addcarryxU64(&x28, &x29, x27, x15, cast(
+        u64,
+        0x0,
+    ));
     var x30: u64 = undefined;
     var x31: u1 = undefined;
-    addcarryxU64(&x30, &x31, x29, x17, x22);
+    addcarryxU64(
+        &x30,
+        &x31,
+        x29,
+        x17,
+        x22,
+    );
     var x32: u64 = undefined;
     var x33: u1 = undefined;
-    addcarryxU64(&x32, &x33, x31, x19, x23);
+    addcarryxU64(
+        &x32,
+        &x33,
+        x31,
+        x19,
+        x23,
+    );
     var x34: u64 = undefined;
     var x35: u64 = undefined;
-    mulxU64(&x34, &x35, x1, (arg2[3]));
+    mulxU64(
+        &x34,
+        &x35,
+        x1,
+        (arg2[3]),
+    );
     var x36: u64 = undefined;
     var x37: u64 = undefined;
-    mulxU64(&x36, &x37, x1, (arg2[2]));
+    mulxU64(
+        &x36,
+        &x37,
+        x1,
+        (arg2[2]),
+    );
     var x38: u64 = undefined;
     var x39: u64 = undefined;
-    mulxU64(&x38, &x39, x1, (arg2[1]));
+    mulxU64(
+        &x38,
+        &x39,
+        x1,
+        (arg2[1]),
+    );
     var x40: u64 = undefined;
     var x41: u64 = undefined;
-    mulxU64(&x40, &x41, x1, (arg2[0]));
+    mulxU64(
+        &x40,
+        &x41,
+        x1,
+        (arg2[0]),
+    );
     var x42: u64 = undefined;
     var x43: u1 = undefined;
-    addcarryxU64(&x42, &x43, 0x0, x41, x38);
+    addcarryxU64(
+        &x42,
+        &x43,
+        0x0,
+        x41,
+        x38,
+    );
     var x44: u64 = undefined;
     var x45: u1 = undefined;
-    addcarryxU64(&x44, &x45, x43, x39, x36);
+    addcarryxU64(
+        &x44,
+        &x45,
+        x43,
+        x39,
+        x36,
+    );
     var x46: u64 = undefined;
     var x47: u1 = undefined;
-    addcarryxU64(&x46, &x47, x45, x37, x34);
-    const x48 = (cast(u64, x47) + x35);
+    addcarryxU64(
+        &x46,
+        &x47,
+        x45,
+        x37,
+        x34,
+    );
+    const x48 = (cast(
+        u64,
+        x47,
+    ) + x35);
     var x49: u64 = undefined;
     var x50: u1 = undefined;
-    addcarryxU64(&x49, &x50, 0x0, x26, x40);
+    addcarryxU64(
+        &x49,
+        &x50,
+        0x0,
+        x26,
+        x40,
+    );
     var x51: u64 = undefined;
     var x52: u1 = undefined;
-    addcarryxU64(&x51, &x52, x50, x28, x42);
+    addcarryxU64(
+        &x51,
+        &x52,
+        x50,
+        x28,
+        x42,
+    );
     var x53: u64 = undefined;
     var x54: u1 = undefined;
-    addcarryxU64(&x53, &x54, x52, x30, x44);
+    addcarryxU64(
+        &x53,
+        &x54,
+        x52,
+        x30,
+        x44,
+    );
     var x55: u64 = undefined;
     var x56: u1 = undefined;
-    addcarryxU64(&x55, &x56, x54, x32, x46);
+    addcarryxU64(
+        &x55,
+        &x56,
+        x54,
+        x32,
+        x46,
+    );
     var x57: u64 = undefined;
     var x58: u1 = undefined;
-    addcarryxU64(&x57, &x58, x56, cast(u64, x33), x48);
+    addcarryxU64(&x57, &x58, x56, cast(
+        u64,
+        x33,
+    ), x48);
     var x59: u64 = undefined;
     var x60: u64 = undefined;
-    mulxU64(&x59, &x60, x49, 0xffffffffffffffff);
+    mulxU64(
+        &x59,
+        &x60,
+        x49,
+        0xffffffffffffffff,
+    );
     var x61: u64 = undefined;
     var x62: u64 = undefined;
-    mulxU64(&x61, &x62, x59, 0x800000000000011);
+    mulxU64(
+        &x61,
+        &x62,
+        x59,
+        0x800000000000011,
+    );
     var x63: u64 = undefined;
     var x64: u1 = undefined;
-    addcarryxU64(&x63, &x64, 0x0, x49, x59);
+    addcarryxU64(
+        &x63,
+        &x64,
+        0x0,
+        x49,
+        x59,
+    );
     var x65: u64 = undefined;
     var x66: u1 = undefined;
-    addcarryxU64(&x65, &x66, x64, x51, cast(u64, 0x0));
+    addcarryxU64(&x65, &x66, x64, x51, cast(
+        u64,
+        0x0,
+    ));
     var x67: u64 = undefined;
     var x68: u1 = undefined;
-    addcarryxU64(&x67, &x68, x66, x53, cast(u64, 0x0));
+    addcarryxU64(&x67, &x68, x66, x53, cast(
+        u64,
+        0x0,
+    ));
     var x69: u64 = undefined;
     var x70: u1 = undefined;
-    addcarryxU64(&x69, &x70, x68, x55, x61);
+    addcarryxU64(
+        &x69,
+        &x70,
+        x68,
+        x55,
+        x61,
+    );
     var x71: u64 = undefined;
     var x72: u1 = undefined;
-    addcarryxU64(&x71, &x72, x70, x57, x62);
-    const x73 = (cast(u64, x72) + cast(u64, x58));
+    addcarryxU64(
+        &x71,
+        &x72,
+        x70,
+        x57,
+        x62,
+    );
+    const x73 = (cast(
+        u64,
+        x72,
+    ) + cast(
+        u64,
+        x58,
+    ));
     var x74: u64 = undefined;
     var x75: u64 = undefined;
-    mulxU64(&x74, &x75, x2, (arg2[3]));
+    mulxU64(
+        &x74,
+        &x75,
+        x2,
+        (arg2[3]),
+    );
     var x76: u64 = undefined;
     var x77: u64 = undefined;
-    mulxU64(&x76, &x77, x2, (arg2[2]));
+    mulxU64(
+        &x76,
+        &x77,
+        x2,
+        (arg2[2]),
+    );
     var x78: u64 = undefined;
     var x79: u64 = undefined;
-    mulxU64(&x78, &x79, x2, (arg2[1]));
+    mulxU64(
+        &x78,
+        &x79,
+        x2,
+        (arg2[1]),
+    );
     var x80: u64 = undefined;
     var x81: u64 = undefined;
-    mulxU64(&x80, &x81, x2, (arg2[0]));
+    mulxU64(
+        &x80,
+        &x81,
+        x2,
+        (arg2[0]),
+    );
     var x82: u64 = undefined;
     var x83: u1 = undefined;
-    addcarryxU64(&x82, &x83, 0x0, x81, x78);
+    addcarryxU64(
+        &x82,
+        &x83,
+        0x0,
+        x81,
+        x78,
+    );
     var x84: u64 = undefined;
     var x85: u1 = undefined;
-    addcarryxU64(&x84, &x85, x83, x79, x76);
+    addcarryxU64(
+        &x84,
+        &x85,
+        x83,
+        x79,
+        x76,
+    );
     var x86: u64 = undefined;
     var x87: u1 = undefined;
-    addcarryxU64(&x86, &x87, x85, x77, x74);
-    const x88 = (cast(u64, x87) + x75);
+    addcarryxU64(
+        &x86,
+        &x87,
+        x85,
+        x77,
+        x74,
+    );
+    const x88 = (cast(
+        u64,
+        x87,
+    ) + x75);
     var x89: u64 = undefined;
     var x90: u1 = undefined;
-    addcarryxU64(&x89, &x90, 0x0, x65, x80);
+    addcarryxU64(
+        &x89,
+        &x90,
+        0x0,
+        x65,
+        x80,
+    );
     var x91: u64 = undefined;
     var x92: u1 = undefined;
-    addcarryxU64(&x91, &x92, x90, x67, x82);
+    addcarryxU64(
+        &x91,
+        &x92,
+        x90,
+        x67,
+        x82,
+    );
     var x93: u64 = undefined;
     var x94: u1 = undefined;
-    addcarryxU64(&x93, &x94, x92, x69, x84);
+    addcarryxU64(
+        &x93,
+        &x94,
+        x92,
+        x69,
+        x84,
+    );
     var x95: u64 = undefined;
     var x96: u1 = undefined;
-    addcarryxU64(&x95, &x96, x94, x71, x86);
+    addcarryxU64(
+        &x95,
+        &x96,
+        x94,
+        x71,
+        x86,
+    );
     var x97: u64 = undefined;
     var x98: u1 = undefined;
-    addcarryxU64(&x97, &x98, x96, x73, x88);
+    addcarryxU64(
+        &x97,
+        &x98,
+        x96,
+        x73,
+        x88,
+    );
     var x99: u64 = undefined;
     var x100: u64 = undefined;
-    mulxU64(&x99, &x100, x89, 0xffffffffffffffff);
+    mulxU64(
+        &x99,
+        &x100,
+        x89,
+        0xffffffffffffffff,
+    );
     var x101: u64 = undefined;
     var x102: u64 = undefined;
-    mulxU64(&x101, &x102, x99, 0x800000000000011);
+    mulxU64(
+        &x101,
+        &x102,
+        x99,
+        0x800000000000011,
+    );
     var x103: u64 = undefined;
     var x104: u1 = undefined;
-    addcarryxU64(&x103, &x104, 0x0, x89, x99);
+    addcarryxU64(
+        &x103,
+        &x104,
+        0x0,
+        x89,
+        x99,
+    );
     var x105: u64 = undefined;
     var x106: u1 = undefined;
-    addcarryxU64(&x105, &x106, x104, x91, cast(u64, 0x0));
+    addcarryxU64(&x105, &x106, x104, x91, cast(
+        u64,
+        0x0,
+    ));
     var x107: u64 = undefined;
     var x108: u1 = undefined;
-    addcarryxU64(&x107, &x108, x106, x93, cast(u64, 0x0));
+    addcarryxU64(&x107, &x108, x106, x93, cast(
+        u64,
+        0x0,
+    ));
     var x109: u64 = undefined;
     var x110: u1 = undefined;
-    addcarryxU64(&x109, &x110, x108, x95, x101);
+    addcarryxU64(
+        &x109,
+        &x110,
+        x108,
+        x95,
+        x101,
+    );
     var x111: u64 = undefined;
     var x112: u1 = undefined;
-    addcarryxU64(&x111, &x112, x110, x97, x102);
-    const x113 = (cast(u64, x112) + cast(u64, x98));
+    addcarryxU64(
+        &x111,
+        &x112,
+        x110,
+        x97,
+        x102,
+    );
+    const x113 = (cast(
+        u64,
+        x112,
+    ) + cast(
+        u64,
+        x98,
+    ));
     var x114: u64 = undefined;
     var x115: u64 = undefined;
-    mulxU64(&x114, &x115, x3, (arg2[3]));
+    mulxU64(
+        &x114,
+        &x115,
+        x3,
+        (arg2[3]),
+    );
     var x116: u64 = undefined;
     var x117: u64 = undefined;
-    mulxU64(&x116, &x117, x3, (arg2[2]));
+    mulxU64(
+        &x116,
+        &x117,
+        x3,
+        (arg2[2]),
+    );
     var x118: u64 = undefined;
     var x119: u64 = undefined;
-    mulxU64(&x118, &x119, x3, (arg2[1]));
+    mulxU64(
+        &x118,
+        &x119,
+        x3,
+        (arg2[1]),
+    );
     var x120: u64 = undefined;
     var x121: u64 = undefined;
-    mulxU64(&x120, &x121, x3, (arg2[0]));
+    mulxU64(
+        &x120,
+        &x121,
+        x3,
+        (arg2[0]),
+    );
     var x122: u64 = undefined;
     var x123: u1 = undefined;
-    addcarryxU64(&x122, &x123, 0x0, x121, x118);
+    addcarryxU64(
+        &x122,
+        &x123,
+        0x0,
+        x121,
+        x118,
+    );
     var x124: u64 = undefined;
     var x125: u1 = undefined;
-    addcarryxU64(&x124, &x125, x123, x119, x116);
+    addcarryxU64(
+        &x124,
+        &x125,
+        x123,
+        x119,
+        x116,
+    );
     var x126: u64 = undefined;
     var x127: u1 = undefined;
-    addcarryxU64(&x126, &x127, x125, x117, x114);
-    const x128 = (cast(u64, x127) + x115);
+    addcarryxU64(
+        &x126,
+        &x127,
+        x125,
+        x117,
+        x114,
+    );
+    const x128 = (cast(
+        u64,
+        x127,
+    ) + x115);
     var x129: u64 = undefined;
     var x130: u1 = undefined;
-    addcarryxU64(&x129, &x130, 0x0, x105, x120);
+    addcarryxU64(
+        &x129,
+        &x130,
+        0x0,
+        x105,
+        x120,
+    );
     var x131: u64 = undefined;
     var x132: u1 = undefined;
-    addcarryxU64(&x131, &x132, x130, x107, x122);
+    addcarryxU64(
+        &x131,
+        &x132,
+        x130,
+        x107,
+        x122,
+    );
     var x133: u64 = undefined;
     var x134: u1 = undefined;
-    addcarryxU64(&x133, &x134, x132, x109, x124);
+    addcarryxU64(
+        &x133,
+        &x134,
+        x132,
+        x109,
+        x124,
+    );
     var x135: u64 = undefined;
     var x136: u1 = undefined;
-    addcarryxU64(&x135, &x136, x134, x111, x126);
+    addcarryxU64(
+        &x135,
+        &x136,
+        x134,
+        x111,
+        x126,
+    );
     var x137: u64 = undefined;
     var x138: u1 = undefined;
-    addcarryxU64(&x137, &x138, x136, x113, x128);
+    addcarryxU64(
+        &x137,
+        &x138,
+        x136,
+        x113,
+        x128,
+    );
     var x139: u64 = undefined;
     var x140: u64 = undefined;
-    mulxU64(&x139, &x140, x129, 0xffffffffffffffff);
+    mulxU64(
+        &x139,
+        &x140,
+        x129,
+        0xffffffffffffffff,
+    );
     var x141: u64 = undefined;
     var x142: u64 = undefined;
-    mulxU64(&x141, &x142, x139, 0x800000000000011);
+    mulxU64(
+        &x141,
+        &x142,
+        x139,
+        0x800000000000011,
+    );
     var x143: u64 = undefined;
     var x144: u1 = undefined;
-    addcarryxU64(&x143, &x144, 0x0, x129, x139);
+    addcarryxU64(
+        &x143,
+        &x144,
+        0x0,
+        x129,
+        x139,
+    );
     var x145: u64 = undefined;
     var x146: u1 = undefined;
-    addcarryxU64(&x145, &x146, x144, x131, cast(u64, 0x0));
+    addcarryxU64(&x145, &x146, x144, x131, cast(
+        u64,
+        0x0,
+    ));
     var x147: u64 = undefined;
     var x148: u1 = undefined;
-    addcarryxU64(&x147, &x148, x146, x133, cast(u64, 0x0));
+    addcarryxU64(&x147, &x148, x146, x133, cast(
+        u64,
+        0x0,
+    ));
     var x149: u64 = undefined;
     var x150: u1 = undefined;
-    addcarryxU64(&x149, &x150, x148, x135, x141);
+    addcarryxU64(
+        &x149,
+        &x150,
+        x148,
+        x135,
+        x141,
+    );
     var x151: u64 = undefined;
     var x152: u1 = undefined;
-    addcarryxU64(&x151, &x152, x150, x137, x142);
-    const x153 = (cast(u64, x152) + cast(u64, x138));
+    addcarryxU64(
+        &x151,
+        &x152,
+        x150,
+        x137,
+        x142,
+    );
+    const x153 = (cast(
+        u64,
+        x152,
+    ) + cast(
+        u64,
+        x138,
+    ));
     var x154: u64 = undefined;
     var x155: u1 = undefined;
-    subborrowxU64(&x154, &x155, 0x0, x145, cast(u64, 0x1));
+    subborrowxU64(&x154, &x155, 0x0, x145, cast(
+        u64,
+        0x1,
+    ));
     var x156: u64 = undefined;
     var x157: u1 = undefined;
-    subborrowxU64(&x156, &x157, x155, x147, cast(u64, 0x0));
+    subborrowxU64(&x156, &x157, x155, x147, cast(
+        u64,
+        0x0,
+    ));
     var x158: u64 = undefined;
     var x159: u1 = undefined;
-    subborrowxU64(&x158, &x159, x157, x149, cast(u64, 0x0));
+    subborrowxU64(&x158, &x159, x157, x149, cast(
+        u64,
+        0x0,
+    ));
     var x160: u64 = undefined;
     var x161: u1 = undefined;
-    subborrowxU64(&x160, &x161, x159, x151, 0x800000000000011);
+    subborrowxU64(
+        &x160,
+        &x161,
+        x159,
+        x151,
+        0x800000000000011,
+    );
     var x162: u64 = undefined;
     var x163: u1 = undefined;
-    subborrowxU64(&x162, &x163, x161, x153, cast(u64, 0x0));
+    subborrowxU64(&x162, &x163, x161, x153, cast(
+        u64,
+        0x0,
+    ));
     var x164: u64 = undefined;
-    cmovznzU64(&x164, x163, x154, x145);
+    cmovznzU64(
+        &x164,
+        x163,
+        x154,
+        x145,
+    );
     var x165: u64 = undefined;
-    cmovznzU64(&x165, x163, x156, x147);
+    cmovznzU64(
+        &x165,
+        x163,
+        x156,
+        x147,
+    );
     var x166: u64 = undefined;
-    cmovznzU64(&x166, x163, x158, x149);
+    cmovznzU64(
+        &x166,
+        x163,
+        x158,
+        x149,
+    );
     var x167: u64 = undefined;
-    cmovznzU64(&x167, x163, x160, x151);
+    cmovznzU64(
+        &x167,
+        x163,
+        x160,
+        x151,
+    );
     out1[0] = x164;
     out1[1] = x165;
     out1[2] = x166;
@@ -402,7 +939,10 @@ pub fn mul(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldEleme
 ///   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) * eval (from_montgomery arg1)) mod m
 ///   0 ≤ eval out1 < m
 ///
-pub fn square(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldElement) void {
+pub fn square(
+    out1: *MontgomeryDomainFieldElement,
+    arg1: MontgomeryDomainFieldElement,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (arg1[1]);
@@ -411,247 +951,690 @@ pub fn square(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldEl
     const x4 = (arg1[0]);
     var x5: u64 = undefined;
     var x6: u64 = undefined;
-    mulxU64(&x5, &x6, x4, (arg1[3]));
+    mulxU64(
+        &x5,
+        &x6,
+        x4,
+        (arg1[3]),
+    );
     var x7: u64 = undefined;
     var x8: u64 = undefined;
-    mulxU64(&x7, &x8, x4, (arg1[2]));
+    mulxU64(
+        &x7,
+        &x8,
+        x4,
+        (arg1[2]),
+    );
     var x9: u64 = undefined;
     var x10: u64 = undefined;
-    mulxU64(&x9, &x10, x4, (arg1[1]));
+    mulxU64(
+        &x9,
+        &x10,
+        x4,
+        (arg1[1]),
+    );
     var x11: u64 = undefined;
     var x12: u64 = undefined;
-    mulxU64(&x11, &x12, x4, (arg1[0]));
+    mulxU64(
+        &x11,
+        &x12,
+        x4,
+        (arg1[0]),
+    );
     var x13: u64 = undefined;
     var x14: u1 = undefined;
-    addcarryxU64(&x13, &x14, 0x0, x12, x9);
+    addcarryxU64(
+        &x13,
+        &x14,
+        0x0,
+        x12,
+        x9,
+    );
     var x15: u64 = undefined;
     var x16: u1 = undefined;
-    addcarryxU64(&x15, &x16, x14, x10, x7);
+    addcarryxU64(
+        &x15,
+        &x16,
+        x14,
+        x10,
+        x7,
+    );
     var x17: u64 = undefined;
     var x18: u1 = undefined;
-    addcarryxU64(&x17, &x18, x16, x8, x5);
-    const x19 = (cast(u64, x18) + x6);
+    addcarryxU64(
+        &x17,
+        &x18,
+        x16,
+        x8,
+        x5,
+    );
+    const x19 = (cast(
+        u64,
+        x18,
+    ) + x6);
     var x20: u64 = undefined;
     var x21: u64 = undefined;
-    mulxU64(&x20, &x21, x11, 0xffffffffffffffff);
+    mulxU64(
+        &x20,
+        &x21,
+        x11,
+        0xffffffffffffffff,
+    );
     var x22: u64 = undefined;
     var x23: u64 = undefined;
-    mulxU64(&x22, &x23, x20, 0x800000000000011);
+    mulxU64(
+        &x22,
+        &x23,
+        x20,
+        0x800000000000011,
+    );
     var x24: u64 = undefined;
     var x25: u1 = undefined;
-    addcarryxU64(&x24, &x25, 0x0, x11, x20);
+    addcarryxU64(
+        &x24,
+        &x25,
+        0x0,
+        x11,
+        x20,
+    );
     var x26: u64 = undefined;
     var x27: u1 = undefined;
-    addcarryxU64(&x26, &x27, x25, x13, cast(u64, 0x0));
+    addcarryxU64(&x26, &x27, x25, x13, cast(
+        u64,
+        0x0,
+    ));
     var x28: u64 = undefined;
     var x29: u1 = undefined;
-    addcarryxU64(&x28, &x29, x27, x15, cast(u64, 0x0));
+    addcarryxU64(&x28, &x29, x27, x15, cast(
+        u64,
+        0x0,
+    ));
     var x30: u64 = undefined;
     var x31: u1 = undefined;
-    addcarryxU64(&x30, &x31, x29, x17, x22);
+    addcarryxU64(
+        &x30,
+        &x31,
+        x29,
+        x17,
+        x22,
+    );
     var x32: u64 = undefined;
     var x33: u1 = undefined;
-    addcarryxU64(&x32, &x33, x31, x19, x23);
+    addcarryxU64(
+        &x32,
+        &x33,
+        x31,
+        x19,
+        x23,
+    );
     var x34: u64 = undefined;
     var x35: u64 = undefined;
-    mulxU64(&x34, &x35, x1, (arg1[3]));
+    mulxU64(
+        &x34,
+        &x35,
+        x1,
+        (arg1[3]),
+    );
     var x36: u64 = undefined;
     var x37: u64 = undefined;
-    mulxU64(&x36, &x37, x1, (arg1[2]));
+    mulxU64(
+        &x36,
+        &x37,
+        x1,
+        (arg1[2]),
+    );
     var x38: u64 = undefined;
     var x39: u64 = undefined;
-    mulxU64(&x38, &x39, x1, (arg1[1]));
+    mulxU64(
+        &x38,
+        &x39,
+        x1,
+        (arg1[1]),
+    );
     var x40: u64 = undefined;
     var x41: u64 = undefined;
-    mulxU64(&x40, &x41, x1, (arg1[0]));
+    mulxU64(
+        &x40,
+        &x41,
+        x1,
+        (arg1[0]),
+    );
     var x42: u64 = undefined;
     var x43: u1 = undefined;
-    addcarryxU64(&x42, &x43, 0x0, x41, x38);
+    addcarryxU64(
+        &x42,
+        &x43,
+        0x0,
+        x41,
+        x38,
+    );
     var x44: u64 = undefined;
     var x45: u1 = undefined;
-    addcarryxU64(&x44, &x45, x43, x39, x36);
+    addcarryxU64(
+        &x44,
+        &x45,
+        x43,
+        x39,
+        x36,
+    );
     var x46: u64 = undefined;
     var x47: u1 = undefined;
-    addcarryxU64(&x46, &x47, x45, x37, x34);
-    const x48 = (cast(u64, x47) + x35);
+    addcarryxU64(
+        &x46,
+        &x47,
+        x45,
+        x37,
+        x34,
+    );
+    const x48 = (cast(
+        u64,
+        x47,
+    ) + x35);
     var x49: u64 = undefined;
     var x50: u1 = undefined;
-    addcarryxU64(&x49, &x50, 0x0, x26, x40);
+    addcarryxU64(
+        &x49,
+        &x50,
+        0x0,
+        x26,
+        x40,
+    );
     var x51: u64 = undefined;
     var x52: u1 = undefined;
-    addcarryxU64(&x51, &x52, x50, x28, x42);
+    addcarryxU64(
+        &x51,
+        &x52,
+        x50,
+        x28,
+        x42,
+    );
     var x53: u64 = undefined;
     var x54: u1 = undefined;
-    addcarryxU64(&x53, &x54, x52, x30, x44);
+    addcarryxU64(
+        &x53,
+        &x54,
+        x52,
+        x30,
+        x44,
+    );
     var x55: u64 = undefined;
     var x56: u1 = undefined;
-    addcarryxU64(&x55, &x56, x54, x32, x46);
+    addcarryxU64(
+        &x55,
+        &x56,
+        x54,
+        x32,
+        x46,
+    );
     var x57: u64 = undefined;
     var x58: u1 = undefined;
-    addcarryxU64(&x57, &x58, x56, cast(u64, x33), x48);
+    addcarryxU64(&x57, &x58, x56, cast(
+        u64,
+        x33,
+    ), x48);
     var x59: u64 = undefined;
     var x60: u64 = undefined;
-    mulxU64(&x59, &x60, x49, 0xffffffffffffffff);
+    mulxU64(
+        &x59,
+        &x60,
+        x49,
+        0xffffffffffffffff,
+    );
     var x61: u64 = undefined;
     var x62: u64 = undefined;
-    mulxU64(&x61, &x62, x59, 0x800000000000011);
+    mulxU64(
+        &x61,
+        &x62,
+        x59,
+        0x800000000000011,
+    );
     var x63: u64 = undefined;
     var x64: u1 = undefined;
-    addcarryxU64(&x63, &x64, 0x0, x49, x59);
+    addcarryxU64(
+        &x63,
+        &x64,
+        0x0,
+        x49,
+        x59,
+    );
     var x65: u64 = undefined;
     var x66: u1 = undefined;
-    addcarryxU64(&x65, &x66, x64, x51, cast(u64, 0x0));
+    addcarryxU64(&x65, &x66, x64, x51, cast(
+        u64,
+        0x0,
+    ));
     var x67: u64 = undefined;
     var x68: u1 = undefined;
-    addcarryxU64(&x67, &x68, x66, x53, cast(u64, 0x0));
+    addcarryxU64(&x67, &x68, x66, x53, cast(
+        u64,
+        0x0,
+    ));
     var x69: u64 = undefined;
     var x70: u1 = undefined;
-    addcarryxU64(&x69, &x70, x68, x55, x61);
+    addcarryxU64(
+        &x69,
+        &x70,
+        x68,
+        x55,
+        x61,
+    );
     var x71: u64 = undefined;
     var x72: u1 = undefined;
-    addcarryxU64(&x71, &x72, x70, x57, x62);
-    const x73 = (cast(u64, x72) + cast(u64, x58));
+    addcarryxU64(
+        &x71,
+        &x72,
+        x70,
+        x57,
+        x62,
+    );
+    const x73 = (cast(
+        u64,
+        x72,
+    ) + cast(
+        u64,
+        x58,
+    ));
     var x74: u64 = undefined;
     var x75: u64 = undefined;
-    mulxU64(&x74, &x75, x2, (arg1[3]));
+    mulxU64(
+        &x74,
+        &x75,
+        x2,
+        (arg1[3]),
+    );
     var x76: u64 = undefined;
     var x77: u64 = undefined;
-    mulxU64(&x76, &x77, x2, (arg1[2]));
+    mulxU64(
+        &x76,
+        &x77,
+        x2,
+        (arg1[2]),
+    );
     var x78: u64 = undefined;
     var x79: u64 = undefined;
-    mulxU64(&x78, &x79, x2, (arg1[1]));
+    mulxU64(
+        &x78,
+        &x79,
+        x2,
+        (arg1[1]),
+    );
     var x80: u64 = undefined;
     var x81: u64 = undefined;
-    mulxU64(&x80, &x81, x2, (arg1[0]));
+    mulxU64(
+        &x80,
+        &x81,
+        x2,
+        (arg1[0]),
+    );
     var x82: u64 = undefined;
     var x83: u1 = undefined;
-    addcarryxU64(&x82, &x83, 0x0, x81, x78);
+    addcarryxU64(
+        &x82,
+        &x83,
+        0x0,
+        x81,
+        x78,
+    );
     var x84: u64 = undefined;
     var x85: u1 = undefined;
-    addcarryxU64(&x84, &x85, x83, x79, x76);
+    addcarryxU64(
+        &x84,
+        &x85,
+        x83,
+        x79,
+        x76,
+    );
     var x86: u64 = undefined;
     var x87: u1 = undefined;
-    addcarryxU64(&x86, &x87, x85, x77, x74);
-    const x88 = (cast(u64, x87) + x75);
+    addcarryxU64(
+        &x86,
+        &x87,
+        x85,
+        x77,
+        x74,
+    );
+    const x88 = (cast(
+        u64,
+        x87,
+    ) + x75);
     var x89: u64 = undefined;
     var x90: u1 = undefined;
-    addcarryxU64(&x89, &x90, 0x0, x65, x80);
+    addcarryxU64(
+        &x89,
+        &x90,
+        0x0,
+        x65,
+        x80,
+    );
     var x91: u64 = undefined;
     var x92: u1 = undefined;
-    addcarryxU64(&x91, &x92, x90, x67, x82);
+    addcarryxU64(
+        &x91,
+        &x92,
+        x90,
+        x67,
+        x82,
+    );
     var x93: u64 = undefined;
     var x94: u1 = undefined;
-    addcarryxU64(&x93, &x94, x92, x69, x84);
+    addcarryxU64(
+        &x93,
+        &x94,
+        x92,
+        x69,
+        x84,
+    );
     var x95: u64 = undefined;
     var x96: u1 = undefined;
-    addcarryxU64(&x95, &x96, x94, x71, x86);
+    addcarryxU64(
+        &x95,
+        &x96,
+        x94,
+        x71,
+        x86,
+    );
     var x97: u64 = undefined;
     var x98: u1 = undefined;
-    addcarryxU64(&x97, &x98, x96, x73, x88);
+    addcarryxU64(
+        &x97,
+        &x98,
+        x96,
+        x73,
+        x88,
+    );
     var x99: u64 = undefined;
     var x100: u64 = undefined;
-    mulxU64(&x99, &x100, x89, 0xffffffffffffffff);
+    mulxU64(
+        &x99,
+        &x100,
+        x89,
+        0xffffffffffffffff,
+    );
     var x101: u64 = undefined;
     var x102: u64 = undefined;
-    mulxU64(&x101, &x102, x99, 0x800000000000011);
+    mulxU64(
+        &x101,
+        &x102,
+        x99,
+        0x800000000000011,
+    );
     var x103: u64 = undefined;
     var x104: u1 = undefined;
-    addcarryxU64(&x103, &x104, 0x0, x89, x99);
+    addcarryxU64(
+        &x103,
+        &x104,
+        0x0,
+        x89,
+        x99,
+    );
     var x105: u64 = undefined;
     var x106: u1 = undefined;
-    addcarryxU64(&x105, &x106, x104, x91, cast(u64, 0x0));
+    addcarryxU64(&x105, &x106, x104, x91, cast(
+        u64,
+        0x0,
+    ));
     var x107: u64 = undefined;
     var x108: u1 = undefined;
-    addcarryxU64(&x107, &x108, x106, x93, cast(u64, 0x0));
+    addcarryxU64(&x107, &x108, x106, x93, cast(
+        u64,
+        0x0,
+    ));
     var x109: u64 = undefined;
     var x110: u1 = undefined;
-    addcarryxU64(&x109, &x110, x108, x95, x101);
+    addcarryxU64(
+        &x109,
+        &x110,
+        x108,
+        x95,
+        x101,
+    );
     var x111: u64 = undefined;
     var x112: u1 = undefined;
-    addcarryxU64(&x111, &x112, x110, x97, x102);
-    const x113 = (cast(u64, x112) + cast(u64, x98));
+    addcarryxU64(
+        &x111,
+        &x112,
+        x110,
+        x97,
+        x102,
+    );
+    const x113 = (cast(
+        u64,
+        x112,
+    ) + cast(
+        u64,
+        x98,
+    ));
     var x114: u64 = undefined;
     var x115: u64 = undefined;
-    mulxU64(&x114, &x115, x3, (arg1[3]));
+    mulxU64(
+        &x114,
+        &x115,
+        x3,
+        (arg1[3]),
+    );
     var x116: u64 = undefined;
     var x117: u64 = undefined;
-    mulxU64(&x116, &x117, x3, (arg1[2]));
+    mulxU64(
+        &x116,
+        &x117,
+        x3,
+        (arg1[2]),
+    );
     var x118: u64 = undefined;
     var x119: u64 = undefined;
-    mulxU64(&x118, &x119, x3, (arg1[1]));
+    mulxU64(
+        &x118,
+        &x119,
+        x3,
+        (arg1[1]),
+    );
     var x120: u64 = undefined;
     var x121: u64 = undefined;
-    mulxU64(&x120, &x121, x3, (arg1[0]));
+    mulxU64(
+        &x120,
+        &x121,
+        x3,
+        (arg1[0]),
+    );
     var x122: u64 = undefined;
     var x123: u1 = undefined;
-    addcarryxU64(&x122, &x123, 0x0, x121, x118);
+    addcarryxU64(
+        &x122,
+        &x123,
+        0x0,
+        x121,
+        x118,
+    );
     var x124: u64 = undefined;
     var x125: u1 = undefined;
-    addcarryxU64(&x124, &x125, x123, x119, x116);
+    addcarryxU64(
+        &x124,
+        &x125,
+        x123,
+        x119,
+        x116,
+    );
     var x126: u64 = undefined;
     var x127: u1 = undefined;
-    addcarryxU64(&x126, &x127, x125, x117, x114);
-    const x128 = (cast(u64, x127) + x115);
+    addcarryxU64(
+        &x126,
+        &x127,
+        x125,
+        x117,
+        x114,
+    );
+    const x128 = (cast(
+        u64,
+        x127,
+    ) + x115);
     var x129: u64 = undefined;
     var x130: u1 = undefined;
-    addcarryxU64(&x129, &x130, 0x0, x105, x120);
+    addcarryxU64(
+        &x129,
+        &x130,
+        0x0,
+        x105,
+        x120,
+    );
     var x131: u64 = undefined;
     var x132: u1 = undefined;
-    addcarryxU64(&x131, &x132, x130, x107, x122);
+    addcarryxU64(
+        &x131,
+        &x132,
+        x130,
+        x107,
+        x122,
+    );
     var x133: u64 = undefined;
     var x134: u1 = undefined;
-    addcarryxU64(&x133, &x134, x132, x109, x124);
+    addcarryxU64(
+        &x133,
+        &x134,
+        x132,
+        x109,
+        x124,
+    );
     var x135: u64 = undefined;
     var x136: u1 = undefined;
-    addcarryxU64(&x135, &x136, x134, x111, x126);
+    addcarryxU64(
+        &x135,
+        &x136,
+        x134,
+        x111,
+        x126,
+    );
     var x137: u64 = undefined;
     var x138: u1 = undefined;
-    addcarryxU64(&x137, &x138, x136, x113, x128);
+    addcarryxU64(
+        &x137,
+        &x138,
+        x136,
+        x113,
+        x128,
+    );
     var x139: u64 = undefined;
     var x140: u64 = undefined;
-    mulxU64(&x139, &x140, x129, 0xffffffffffffffff);
+    mulxU64(
+        &x139,
+        &x140,
+        x129,
+        0xffffffffffffffff,
+    );
     var x141: u64 = undefined;
     var x142: u64 = undefined;
-    mulxU64(&x141, &x142, x139, 0x800000000000011);
+    mulxU64(
+        &x141,
+        &x142,
+        x139,
+        0x800000000000011,
+    );
     var x143: u64 = undefined;
     var x144: u1 = undefined;
-    addcarryxU64(&x143, &x144, 0x0, x129, x139);
+    addcarryxU64(
+        &x143,
+        &x144,
+        0x0,
+        x129,
+        x139,
+    );
     var x145: u64 = undefined;
     var x146: u1 = undefined;
-    addcarryxU64(&x145, &x146, x144, x131, cast(u64, 0x0));
+    addcarryxU64(&x145, &x146, x144, x131, cast(
+        u64,
+        0x0,
+    ));
     var x147: u64 = undefined;
     var x148: u1 = undefined;
-    addcarryxU64(&x147, &x148, x146, x133, cast(u64, 0x0));
+    addcarryxU64(&x147, &x148, x146, x133, cast(
+        u64,
+        0x0,
+    ));
     var x149: u64 = undefined;
     var x150: u1 = undefined;
-    addcarryxU64(&x149, &x150, x148, x135, x141);
+    addcarryxU64(
+        &x149,
+        &x150,
+        x148,
+        x135,
+        x141,
+    );
     var x151: u64 = undefined;
     var x152: u1 = undefined;
-    addcarryxU64(&x151, &x152, x150, x137, x142);
-    const x153 = (cast(u64, x152) + cast(u64, x138));
+    addcarryxU64(
+        &x151,
+        &x152,
+        x150,
+        x137,
+        x142,
+    );
+    const x153 = (cast(
+        u64,
+        x152,
+    ) + cast(
+        u64,
+        x138,
+    ));
     var x154: u64 = undefined;
     var x155: u1 = undefined;
-    subborrowxU64(&x154, &x155, 0x0, x145, cast(u64, 0x1));
+    subborrowxU64(&x154, &x155, 0x0, x145, cast(
+        u64,
+        0x1,
+    ));
     var x156: u64 = undefined;
     var x157: u1 = undefined;
-    subborrowxU64(&x156, &x157, x155, x147, cast(u64, 0x0));
+    subborrowxU64(&x156, &x157, x155, x147, cast(
+        u64,
+        0x0,
+    ));
     var x158: u64 = undefined;
     var x159: u1 = undefined;
-    subborrowxU64(&x158, &x159, x157, x149, cast(u64, 0x0));
+    subborrowxU64(&x158, &x159, x157, x149, cast(
+        u64,
+        0x0,
+    ));
     var x160: u64 = undefined;
     var x161: u1 = undefined;
-    subborrowxU64(&x160, &x161, x159, x151, 0x800000000000011);
+    subborrowxU64(
+        &x160,
+        &x161,
+        x159,
+        x151,
+        0x800000000000011,
+    );
     var x162: u64 = undefined;
     var x163: u1 = undefined;
-    subborrowxU64(&x162, &x163, x161, x153, cast(u64, 0x0));
+    subborrowxU64(&x162, &x163, x161, x153, cast(
+        u64,
+        0x0,
+    ));
     var x164: u64 = undefined;
-    cmovznzU64(&x164, x163, x154, x145);
+    cmovznzU64(
+        &x164,
+        x163,
+        x154,
+        x145,
+    );
     var x165: u64 = undefined;
-    cmovznzU64(&x165, x163, x156, x147);
+    cmovznzU64(
+        &x165,
+        x163,
+        x156,
+        x147,
+    );
     var x166: u64 = undefined;
-    cmovznzU64(&x166, x163, x158, x149);
+    cmovznzU64(
+        &x166,
+        x163,
+        x158,
+        x149,
+    );
     var x167: u64 = undefined;
-    cmovznzU64(&x167, x163, x160, x151);
+    cmovznzU64(
+        &x167,
+        x163,
+        x160,
+        x151,
+    );
     out1[0] = x164;
     out1[1] = x165;
     out1[2] = x166;
@@ -667,44 +1650,113 @@ pub fn square(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldEl
 ///   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) + eval (from_montgomery arg2)) mod m
 ///   0 ≤ eval out1 < m
 ///
-pub fn add(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldElement, arg2: MontgomeryDomainFieldElement) void {
+pub fn add(
+    out1: *MontgomeryDomainFieldElement,
+    arg1: MontgomeryDomainFieldElement,
+    arg2: MontgomeryDomainFieldElement,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     var x1: u64 = undefined;
     var x2: u1 = undefined;
-    addcarryxU64(&x1, &x2, 0x0, (arg1[0]), (arg2[0]));
+    addcarryxU64(
+        &x1,
+        &x2,
+        0x0,
+        (arg1[0]),
+        (arg2[0]),
+    );
     var x3: u64 = undefined;
     var x4: u1 = undefined;
-    addcarryxU64(&x3, &x4, x2, (arg1[1]), (arg2[1]));
+    addcarryxU64(
+        &x3,
+        &x4,
+        x2,
+        (arg1[1]),
+        (arg2[1]),
+    );
     var x5: u64 = undefined;
     var x6: u1 = undefined;
-    addcarryxU64(&x5, &x6, x4, (arg1[2]), (arg2[2]));
+    addcarryxU64(
+        &x5,
+        &x6,
+        x4,
+        (arg1[2]),
+        (arg2[2]),
+    );
     var x7: u64 = undefined;
     var x8: u1 = undefined;
-    addcarryxU64(&x7, &x8, x6, (arg1[3]), (arg2[3]));
+    addcarryxU64(
+        &x7,
+        &x8,
+        x6,
+        (arg1[3]),
+        (arg2[3]),
+    );
     var x9: u64 = undefined;
     var x10: u1 = undefined;
-    subborrowxU64(&x9, &x10, 0x0, x1, cast(u64, 0x1));
+    subborrowxU64(&x9, &x10, 0x0, x1, cast(
+        u64,
+        0x1,
+    ));
     var x11: u64 = undefined;
     var x12: u1 = undefined;
-    subborrowxU64(&x11, &x12, x10, x3, cast(u64, 0x0));
+    subborrowxU64(&x11, &x12, x10, x3, cast(
+        u64,
+        0x0,
+    ));
     var x13: u64 = undefined;
     var x14: u1 = undefined;
-    subborrowxU64(&x13, &x14, x12, x5, cast(u64, 0x0));
+    subborrowxU64(&x13, &x14, x12, x5, cast(
+        u64,
+        0x0,
+    ));
     var x15: u64 = undefined;
     var x16: u1 = undefined;
-    subborrowxU64(&x15, &x16, x14, x7, 0x800000000000011);
+    subborrowxU64(
+        &x15,
+        &x16,
+        x14,
+        x7,
+        0x800000000000011,
+    );
     var x17: u64 = undefined;
     var x18: u1 = undefined;
-    subborrowxU64(&x17, &x18, x16, cast(u64, x8), cast(u64, 0x0));
+    subborrowxU64(&x17, &x18, x16, cast(
+        u64,
+        x8,
+    ), cast(
+        u64,
+        0x0,
+    ));
     var x19: u64 = undefined;
-    cmovznzU64(&x19, x18, x9, x1);
+    cmovznzU64(
+        &x19,
+        x18,
+        x9,
+        x1,
+    );
     var x20: u64 = undefined;
-    cmovznzU64(&x20, x18, x11, x3);
+    cmovznzU64(
+        &x20,
+        x18,
+        x11,
+        x3,
+    );
     var x21: u64 = undefined;
-    cmovznzU64(&x21, x18, x13, x5);
+    cmovznzU64(
+        &x21,
+        x18,
+        x13,
+        x5,
+    );
     var x22: u64 = undefined;
-    cmovznzU64(&x22, x18, x15, x7);
+    cmovznzU64(
+        &x22,
+        x18,
+        x15,
+        x7,
+    );
     out1[0] = x19;
     out1[1] = x20;
     out1[2] = x21;
@@ -720,35 +1772,81 @@ pub fn add(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldEleme
 ///   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) - eval (from_montgomery arg2)) mod m
 ///   0 ≤ eval out1 < m
 ///
-pub fn sub(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldElement, arg2: MontgomeryDomainFieldElement) void {
+pub fn sub(
+    out1: *MontgomeryDomainFieldElement,
+    arg1: MontgomeryDomainFieldElement,
+    arg2: MontgomeryDomainFieldElement,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     var x1: u64 = undefined;
     var x2: u1 = undefined;
-    subborrowxU64(&x1, &x2, 0x0, (arg1[0]), (arg2[0]));
+    subborrowxU64(
+        &x1,
+        &x2,
+        0x0,
+        (arg1[0]),
+        (arg2[0]),
+    );
     var x3: u64 = undefined;
     var x4: u1 = undefined;
-    subborrowxU64(&x3, &x4, x2, (arg1[1]), (arg2[1]));
+    subborrowxU64(
+        &x3,
+        &x4,
+        x2,
+        (arg1[1]),
+        (arg2[1]),
+    );
     var x5: u64 = undefined;
     var x6: u1 = undefined;
-    subborrowxU64(&x5, &x6, x4, (arg1[2]), (arg2[2]));
+    subborrowxU64(
+        &x5,
+        &x6,
+        x4,
+        (arg1[2]),
+        (arg2[2]),
+    );
     var x7: u64 = undefined;
     var x8: u1 = undefined;
-    subborrowxU64(&x7, &x8, x6, (arg1[3]), (arg2[3]));
+    subborrowxU64(
+        &x7,
+        &x8,
+        x6,
+        (arg1[3]),
+        (arg2[3]),
+    );
     var x9: u64 = undefined;
-    cmovznzU64(&x9, x8, cast(u64, 0x0), 0xffffffffffffffff);
+    cmovznzU64(&x9, x8, cast(
+        u64,
+        0x0,
+    ), 0xffffffffffffffff);
     var x10: u64 = undefined;
     var x11: u1 = undefined;
-    addcarryxU64(&x10, &x11, 0x0, x1, cast(u64, cast(u1, (x9 & cast(u64, 0x1)))));
+    addcarryxU64(&x10, &x11, 0x0, x1, cast(u64, cast(u1, (x9 & cast(
+        u64,
+        0x1,
+    )))));
     var x12: u64 = undefined;
     var x13: u1 = undefined;
-    addcarryxU64(&x12, &x13, x11, x3, cast(u64, 0x0));
+    addcarryxU64(&x12, &x13, x11, x3, cast(
+        u64,
+        0x0,
+    ));
     var x14: u64 = undefined;
     var x15: u1 = undefined;
-    addcarryxU64(&x14, &x15, x13, x5, cast(u64, 0x0));
+    addcarryxU64(&x14, &x15, x13, x5, cast(
+        u64,
+        0x0,
+    ));
     var x16: u64 = undefined;
     var x17: u1 = undefined;
-    addcarryxU64(&x16, &x17, x15, x7, (x9 & 0x800000000000011));
+    addcarryxU64(
+        &x16,
+        &x17,
+        x15,
+        x7,
+        (x9 & 0x800000000000011),
+    );
     out1[0] = x10;
     out1[1] = x12;
     out1[2] = x14;
@@ -763,35 +1861,68 @@ pub fn sub(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldEleme
 ///   eval (from_montgomery out1) mod m = -eval (from_montgomery arg1) mod m
 ///   0 ≤ eval out1 < m
 ///
-pub fn opp(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldElement) void {
+pub fn opp(
+    out1: *MontgomeryDomainFieldElement,
+    arg1: MontgomeryDomainFieldElement,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     var x1: u64 = undefined;
     var x2: u1 = undefined;
-    subborrowxU64(&x1, &x2, 0x0, cast(u64, 0x0), (arg1[0]));
+    subborrowxU64(&x1, &x2, 0x0, cast(
+        u64,
+        0x0,
+    ), (arg1[0]));
     var x3: u64 = undefined;
     var x4: u1 = undefined;
-    subborrowxU64(&x3, &x4, x2, cast(u64, 0x0), (arg1[1]));
+    subborrowxU64(&x3, &x4, x2, cast(
+        u64,
+        0x0,
+    ), (arg1[1]));
     var x5: u64 = undefined;
     var x6: u1 = undefined;
-    subborrowxU64(&x5, &x6, x4, cast(u64, 0x0), (arg1[2]));
+    subborrowxU64(&x5, &x6, x4, cast(
+        u64,
+        0x0,
+    ), (arg1[2]));
     var x7: u64 = undefined;
     var x8: u1 = undefined;
-    subborrowxU64(&x7, &x8, x6, cast(u64, 0x0), (arg1[3]));
+    subborrowxU64(&x7, &x8, x6, cast(
+        u64,
+        0x0,
+    ), (arg1[3]));
     var x9: u64 = undefined;
-    cmovznzU64(&x9, x8, cast(u64, 0x0), 0xffffffffffffffff);
+    cmovznzU64(&x9, x8, cast(
+        u64,
+        0x0,
+    ), 0xffffffffffffffff);
     var x10: u64 = undefined;
     var x11: u1 = undefined;
-    addcarryxU64(&x10, &x11, 0x0, x1, cast(u64, cast(u1, (x9 & cast(u64, 0x1)))));
+    addcarryxU64(&x10, &x11, 0x0, x1, cast(u64, cast(u1, (x9 & cast(
+        u64,
+        0x1,
+    )))));
     var x12: u64 = undefined;
     var x13: u1 = undefined;
-    addcarryxU64(&x12, &x13, x11, x3, cast(u64, 0x0));
+    addcarryxU64(&x12, &x13, x11, x3, cast(
+        u64,
+        0x0,
+    ));
     var x14: u64 = undefined;
     var x15: u1 = undefined;
-    addcarryxU64(&x14, &x15, x13, x5, cast(u64, 0x0));
+    addcarryxU64(&x14, &x15, x13, x5, cast(
+        u64,
+        0x0,
+    ));
     var x16: u64 = undefined;
     var x17: u1 = undefined;
-    addcarryxU64(&x16, &x17, x15, x7, (x9 & 0x800000000000011));
+    addcarryxU64(
+        &x16,
+        &x17,
+        x15,
+        x7,
+        (x9 & 0x800000000000011),
+    );
     out1[0] = x10;
     out1[1] = x12;
     out1[2] = x14;
@@ -806,112 +1937,280 @@ pub fn opp(out1: *MontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldEleme
 ///   eval out1 mod m = (eval arg1 * ((2^64)⁻¹ mod m)^4) mod m
 ///   0 ≤ eval out1 < m
 ///
-pub fn fromMontgomery(out1: *NonMontgomeryDomainFieldElement, arg1: MontgomeryDomainFieldElement) void {
+pub fn fromMontgomery(
+    out1: *NonMontgomeryDomainFieldElement,
+    arg1: MontgomeryDomainFieldElement,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (arg1[0]);
     var x2: u64 = undefined;
     var x3: u64 = undefined;
-    mulxU64(&x2, &x3, x1, 0xffffffffffffffff);
+    mulxU64(
+        &x2,
+        &x3,
+        x1,
+        0xffffffffffffffff,
+    );
     var x4: u64 = undefined;
     var x5: u64 = undefined;
-    mulxU64(&x4, &x5, x2, 0x800000000000011);
+    mulxU64(
+        &x4,
+        &x5,
+        x2,
+        0x800000000000011,
+    );
     var x6: u64 = undefined;
     var x7: u1 = undefined;
-    addcarryxU64(&x6, &x7, 0x0, x1, x2);
+    addcarryxU64(
+        &x6,
+        &x7,
+        0x0,
+        x1,
+        x2,
+    );
     var x8: u64 = undefined;
     var x9: u1 = undefined;
-    addcarryxU64(&x8, &x9, 0x0, cast(u64, x7), (arg1[1]));
+    addcarryxU64(&x8, &x9, 0x0, cast(
+        u64,
+        x7,
+    ), (arg1[1]));
     var x10: u64 = undefined;
     var x11: u64 = undefined;
-    mulxU64(&x10, &x11, x8, 0xffffffffffffffff);
+    mulxU64(
+        &x10,
+        &x11,
+        x8,
+        0xffffffffffffffff,
+    );
     var x12: u64 = undefined;
     var x13: u64 = undefined;
-    mulxU64(&x12, &x13, x10, 0x800000000000011);
+    mulxU64(
+        &x12,
+        &x13,
+        x10,
+        0x800000000000011,
+    );
     var x14: u64 = undefined;
     var x15: u1 = undefined;
-    addcarryxU64(&x14, &x15, 0x0, x5, x12);
+    addcarryxU64(
+        &x14,
+        &x15,
+        0x0,
+        x5,
+        x12,
+    );
     var x16: u64 = undefined;
     var x17: u1 = undefined;
-    addcarryxU64(&x16, &x17, 0x0, x8, x10);
+    addcarryxU64(
+        &x16,
+        &x17,
+        0x0,
+        x8,
+        x10,
+    );
     var x18: u64 = undefined;
     var x19: u1 = undefined;
-    addcarryxU64(&x18, &x19, 0x0, (cast(u64, x17) + cast(u64, x9)), (arg1[2]));
+    addcarryxU64(&x18, &x19, 0x0, (cast(
+        u64,
+        x17,
+    ) + cast(
+        u64,
+        x9,
+    )), (arg1[2]));
     var x20: u64 = undefined;
     var x21: u1 = undefined;
-    addcarryxU64(&x20, &x21, x19, x4, cast(u64, 0x0));
+    addcarryxU64(&x20, &x21, x19, x4, cast(
+        u64,
+        0x0,
+    ));
     var x22: u64 = undefined;
     var x23: u1 = undefined;
-    addcarryxU64(&x22, &x23, x21, x14, cast(u64, 0x0));
+    addcarryxU64(&x22, &x23, x21, x14, cast(
+        u64,
+        0x0,
+    ));
     var x24: u64 = undefined;
     var x25: u64 = undefined;
-    mulxU64(&x24, &x25, x18, 0xffffffffffffffff);
+    mulxU64(
+        &x24,
+        &x25,
+        x18,
+        0xffffffffffffffff,
+    );
     var x26: u64 = undefined;
     var x27: u64 = undefined;
-    mulxU64(&x26, &x27, x24, 0x800000000000011);
+    mulxU64(
+        &x26,
+        &x27,
+        x24,
+        0x800000000000011,
+    );
     var x28: u64 = undefined;
     var x29: u1 = undefined;
-    addcarryxU64(&x28, &x29, 0x0, x18, x24);
+    addcarryxU64(
+        &x28,
+        &x29,
+        0x0,
+        x18,
+        x24,
+    );
     var x30: u64 = undefined;
     var x31: u1 = undefined;
-    addcarryxU64(&x30, &x31, x29, x20, cast(u64, 0x0));
+    addcarryxU64(&x30, &x31, x29, x20, cast(
+        u64,
+        0x0,
+    ));
     var x32: u64 = undefined;
     var x33: u1 = undefined;
-    addcarryxU64(&x32, &x33, x31, x22, cast(u64, 0x0));
+    addcarryxU64(&x32, &x33, x31, x22, cast(
+        u64,
+        0x0,
+    ));
     var x34: u64 = undefined;
     var x35: u1 = undefined;
-    addcarryxU64(&x34, &x35, x33, (cast(u64, x23) + (cast(u64, x15) + x13)), x26);
+    addcarryxU64(&x34, &x35, x33, (cast(
+        u64,
+        x23,
+    ) + (cast(
+        u64,
+        x15,
+    ) + x13)), x26);
     var x36: u64 = undefined;
     var x37: u1 = undefined;
-    addcarryxU64(&x36, &x37, 0x0, x30, (arg1[3]));
+    addcarryxU64(
+        &x36,
+        &x37,
+        0x0,
+        x30,
+        (arg1[3]),
+    );
     var x38: u64 = undefined;
     var x39: u1 = undefined;
-    addcarryxU64(&x38, &x39, x37, x32, cast(u64, 0x0));
+    addcarryxU64(&x38, &x39, x37, x32, cast(
+        u64,
+        0x0,
+    ));
     var x40: u64 = undefined;
     var x41: u1 = undefined;
-    addcarryxU64(&x40, &x41, x39, x34, cast(u64, 0x0));
+    addcarryxU64(&x40, &x41, x39, x34, cast(
+        u64,
+        0x0,
+    ));
     var x42: u64 = undefined;
     var x43: u64 = undefined;
-    mulxU64(&x42, &x43, x36, 0xffffffffffffffff);
+    mulxU64(
+        &x42,
+        &x43,
+        x36,
+        0xffffffffffffffff,
+    );
     var x44: u64 = undefined;
     var x45: u64 = undefined;
-    mulxU64(&x44, &x45, x42, 0x800000000000011);
+    mulxU64(
+        &x44,
+        &x45,
+        x42,
+        0x800000000000011,
+    );
     var x46: u64 = undefined;
     var x47: u1 = undefined;
-    addcarryxU64(&x46, &x47, 0x0, x36, x42);
+    addcarryxU64(
+        &x46,
+        &x47,
+        0x0,
+        x36,
+        x42,
+    );
     var x48: u64 = undefined;
     var x49: u1 = undefined;
-    addcarryxU64(&x48, &x49, x47, x38, cast(u64, 0x0));
+    addcarryxU64(&x48, &x49, x47, x38, cast(
+        u64,
+        0x0,
+    ));
     var x50: u64 = undefined;
     var x51: u1 = undefined;
-    addcarryxU64(&x50, &x51, x49, x40, cast(u64, 0x0));
+    addcarryxU64(&x50, &x51, x49, x40, cast(
+        u64,
+        0x0,
+    ));
     var x52: u64 = undefined;
     var x53: u1 = undefined;
-    addcarryxU64(&x52, &x53, x51, (cast(u64, x41) + (cast(u64, x35) + x27)), x44);
-    const x54 = (cast(u64, x53) + x45);
+    addcarryxU64(&x52, &x53, x51, (cast(
+        u64,
+        x41,
+    ) + (cast(
+        u64,
+        x35,
+    ) + x27)), x44);
+    const x54 = (cast(
+        u64,
+        x53,
+    ) + x45);
     var x55: u64 = undefined;
     var x56: u1 = undefined;
-    subborrowxU64(&x55, &x56, 0x0, x48, cast(u64, 0x1));
+    subborrowxU64(&x55, &x56, 0x0, x48, cast(
+        u64,
+        0x1,
+    ));
     var x57: u64 = undefined;
     var x58: u1 = undefined;
-    subborrowxU64(&x57, &x58, x56, x50, cast(u64, 0x0));
+    subborrowxU64(&x57, &x58, x56, x50, cast(
+        u64,
+        0x0,
+    ));
     var x59: u64 = undefined;
     var x60: u1 = undefined;
-    subborrowxU64(&x59, &x60, x58, x52, cast(u64, 0x0));
+    subborrowxU64(&x59, &x60, x58, x52, cast(
+        u64,
+        0x0,
+    ));
     var x61: u64 = undefined;
     var x62: u1 = undefined;
-    subborrowxU64(&x61, &x62, x60, x54, 0x800000000000011);
+    subborrowxU64(
+        &x61,
+        &x62,
+        x60,
+        x54,
+        0x800000000000011,
+    );
     var x63: u64 = undefined;
     var x64: u1 = undefined;
-    subborrowxU64(&x63, &x64, x62, cast(u64, 0x0), cast(u64, 0x0));
+    subborrowxU64(&x63, &x64, x62, cast(
+        u64,
+        0x0,
+    ), cast(
+        u64,
+        0x0,
+    ));
     var x65: u64 = undefined;
-    cmovznzU64(&x65, x64, x55, x48);
+    cmovznzU64(
+        &x65,
+        x64,
+        x55,
+        x48,
+    );
     var x66: u64 = undefined;
-    cmovznzU64(&x66, x64, x57, x50);
+    cmovznzU64(
+        &x66,
+        x64,
+        x57,
+        x50,
+    );
     var x67: u64 = undefined;
-    cmovznzU64(&x67, x64, x59, x52);
+    cmovznzU64(
+        &x67,
+        x64,
+        x59,
+        x52,
+    );
     var x68: u64 = undefined;
-    cmovznzU64(&x68, x64, x61, x54);
+    cmovznzU64(
+        &x68,
+        x64,
+        x61,
+        x54,
+    );
     out1[0] = x65;
     out1[1] = x66;
     out1[2] = x67;
@@ -926,7 +2225,10 @@ pub fn fromMontgomery(out1: *NonMontgomeryDomainFieldElement, arg1: MontgomeryDo
 ///   eval (from_montgomery out1) mod m = eval arg1 mod m
 ///   0 ≤ eval out1 < m
 ///
-pub fn toMontgomery(out1: *MontgomeryDomainFieldElement, arg1: NonMontgomeryDomainFieldElement) void {
+pub fn toMontgomery(
+    out1: *MontgomeryDomainFieldElement,
+    arg1: NonMontgomeryDomainFieldElement,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (arg1[1]);
@@ -935,220 +2237,612 @@ pub fn toMontgomery(out1: *MontgomeryDomainFieldElement, arg1: NonMontgomeryDoma
     const x4 = (arg1[0]);
     var x5: u64 = undefined;
     var x6: u64 = undefined;
-    mulxU64(&x5, &x6, x4, 0x7ffd4ab5e008810);
+    mulxU64(
+        &x5,
+        &x6,
+        x4,
+        0x7ffd4ab5e008810,
+    );
     var x7: u64 = undefined;
     var x8: u64 = undefined;
-    mulxU64(&x7, &x8, x4, 0xffffffffff6f8000);
+    mulxU64(
+        &x7,
+        &x8,
+        x4,
+        0xffffffffff6f8000,
+    );
     var x9: u64 = undefined;
     var x10: u64 = undefined;
-    mulxU64(&x9, &x10, x4, 0x1330fffff);
+    mulxU64(
+        &x9,
+        &x10,
+        x4,
+        0x1330fffff,
+    );
     var x11: u64 = undefined;
     var x12: u64 = undefined;
-    mulxU64(&x11, &x12, x4, 0xfffffd737e000401);
+    mulxU64(
+        &x11,
+        &x12,
+        x4,
+        0xfffffd737e000401,
+    );
     var x13: u64 = undefined;
     var x14: u1 = undefined;
-    addcarryxU64(&x13, &x14, 0x0, x12, x9);
+    addcarryxU64(
+        &x13,
+        &x14,
+        0x0,
+        x12,
+        x9,
+    );
     var x15: u64 = undefined;
     var x16: u1 = undefined;
-    addcarryxU64(&x15, &x16, x14, x10, x7);
+    addcarryxU64(
+        &x15,
+        &x16,
+        x14,
+        x10,
+        x7,
+    );
     var x17: u64 = undefined;
     var x18: u1 = undefined;
-    addcarryxU64(&x17, &x18, x16, x8, x5);
+    addcarryxU64(
+        &x17,
+        &x18,
+        x16,
+        x8,
+        x5,
+    );
     var x19: u64 = undefined;
     var x20: u64 = undefined;
-    mulxU64(&x19, &x20, x11, 0xffffffffffffffff);
+    mulxU64(
+        &x19,
+        &x20,
+        x11,
+        0xffffffffffffffff,
+    );
     var x21: u64 = undefined;
     var x22: u64 = undefined;
-    mulxU64(&x21, &x22, x19, 0x800000000000011);
+    mulxU64(
+        &x21,
+        &x22,
+        x19,
+        0x800000000000011,
+    );
     var x23: u64 = undefined;
     var x24: u1 = undefined;
-    addcarryxU64(&x23, &x24, 0x0, x11, x19);
+    addcarryxU64(
+        &x23,
+        &x24,
+        0x0,
+        x11,
+        x19,
+    );
     var x25: u64 = undefined;
     var x26: u1 = undefined;
-    addcarryxU64(&x25, &x26, x24, x13, cast(u64, 0x0));
+    addcarryxU64(&x25, &x26, x24, x13, cast(
+        u64,
+        0x0,
+    ));
     var x27: u64 = undefined;
     var x28: u1 = undefined;
-    addcarryxU64(&x27, &x28, x26, x15, cast(u64, 0x0));
+    addcarryxU64(&x27, &x28, x26, x15, cast(
+        u64,
+        0x0,
+    ));
     var x29: u64 = undefined;
     var x30: u1 = undefined;
-    addcarryxU64(&x29, &x30, x28, x17, x21);
+    addcarryxU64(
+        &x29,
+        &x30,
+        x28,
+        x17,
+        x21,
+    );
     var x31: u64 = undefined;
     var x32: u64 = undefined;
-    mulxU64(&x31, &x32, x1, 0x7ffd4ab5e008810);
+    mulxU64(
+        &x31,
+        &x32,
+        x1,
+        0x7ffd4ab5e008810,
+    );
     var x33: u64 = undefined;
     var x34: u64 = undefined;
-    mulxU64(&x33, &x34, x1, 0xffffffffff6f8000);
+    mulxU64(
+        &x33,
+        &x34,
+        x1,
+        0xffffffffff6f8000,
+    );
     var x35: u64 = undefined;
     var x36: u64 = undefined;
-    mulxU64(&x35, &x36, x1, 0x1330fffff);
+    mulxU64(
+        &x35,
+        &x36,
+        x1,
+        0x1330fffff,
+    );
     var x37: u64 = undefined;
     var x38: u64 = undefined;
-    mulxU64(&x37, &x38, x1, 0xfffffd737e000401);
+    mulxU64(
+        &x37,
+        &x38,
+        x1,
+        0xfffffd737e000401,
+    );
     var x39: u64 = undefined;
     var x40: u1 = undefined;
-    addcarryxU64(&x39, &x40, 0x0, x38, x35);
+    addcarryxU64(
+        &x39,
+        &x40,
+        0x0,
+        x38,
+        x35,
+    );
     var x41: u64 = undefined;
     var x42: u1 = undefined;
-    addcarryxU64(&x41, &x42, x40, x36, x33);
+    addcarryxU64(
+        &x41,
+        &x42,
+        x40,
+        x36,
+        x33,
+    );
     var x43: u64 = undefined;
     var x44: u1 = undefined;
-    addcarryxU64(&x43, &x44, x42, x34, x31);
+    addcarryxU64(
+        &x43,
+        &x44,
+        x42,
+        x34,
+        x31,
+    );
     var x45: u64 = undefined;
     var x46: u1 = undefined;
-    addcarryxU64(&x45, &x46, 0x0, x25, x37);
+    addcarryxU64(
+        &x45,
+        &x46,
+        0x0,
+        x25,
+        x37,
+    );
     var x47: u64 = undefined;
     var x48: u1 = undefined;
-    addcarryxU64(&x47, &x48, x46, x27, x39);
+    addcarryxU64(
+        &x47,
+        &x48,
+        x46,
+        x27,
+        x39,
+    );
     var x49: u64 = undefined;
     var x50: u1 = undefined;
-    addcarryxU64(&x49, &x50, x48, x29, x41);
+    addcarryxU64(
+        &x49,
+        &x50,
+        x48,
+        x29,
+        x41,
+    );
     var x51: u64 = undefined;
     var x52: u1 = undefined;
-    addcarryxU64(&x51, &x52, x50, ((cast(u64, x30) + (cast(u64, x18) + x6)) + x22), x43);
+    addcarryxU64(&x51, &x52, x50, ((cast(
+        u64,
+        x30,
+    ) + (cast(
+        u64,
+        x18,
+    ) + x6)) + x22), x43);
     var x53: u64 = undefined;
     var x54: u64 = undefined;
-    mulxU64(&x53, &x54, x45, 0xffffffffffffffff);
+    mulxU64(
+        &x53,
+        &x54,
+        x45,
+        0xffffffffffffffff,
+    );
     var x55: u64 = undefined;
     var x56: u64 = undefined;
-    mulxU64(&x55, &x56, x53, 0x800000000000011);
+    mulxU64(
+        &x55,
+        &x56,
+        x53,
+        0x800000000000011,
+    );
     var x57: u64 = undefined;
     var x58: u1 = undefined;
-    addcarryxU64(&x57, &x58, 0x0, x45, x53);
+    addcarryxU64(
+        &x57,
+        &x58,
+        0x0,
+        x45,
+        x53,
+    );
     var x59: u64 = undefined;
     var x60: u1 = undefined;
-    addcarryxU64(&x59, &x60, x58, x47, cast(u64, 0x0));
+    addcarryxU64(&x59, &x60, x58, x47, cast(
+        u64,
+        0x0,
+    ));
     var x61: u64 = undefined;
     var x62: u1 = undefined;
-    addcarryxU64(&x61, &x62, x60, x49, cast(u64, 0x0));
+    addcarryxU64(&x61, &x62, x60, x49, cast(
+        u64,
+        0x0,
+    ));
     var x63: u64 = undefined;
     var x64: u1 = undefined;
-    addcarryxU64(&x63, &x64, x62, x51, x55);
+    addcarryxU64(
+        &x63,
+        &x64,
+        x62,
+        x51,
+        x55,
+    );
     var x65: u64 = undefined;
     var x66: u64 = undefined;
-    mulxU64(&x65, &x66, x2, 0x7ffd4ab5e008810);
+    mulxU64(
+        &x65,
+        &x66,
+        x2,
+        0x7ffd4ab5e008810,
+    );
     var x67: u64 = undefined;
     var x68: u64 = undefined;
-    mulxU64(&x67, &x68, x2, 0xffffffffff6f8000);
+    mulxU64(
+        &x67,
+        &x68,
+        x2,
+        0xffffffffff6f8000,
+    );
     var x69: u64 = undefined;
     var x70: u64 = undefined;
-    mulxU64(&x69, &x70, x2, 0x1330fffff);
+    mulxU64(
+        &x69,
+        &x70,
+        x2,
+        0x1330fffff,
+    );
     var x71: u64 = undefined;
     var x72: u64 = undefined;
-    mulxU64(&x71, &x72, x2, 0xfffffd737e000401);
+    mulxU64(
+        &x71,
+        &x72,
+        x2,
+        0xfffffd737e000401,
+    );
     var x73: u64 = undefined;
     var x74: u1 = undefined;
-    addcarryxU64(&x73, &x74, 0x0, x72, x69);
+    addcarryxU64(
+        &x73,
+        &x74,
+        0x0,
+        x72,
+        x69,
+    );
     var x75: u64 = undefined;
     var x76: u1 = undefined;
-    addcarryxU64(&x75, &x76, x74, x70, x67);
+    addcarryxU64(
+        &x75,
+        &x76,
+        x74,
+        x70,
+        x67,
+    );
     var x77: u64 = undefined;
     var x78: u1 = undefined;
-    addcarryxU64(&x77, &x78, x76, x68, x65);
+    addcarryxU64(
+        &x77,
+        &x78,
+        x76,
+        x68,
+        x65,
+    );
     var x79: u64 = undefined;
     var x80: u1 = undefined;
-    addcarryxU64(&x79, &x80, 0x0, x59, x71);
+    addcarryxU64(
+        &x79,
+        &x80,
+        0x0,
+        x59,
+        x71,
+    );
     var x81: u64 = undefined;
     var x82: u1 = undefined;
-    addcarryxU64(&x81, &x82, x80, x61, x73);
+    addcarryxU64(
+        &x81,
+        &x82,
+        x80,
+        x61,
+        x73,
+    );
     var x83: u64 = undefined;
     var x84: u1 = undefined;
-    addcarryxU64(&x83, &x84, x82, x63, x75);
+    addcarryxU64(
+        &x83,
+        &x84,
+        x82,
+        x63,
+        x75,
+    );
     var x85: u64 = undefined;
     var x86: u1 = undefined;
-    addcarryxU64(&x85, &x86, x84, ((cast(u64, x64) + (cast(u64, x52) + (cast(u64, x44) + x32))) + x56), x77);
+    addcarryxU64(&x85, &x86, x84, ((cast(
+        u64,
+        x64,
+    ) + (cast(
+        u64,
+        x52,
+    ) + (cast(
+        u64,
+        x44,
+    ) + x32))) + x56), x77);
     var x87: u64 = undefined;
     var x88: u64 = undefined;
-    mulxU64(&x87, &x88, x79, 0xffffffffffffffff);
+    mulxU64(
+        &x87,
+        &x88,
+        x79,
+        0xffffffffffffffff,
+    );
     var x89: u64 = undefined;
     var x90: u64 = undefined;
-    mulxU64(&x89, &x90, x87, 0x800000000000011);
+    mulxU64(
+        &x89,
+        &x90,
+        x87,
+        0x800000000000011,
+    );
     var x91: u64 = undefined;
     var x92: u1 = undefined;
-    addcarryxU64(&x91, &x92, 0x0, x79, x87);
+    addcarryxU64(
+        &x91,
+        &x92,
+        0x0,
+        x79,
+        x87,
+    );
     var x93: u64 = undefined;
     var x94: u1 = undefined;
-    addcarryxU64(&x93, &x94, x92, x81, cast(u64, 0x0));
+    addcarryxU64(&x93, &x94, x92, x81, cast(
+        u64,
+        0x0,
+    ));
     var x95: u64 = undefined;
     var x96: u1 = undefined;
-    addcarryxU64(&x95, &x96, x94, x83, cast(u64, 0x0));
+    addcarryxU64(&x95, &x96, x94, x83, cast(
+        u64,
+        0x0,
+    ));
     var x97: u64 = undefined;
     var x98: u1 = undefined;
-    addcarryxU64(&x97, &x98, x96, x85, x89);
+    addcarryxU64(
+        &x97,
+        &x98,
+        x96,
+        x85,
+        x89,
+    );
     var x99: u64 = undefined;
     var x100: u64 = undefined;
-    mulxU64(&x99, &x100, x3, 0x7ffd4ab5e008810);
+    mulxU64(
+        &x99,
+        &x100,
+        x3,
+        0x7ffd4ab5e008810,
+    );
     var x101: u64 = undefined;
     var x102: u64 = undefined;
-    mulxU64(&x101, &x102, x3, 0xffffffffff6f8000);
+    mulxU64(
+        &x101,
+        &x102,
+        x3,
+        0xffffffffff6f8000,
+    );
     var x103: u64 = undefined;
     var x104: u64 = undefined;
-    mulxU64(&x103, &x104, x3, 0x1330fffff);
+    mulxU64(
+        &x103,
+        &x104,
+        x3,
+        0x1330fffff,
+    );
     var x105: u64 = undefined;
     var x106: u64 = undefined;
-    mulxU64(&x105, &x106, x3, 0xfffffd737e000401);
+    mulxU64(
+        &x105,
+        &x106,
+        x3,
+        0xfffffd737e000401,
+    );
     var x107: u64 = undefined;
     var x108: u1 = undefined;
-    addcarryxU64(&x107, &x108, 0x0, x106, x103);
+    addcarryxU64(
+        &x107,
+        &x108,
+        0x0,
+        x106,
+        x103,
+    );
     var x109: u64 = undefined;
     var x110: u1 = undefined;
-    addcarryxU64(&x109, &x110, x108, x104, x101);
+    addcarryxU64(
+        &x109,
+        &x110,
+        x108,
+        x104,
+        x101,
+    );
     var x111: u64 = undefined;
     var x112: u1 = undefined;
-    addcarryxU64(&x111, &x112, x110, x102, x99);
+    addcarryxU64(
+        &x111,
+        &x112,
+        x110,
+        x102,
+        x99,
+    );
     var x113: u64 = undefined;
     var x114: u1 = undefined;
-    addcarryxU64(&x113, &x114, 0x0, x93, x105);
+    addcarryxU64(
+        &x113,
+        &x114,
+        0x0,
+        x93,
+        x105,
+    );
     var x115: u64 = undefined;
     var x116: u1 = undefined;
-    addcarryxU64(&x115, &x116, x114, x95, x107);
+    addcarryxU64(
+        &x115,
+        &x116,
+        x114,
+        x95,
+        x107,
+    );
     var x117: u64 = undefined;
     var x118: u1 = undefined;
-    addcarryxU64(&x117, &x118, x116, x97, x109);
+    addcarryxU64(
+        &x117,
+        &x118,
+        x116,
+        x97,
+        x109,
+    );
     var x119: u64 = undefined;
     var x120: u1 = undefined;
-    addcarryxU64(&x119, &x120, x118, ((cast(u64, x98) + (cast(u64, x86) + (cast(u64, x78) + x66))) + x90), x111);
+    addcarryxU64(&x119, &x120, x118, ((cast(
+        u64,
+        x98,
+    ) + (cast(
+        u64,
+        x86,
+    ) + (cast(
+        u64,
+        x78,
+    ) + x66))) + x90), x111);
     var x121: u64 = undefined;
     var x122: u64 = undefined;
-    mulxU64(&x121, &x122, x113, 0xffffffffffffffff);
+    mulxU64(
+        &x121,
+        &x122,
+        x113,
+        0xffffffffffffffff,
+    );
     var x123: u64 = undefined;
     var x124: u64 = undefined;
-    mulxU64(&x123, &x124, x121, 0x800000000000011);
+    mulxU64(
+        &x123,
+        &x124,
+        x121,
+        0x800000000000011,
+    );
     var x125: u64 = undefined;
     var x126: u1 = undefined;
-    addcarryxU64(&x125, &x126, 0x0, x113, x121);
+    addcarryxU64(
+        &x125,
+        &x126,
+        0x0,
+        x113,
+        x121,
+    );
     var x127: u64 = undefined;
     var x128: u1 = undefined;
-    addcarryxU64(&x127, &x128, x126, x115, cast(u64, 0x0));
+    addcarryxU64(&x127, &x128, x126, x115, cast(
+        u64,
+        0x0,
+    ));
     var x129: u64 = undefined;
     var x130: u1 = undefined;
-    addcarryxU64(&x129, &x130, x128, x117, cast(u64, 0x0));
+    addcarryxU64(&x129, &x130, x128, x117, cast(
+        u64,
+        0x0,
+    ));
     var x131: u64 = undefined;
     var x132: u1 = undefined;
-    addcarryxU64(&x131, &x132, x130, x119, x123);
-    const x133 = ((cast(u64, x132) + (cast(u64, x120) + (cast(u64, x112) + x100))) + x124);
+    addcarryxU64(
+        &x131,
+        &x132,
+        x130,
+        x119,
+        x123,
+    );
+    const x133 = ((cast(
+        u64,
+        x132,
+    ) + (cast(
+        u64,
+        x120,
+    ) + (cast(
+        u64,
+        x112,
+    ) + x100))) + x124);
     var x134: u64 = undefined;
     var x135: u1 = undefined;
-    subborrowxU64(&x134, &x135, 0x0, x127, cast(u64, 0x1));
+    subborrowxU64(&x134, &x135, 0x0, x127, cast(
+        u64,
+        0x1,
+    ));
     var x136: u64 = undefined;
     var x137: u1 = undefined;
-    subborrowxU64(&x136, &x137, x135, x129, cast(u64, 0x0));
+    subborrowxU64(&x136, &x137, x135, x129, cast(
+        u64,
+        0x0,
+    ));
     var x138: u64 = undefined;
     var x139: u1 = undefined;
-    subborrowxU64(&x138, &x139, x137, x131, cast(u64, 0x0));
+    subborrowxU64(&x138, &x139, x137, x131, cast(
+        u64,
+        0x0,
+    ));
     var x140: u64 = undefined;
     var x141: u1 = undefined;
-    subborrowxU64(&x140, &x141, x139, x133, 0x800000000000011);
+    subborrowxU64(
+        &x140,
+        &x141,
+        x139,
+        x133,
+        0x800000000000011,
+    );
     var x142: u64 = undefined;
     var x143: u1 = undefined;
-    subborrowxU64(&x142, &x143, x141, cast(u64, 0x0), cast(u64, 0x0));
+    subborrowxU64(&x142, &x143, x141, cast(
+        u64,
+        0x0,
+    ), cast(
+        u64,
+        0x0,
+    ));
     var x144: u64 = undefined;
-    cmovznzU64(&x144, x143, x134, x127);
+    cmovznzU64(
+        &x144,
+        x143,
+        x134,
+        x127,
+    );
     var x145: u64 = undefined;
-    cmovznzU64(&x145, x143, x136, x129);
+    cmovznzU64(
+        &x145,
+        x143,
+        x136,
+        x129,
+    );
     var x146: u64 = undefined;
-    cmovznzU64(&x146, x143, x138, x131);
+    cmovznzU64(
+        &x146,
+        x143,
+        x138,
+        x131,
+    );
     var x147: u64 = undefined;
-    cmovznzU64(&x147, x143, x140, x133);
+    cmovznzU64(
+        &x147,
+        x143,
+        x140,
+        x133,
+    );
     out1[0] = x144;
     out1[1] = x145;
     out1[2] = x146;
@@ -1166,7 +2860,10 @@ pub fn toMontgomery(out1: *MontgomeryDomainFieldElement, arg1: NonMontgomeryDoma
 ///   arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
-pub fn nonzero(out1: *u64, arg1: [4]u64) void {
+pub fn nonzero(
+    out1: *u64,
+    arg1: [4]u64,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | (arg1[3]))));
@@ -1184,17 +2881,42 @@ pub fn nonzero(out1: *u64, arg1: [4]u64) void {
 ///   arg3: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
-pub fn selectznz(out1: *[4]u64, arg1: u1, arg2: [4]u64, arg3: [4]u64) void {
+pub fn selectznz(
+    out1: *[4]u64,
+    arg1: u1,
+    arg2: [4]u64,
+    arg3: [4]u64,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     var x1: u64 = undefined;
-    cmovznzU64(&x1, arg1, (arg2[0]), (arg3[0]));
+    cmovznzU64(
+        &x1,
+        arg1,
+        (arg2[0]),
+        (arg3[0]),
+    );
     var x2: u64 = undefined;
-    cmovznzU64(&x2, arg1, (arg2[1]), (arg3[1]));
+    cmovznzU64(
+        &x2,
+        arg1,
+        (arg2[1]),
+        (arg3[1]),
+    );
     var x3: u64 = undefined;
-    cmovznzU64(&x3, arg1, (arg2[2]), (arg3[2]));
+    cmovznzU64(
+        &x3,
+        arg1,
+        (arg2[2]),
+        (arg3[2]),
+    );
     var x4: u64 = undefined;
-    cmovznzU64(&x4, arg1, (arg2[3]), (arg3[3]));
+    cmovznzU64(
+        &x4,
+        arg1,
+        (arg2[3]),
+        (arg3[3]),
+    );
     out1[0] = x1;
     out1[1] = x2;
     out1[2] = x3;
@@ -1206,75 +2928,174 @@ pub fn selectznz(out1: *[4]u64, arg1: u1, arg2: [4]u64, arg3: [4]u64) void {
 /// Preconditions:
 ///   0 ≤ eval arg1 < m
 /// Postconditions:
-///   out1 = map (λ x, ⌊((eval arg1 mod m) mod 2^(8 * (x + 1))) / 2^(8 * x)⌋) [0..31]
+///   out1 = map (λ x, ⌊((eval arg1 mod m) mod 2^(8 * (x + 1))) / 2^(8 * x)⌋,) [0..31]
 ///
 /// Input Bounds:
 ///   arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xfffffffffffffff]]
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xf]]
-pub fn toBytes(out1: *[32]u8, arg1: [4]u64) void {
+pub fn toBytes(
+    out1: *[32]u8,
+    arg1: [4]u64,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (arg1[3]);
     const x2 = (arg1[2]);
     const x3 = (arg1[1]);
     const x4 = (arg1[0]);
-    const x5 = cast(u8, (x4 & cast(u64, 0xff)));
+    const x5 = cast(u8, (x4 & cast(
+        u64,
+        0xff,
+    )));
     const x6 = (x4 >> 8);
-    const x7 = cast(u8, (x6 & cast(u64, 0xff)));
+    const x7 = cast(u8, (x6 & cast(
+        u64,
+        0xff,
+    )));
     const x8 = (x6 >> 8);
-    const x9 = cast(u8, (x8 & cast(u64, 0xff)));
+    const x9 = cast(u8, (x8 & cast(
+        u64,
+        0xff,
+    )));
     const x10 = (x8 >> 8);
-    const x11 = cast(u8, (x10 & cast(u64, 0xff)));
+    const x11 = cast(u8, (x10 & cast(
+        u64,
+        0xff,
+    )));
     const x12 = (x10 >> 8);
-    const x13 = cast(u8, (x12 & cast(u64, 0xff)));
+    const x13 = cast(u8, (x12 & cast(
+        u64,
+        0xff,
+    )));
     const x14 = (x12 >> 8);
-    const x15 = cast(u8, (x14 & cast(u64, 0xff)));
+    const x15 = cast(u8, (x14 & cast(
+        u64,
+        0xff,
+    )));
     const x16 = (x14 >> 8);
-    const x17 = cast(u8, (x16 & cast(u64, 0xff)));
-    const x18 = cast(u8, (x16 >> 8));
-    const x19 = cast(u8, (x3 & cast(u64, 0xff)));
+    const x17 = cast(u8, (x16 & cast(
+        u64,
+        0xff,
+    )));
+    const x18 = cast(
+        u8,
+        (x16 >> 8),
+    );
+    const x19 = cast(u8, (x3 & cast(
+        u64,
+        0xff,
+    )));
     const x20 = (x3 >> 8);
-    const x21 = cast(u8, (x20 & cast(u64, 0xff)));
+    const x21 = cast(u8, (x20 & cast(
+        u64,
+        0xff,
+    )));
     const x22 = (x20 >> 8);
-    const x23 = cast(u8, (x22 & cast(u64, 0xff)));
+    const x23 = cast(u8, (x22 & cast(
+        u64,
+        0xff,
+    )));
     const x24 = (x22 >> 8);
-    const x25 = cast(u8, (x24 & cast(u64, 0xff)));
+    const x25 = cast(u8, (x24 & cast(
+        u64,
+        0xff,
+    )));
     const x26 = (x24 >> 8);
-    const x27 = cast(u8, (x26 & cast(u64, 0xff)));
+    const x27 = cast(u8, (x26 & cast(
+        u64,
+        0xff,
+    )));
     const x28 = (x26 >> 8);
-    const x29 = cast(u8, (x28 & cast(u64, 0xff)));
+    const x29 = cast(u8, (x28 & cast(
+        u64,
+        0xff,
+    )));
     const x30 = (x28 >> 8);
-    const x31 = cast(u8, (x30 & cast(u64, 0xff)));
-    const x32 = cast(u8, (x30 >> 8));
-    const x33 = cast(u8, (x2 & cast(u64, 0xff)));
+    const x31 = cast(u8, (x30 & cast(
+        u64,
+        0xff,
+    )));
+    const x32 = cast(
+        u8,
+        (x30 >> 8),
+    );
+    const x33 = cast(u8, (x2 & cast(
+        u64,
+        0xff,
+    )));
     const x34 = (x2 >> 8);
-    const x35 = cast(u8, (x34 & cast(u64, 0xff)));
+    const x35 = cast(u8, (x34 & cast(
+        u64,
+        0xff,
+    )));
     const x36 = (x34 >> 8);
-    const x37 = cast(u8, (x36 & cast(u64, 0xff)));
+    const x37 = cast(u8, (x36 & cast(
+        u64,
+        0xff,
+    )));
     const x38 = (x36 >> 8);
-    const x39 = cast(u8, (x38 & cast(u64, 0xff)));
+    const x39 = cast(u8, (x38 & cast(
+        u64,
+        0xff,
+    )));
     const x40 = (x38 >> 8);
-    const x41 = cast(u8, (x40 & cast(u64, 0xff)));
+    const x41 = cast(u8, (x40 & cast(
+        u64,
+        0xff,
+    )));
     const x42 = (x40 >> 8);
-    const x43 = cast(u8, (x42 & cast(u64, 0xff)));
+    const x43 = cast(u8, (x42 & cast(
+        u64,
+        0xff,
+    )));
     const x44 = (x42 >> 8);
-    const x45 = cast(u8, (x44 & cast(u64, 0xff)));
-    const x46 = cast(u8, (x44 >> 8));
-    const x47 = cast(u8, (x1 & cast(u64, 0xff)));
+    const x45 = cast(u8, (x44 & cast(
+        u64,
+        0xff,
+    )));
+    const x46 = cast(
+        u8,
+        (x44 >> 8),
+    );
+    const x47 = cast(u8, (x1 & cast(
+        u64,
+        0xff,
+    )));
     const x48 = (x1 >> 8);
-    const x49 = cast(u8, (x48 & cast(u64, 0xff)));
+    const x49 = cast(u8, (x48 & cast(
+        u64,
+        0xff,
+    )));
     const x50 = (x48 >> 8);
-    const x51 = cast(u8, (x50 & cast(u64, 0xff)));
+    const x51 = cast(u8, (x50 & cast(
+        u64,
+        0xff,
+    )));
     const x52 = (x50 >> 8);
-    const x53 = cast(u8, (x52 & cast(u64, 0xff)));
+    const x53 = cast(u8, (x52 & cast(
+        u64,
+        0xff,
+    )));
     const x54 = (x52 >> 8);
-    const x55 = cast(u8, (x54 & cast(u64, 0xff)));
+    const x55 = cast(u8, (x54 & cast(
+        u64,
+        0xff,
+    )));
     const x56 = (x54 >> 8);
-    const x57 = cast(u8, (x56 & cast(u64, 0xff)));
+    const x57 = cast(u8, (x56 & cast(
+        u64,
+        0xff,
+    )));
     const x58 = (x56 >> 8);
-    const x59 = cast(u8, (x58 & cast(u64, 0xff)));
-    const x60 = cast(u8, (x58 >> 8));
+    const x59 = cast(u8, (x58 & cast(
+        u64,
+        0xff,
+    )));
+    const x60 = cast(
+        u8,
+        (x58 >> 8),
+    );
     out1[0] = x5;
     out1[1] = x7;
     out1[2] = x9;
@@ -1321,63 +3142,162 @@ pub fn toBytes(out1: *[32]u8, arg1: [4]u64) void {
 ///   arg1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xf]]
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xfffffffffffffff]]
-pub fn fromBytes(out1: *[4]u64, arg1: [32]u8) void {
+pub fn fromBytes(
+    out1: *[4]u64,
+    arg1: [32]u8,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (cast(u64, (arg1[31])) << 56);
-    const x2 = (cast(u64, (arg1[30])) << 48);
-    const x3 = (cast(u64, (arg1[29])) << 40);
-    const x4 = (cast(u64, (arg1[28])) << 32);
-    const x5 = (cast(u64, (arg1[27])) << 24);
-    const x6 = (cast(u64, (arg1[26])) << 16);
-    const x7 = (cast(u64, (arg1[25])) << 8);
+    const x1 = (cast(
+        u64,
+        (arg1[31]),
+    ) << 56);
+    const x2 = (cast(
+        u64,
+        (arg1[30]),
+    ) << 48);
+    const x3 = (cast(
+        u64,
+        (arg1[29]),
+    ) << 40);
+    const x4 = (cast(
+        u64,
+        (arg1[28]),
+    ) << 32);
+    const x5 = (cast(
+        u64,
+        (arg1[27]),
+    ) << 24);
+    const x6 = (cast(
+        u64,
+        (arg1[26]),
+    ) << 16);
+    const x7 = (cast(
+        u64,
+        (arg1[25]),
+    ) << 8);
     const x8 = (arg1[24]);
-    const x9 = (cast(u64, (arg1[23])) << 56);
-    const x10 = (cast(u64, (arg1[22])) << 48);
-    const x11 = (cast(u64, (arg1[21])) << 40);
-    const x12 = (cast(u64, (arg1[20])) << 32);
-    const x13 = (cast(u64, (arg1[19])) << 24);
-    const x14 = (cast(u64, (arg1[18])) << 16);
-    const x15 = (cast(u64, (arg1[17])) << 8);
+    const x9 = (cast(
+        u64,
+        (arg1[23]),
+    ) << 56);
+    const x10 = (cast(
+        u64,
+        (arg1[22]),
+    ) << 48);
+    const x11 = (cast(
+        u64,
+        (arg1[21]),
+    ) << 40);
+    const x12 = (cast(
+        u64,
+        (arg1[20]),
+    ) << 32);
+    const x13 = (cast(
+        u64,
+        (arg1[19]),
+    ) << 24);
+    const x14 = (cast(
+        u64,
+        (arg1[18]),
+    ) << 16);
+    const x15 = (cast(
+        u64,
+        (arg1[17]),
+    ) << 8);
     const x16 = (arg1[16]);
-    const x17 = (cast(u64, (arg1[15])) << 56);
-    const x18 = (cast(u64, (arg1[14])) << 48);
-    const x19 = (cast(u64, (arg1[13])) << 40);
-    const x20 = (cast(u64, (arg1[12])) << 32);
-    const x21 = (cast(u64, (arg1[11])) << 24);
-    const x22 = (cast(u64, (arg1[10])) << 16);
-    const x23 = (cast(u64, (arg1[9])) << 8);
+    const x17 = (cast(
+        u64,
+        (arg1[15]),
+    ) << 56);
+    const x18 = (cast(
+        u64,
+        (arg1[14]),
+    ) << 48);
+    const x19 = (cast(
+        u64,
+        (arg1[13]),
+    ) << 40);
+    const x20 = (cast(
+        u64,
+        (arg1[12]),
+    ) << 32);
+    const x21 = (cast(
+        u64,
+        (arg1[11]),
+    ) << 24);
+    const x22 = (cast(
+        u64,
+        (arg1[10]),
+    ) << 16);
+    const x23 = (cast(
+        u64,
+        (arg1[9]),
+    ) << 8);
     const x24 = (arg1[8]);
-    const x25 = (cast(u64, (arg1[7])) << 56);
-    const x26 = (cast(u64, (arg1[6])) << 48);
-    const x27 = (cast(u64, (arg1[5])) << 40);
-    const x28 = (cast(u64, (arg1[4])) << 32);
-    const x29 = (cast(u64, (arg1[3])) << 24);
-    const x30 = (cast(u64, (arg1[2])) << 16);
-    const x31 = (cast(u64, (arg1[1])) << 8);
+    const x25 = (cast(
+        u64,
+        (arg1[7]),
+    ) << 56);
+    const x26 = (cast(
+        u64,
+        (arg1[6]),
+    ) << 48);
+    const x27 = (cast(
+        u64,
+        (arg1[5]),
+    ) << 40);
+    const x28 = (cast(
+        u64,
+        (arg1[4]),
+    ) << 32);
+    const x29 = (cast(
+        u64,
+        (arg1[3]),
+    ) << 24);
+    const x30 = (cast(
+        u64,
+        (arg1[2]),
+    ) << 16);
+    const x31 = (cast(
+        u64,
+        (arg1[1]),
+    ) << 8);
     const x32 = (arg1[0]);
-    const x33 = (x31 + cast(u64, x32));
+    const x33 = (x31 + cast(
+        u64,
+        x32,
+    ));
     const x34 = (x30 + x33);
     const x35 = (x29 + x34);
     const x36 = (x28 + x35);
     const x37 = (x27 + x36);
     const x38 = (x26 + x37);
     const x39 = (x25 + x38);
-    const x40 = (x23 + cast(u64, x24));
+    const x40 = (x23 + cast(
+        u64,
+        x24,
+    ));
     const x41 = (x22 + x40);
     const x42 = (x21 + x41);
     const x43 = (x20 + x42);
     const x44 = (x19 + x43);
     const x45 = (x18 + x44);
     const x46 = (x17 + x45);
-    const x47 = (x15 + cast(u64, x16));
+    const x47 = (x15 + cast(
+        u64,
+        x16,
+    ));
     const x48 = (x14 + x47);
     const x49 = (x13 + x48);
     const x50 = (x12 + x49);
     const x51 = (x11 + x50);
     const x52 = (x10 + x51);
     const x53 = (x9 + x52);
-    const x54 = (x7 + cast(u64, x8));
+    const x54 = (x7 + cast(
+        u64,
+        x8,
+    ));
     const x55 = (x6 + x54);
     const x56 = (x5 + x55);
     const x57 = (x4 + x56);
@@ -1416,11 +3336,23 @@ pub fn setOne(out1: *MontgomeryDomainFieldElement) void {
 pub fn msat(out1: *[5]u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    out1[0] = cast(u64, 0x1);
-    out1[1] = cast(u64, 0x0);
-    out1[2] = cast(u64, 0x0);
+    out1[0] = cast(
+        u64,
+        0x1,
+    );
+    out1[1] = cast(
+        u64,
+        0x0,
+    );
+    out1[2] = cast(
+        u64,
+        0x0,
+    );
     out1[3] = 0x800000000000011;
-    out1[4] = cast(u64, 0x0);
+    out1[4] = cast(
+        u64,
+        0x0,
+    );
 }
 
 /// The function divstep computes a divstep.
@@ -1451,211 +3383,606 @@ pub fn msat(out1: *[5]u64) void {
 ///   out3: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 ///   out4: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 ///   out5: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
-pub fn divstep(out1: *u64, out2: *[5]u64, out3: *[5]u64, out4: *[4]u64, out5: *[4]u64, arg1: u64, arg2: [5]u64, arg3: [5]u64, arg4: [4]u64, arg5: [4]u64) void {
+pub fn divstep(
+    out1: *u64,
+    out2: *[5]u64,
+    out3: *[5]u64,
+    out4: *[4]u64,
+    out5: *[4]u64,
+    arg1: u64,
+    arg2: [5]u64,
+    arg3: [5]u64,
+    arg4: [4]u64,
+    arg5: [4]u64,
+) void {
     @setRuntimeSafety(mode == .Debug);
 
     var x1: u64 = undefined;
     var x2: u1 = undefined;
-    addcarryxU64(&x1, &x2, 0x0, (~arg1), cast(u64, 0x1));
-    const x3 = (cast(u1, (x1 >> 63)) & cast(u1, ((arg3[0]) & cast(u64, 0x1))));
+    addcarryxU64(
+        &x1,
+        &x2,
+        0x0,
+        (~arg1),
+        cast(
+            u64,
+            0x1,
+        ),
+    );
+    const x3 = (cast(
+        u1,
+        (x1 >> 63),
+    ) & cast(
+        u1,
+        ((arg3[0]) & cast(
+            u64,
+            0x1,
+        )),
+    ));
     var x4: u64 = undefined;
     var x5: u1 = undefined;
-    addcarryxU64(&x4, &x5, 0x0, (~arg1), cast(u64, 0x1));
+    addcarryxU64(&x4, &x5, 0x0, (~arg1), cast(
+        u64,
+        0x1,
+    ));
     var x6: u64 = undefined;
-    cmovznzU64(&x6, x3, arg1, x4);
+    cmovznzU64(
+        &x6,
+        x3,
+        arg1,
+        x4,
+    );
     var x7: u64 = undefined;
-    cmovznzU64(&x7, x3, (arg2[0]), (arg3[0]));
+    cmovznzU64(
+        &x7,
+        x3,
+        (arg2[0]),
+        (arg3[0]),
+    );
     var x8: u64 = undefined;
-    cmovznzU64(&x8, x3, (arg2[1]), (arg3[1]));
+    cmovznzU64(
+        &x8,
+        x3,
+        (arg2[1]),
+        (arg3[1]),
+    );
     var x9: u64 = undefined;
-    cmovznzU64(&x9, x3, (arg2[2]), (arg3[2]));
+    cmovznzU64(
+        &x9,
+        x3,
+        (arg2[2]),
+        (arg3[2]),
+    );
     var x10: u64 = undefined;
-    cmovznzU64(&x10, x3, (arg2[3]), (arg3[3]));
+    cmovznzU64(
+        &x10,
+        x3,
+        (arg2[3]),
+        (arg3[3]),
+    );
     var x11: u64 = undefined;
-    cmovznzU64(&x11, x3, (arg2[4]), (arg3[4]));
+    cmovznzU64(
+        &x11,
+        x3,
+        (arg2[4]),
+        (arg3[4]),
+    );
     var x12: u64 = undefined;
     var x13: u1 = undefined;
-    addcarryxU64(&x12, &x13, 0x0, cast(u64, 0x1), (~(arg2[0])));
+    addcarryxU64(
+        &x12,
+        &x13,
+        0x0,
+        cast(
+            u64,
+            0x1,
+        ),
+        (~(arg2[0])),
+    );
     var x14: u64 = undefined;
     var x15: u1 = undefined;
-    addcarryxU64(&x14, &x15, x13, cast(u64, 0x0), (~(arg2[1])));
+    addcarryxU64(
+        &x14,
+        &x15,
+        x13,
+        cast(
+            u64,
+            0x0,
+        ),
+        (~(arg2[1])),
+    );
     var x16: u64 = undefined;
     var x17: u1 = undefined;
-    addcarryxU64(&x16, &x17, x15, cast(u64, 0x0), (~(arg2[2])));
+    addcarryxU64(
+        &x16,
+        &x17,
+        x15,
+        cast(
+            u64,
+            0x0,
+        ),
+        (~(arg2[2])),
+    );
     var x18: u64 = undefined;
     var x19: u1 = undefined;
-    addcarryxU64(&x18, &x19, x17, cast(u64, 0x0), (~(arg2[3])));
+    addcarryxU64(
+        &x18,
+        &x19,
+        x17,
+        cast(
+            u64,
+            0x0,
+        ),
+        (~(arg2[3])),
+    );
     var x20: u64 = undefined;
     var x21: u1 = undefined;
-    addcarryxU64(&x20, &x21, x19, cast(u64, 0x0), (~(arg2[4])));
+    addcarryxU64(
+        &x20,
+        &x21,
+        x19,
+        cast(
+            u64,
+            0x0,
+        ),
+        (~(arg2[4])),
+    );
     var x22: u64 = undefined;
-    cmovznzU64(&x22, x3, (arg3[0]), x12);
+    cmovznzU64(
+        &x22,
+        x3,
+        (arg3[0]),
+        x12,
+    );
     var x23: u64 = undefined;
-    cmovznzU64(&x23, x3, (arg3[1]), x14);
+    cmovznzU64(
+        &x23,
+        x3,
+        (arg3[1]),
+        x14,
+    );
     var x24: u64 = undefined;
-    cmovznzU64(&x24, x3, (arg3[2]), x16);
+    cmovznzU64(
+        &x24,
+        x3,
+        (arg3[2]),
+        x16,
+    );
     var x25: u64 = undefined;
-    cmovznzU64(&x25, x3, (arg3[3]), x18);
+    cmovznzU64(
+        &x25,
+        x3,
+        (arg3[3]),
+        x18,
+    );
     var x26: u64 = undefined;
-    cmovznzU64(&x26, x3, (arg3[4]), x20);
+    cmovznzU64(
+        &x26,
+        x3,
+        (arg3[4]),
+        x20,
+    );
     var x27: u64 = undefined;
-    cmovznzU64(&x27, x3, (arg4[0]), (arg5[0]));
+    cmovznzU64(
+        &x27,
+        x3,
+        (arg4[0]),
+        (arg5[0]),
+    );
     var x28: u64 = undefined;
-    cmovznzU64(&x28, x3, (arg4[1]), (arg5[1]));
+    cmovznzU64(
+        &x28,
+        x3,
+        (arg4[1]),
+        (arg5[1]),
+    );
     var x29: u64 = undefined;
-    cmovznzU64(&x29, x3, (arg4[2]), (arg5[2]));
+    cmovznzU64(
+        &x29,
+        x3,
+        (arg4[2]),
+        (arg5[2]),
+    );
     var x30: u64 = undefined;
-    cmovznzU64(&x30, x3, (arg4[3]), (arg5[3]));
+    cmovznzU64(
+        &x30,
+        x3,
+        (arg4[3]),
+        (arg5[3]),
+    );
     var x31: u64 = undefined;
     var x32: u1 = undefined;
-    addcarryxU64(&x31, &x32, 0x0, x27, x27);
+    addcarryxU64(
+        &x31,
+        &x32,
+        0x0,
+        x27,
+        x27,
+    );
     var x33: u64 = undefined;
     var x34: u1 = undefined;
-    addcarryxU64(&x33, &x34, x32, x28, x28);
+    addcarryxU64(
+        &x33,
+        &x34,
+        x32,
+        x28,
+        x28,
+    );
     var x35: u64 = undefined;
     var x36: u1 = undefined;
-    addcarryxU64(&x35, &x36, x34, x29, x29);
+    addcarryxU64(
+        &x35,
+        &x36,
+        x34,
+        x29,
+        x29,
+    );
     var x37: u64 = undefined;
     var x38: u1 = undefined;
-    addcarryxU64(&x37, &x38, x36, x30, x30);
+    addcarryxU64(
+        &x37,
+        &x38,
+        x36,
+        x30,
+        x30,
+    );
     var x39: u64 = undefined;
     var x40: u1 = undefined;
-    subborrowxU64(&x39, &x40, 0x0, x31, cast(u64, 0x1));
+    subborrowxU64(&x39, &x40, 0x0, x31, cast(
+        u64,
+        0x1,
+    ));
     var x41: u64 = undefined;
     var x42: u1 = undefined;
-    subborrowxU64(&x41, &x42, x40, x33, cast(u64, 0x0));
+    subborrowxU64(&x41, &x42, x40, x33, cast(
+        u64,
+        0x0,
+    ));
     var x43: u64 = undefined;
     var x44: u1 = undefined;
-    subborrowxU64(&x43, &x44, x42, x35, cast(u64, 0x0));
+    subborrowxU64(&x43, &x44, x42, x35, cast(
+        u64,
+        0x0,
+    ));
     var x45: u64 = undefined;
     var x46: u1 = undefined;
-    subborrowxU64(&x45, &x46, x44, x37, 0x800000000000011);
+    subborrowxU64(
+        &x45,
+        &x46,
+        x44,
+        x37,
+        0x800000000000011,
+    );
     var x47: u64 = undefined;
     var x48: u1 = undefined;
-    subborrowxU64(&x47, &x48, x46, cast(u64, x38), cast(u64, 0x0));
+    subborrowxU64(&x47, &x48, x46, cast(
+        u64,
+        x38,
+    ), cast(
+        u64,
+        0x0,
+    ));
     const x49 = (arg4[3]);
     const x50 = (arg4[2]);
     const x51 = (arg4[1]);
     const x52 = (arg4[0]);
     var x53: u64 = undefined;
     var x54: u1 = undefined;
-    subborrowxU64(&x53, &x54, 0x0, cast(u64, 0x0), x52);
+    subborrowxU64(&x53, &x54, 0x0, cast(
+        u64,
+        0x0,
+    ), x52);
     var x55: u64 = undefined;
     var x56: u1 = undefined;
-    subborrowxU64(&x55, &x56, x54, cast(u64, 0x0), x51);
+    subborrowxU64(&x55, &x56, x54, cast(
+        u64,
+        0x0,
+    ), x51);
     var x57: u64 = undefined;
     var x58: u1 = undefined;
-    subborrowxU64(&x57, &x58, x56, cast(u64, 0x0), x50);
+    subborrowxU64(&x57, &x58, x56, cast(
+        u64,
+        0x0,
+    ), x50);
     var x59: u64 = undefined;
     var x60: u1 = undefined;
-    subborrowxU64(&x59, &x60, x58, cast(u64, 0x0), x49);
+    subborrowxU64(&x59, &x60, x58, cast(
+        u64,
+        0x0,
+    ), x49);
     var x61: u64 = undefined;
-    cmovznzU64(&x61, x60, cast(u64, 0x0), 0xffffffffffffffff);
+    cmovznzU64(&x61, x60, cast(
+        u64,
+        0x0,
+    ), 0xffffffffffffffff);
     var x62: u64 = undefined;
     var x63: u1 = undefined;
-    addcarryxU64(&x62, &x63, 0x0, x53, cast(u64, cast(u1, (x61 & cast(u64, 0x1)))));
+    addcarryxU64(&x62, &x63, 0x0, x53, cast(u64, cast(u1, (x61 & cast(
+        u64,
+        0x1,
+    )))));
     var x64: u64 = undefined;
     var x65: u1 = undefined;
-    addcarryxU64(&x64, &x65, x63, x55, cast(u64, 0x0));
+    addcarryxU64(&x64, &x65, x63, x55, cast(
+        u64,
+        0x0,
+    ));
     var x66: u64 = undefined;
     var x67: u1 = undefined;
-    addcarryxU64(&x66, &x67, x65, x57, cast(u64, 0x0));
+    addcarryxU64(&x66, &x67, x65, x57, cast(
+        u64,
+        0x0,
+    ));
     var x68: u64 = undefined;
     var x69: u1 = undefined;
-    addcarryxU64(&x68, &x69, x67, x59, (x61 & 0x800000000000011));
+    addcarryxU64(
+        &x68,
+        &x69,
+        x67,
+        x59,
+        (x61 & 0x800000000000011),
+    );
     var x70: u64 = undefined;
-    cmovznzU64(&x70, x3, (arg5[0]), x62);
+    cmovznzU64(
+        &x70,
+        x3,
+        (arg5[0]),
+        x62,
+    );
     var x71: u64 = undefined;
-    cmovznzU64(&x71, x3, (arg5[1]), x64);
+    cmovznzU64(
+        &x71,
+        x3,
+        (arg5[1]),
+        x64,
+    );
     var x72: u64 = undefined;
-    cmovznzU64(&x72, x3, (arg5[2]), x66);
+    cmovznzU64(
+        &x72,
+        x3,
+        (arg5[2]),
+        x66,
+    );
     var x73: u64 = undefined;
-    cmovznzU64(&x73, x3, (arg5[3]), x68);
-    const x74 = cast(u1, (x22 & cast(u64, 0x1)));
+    cmovznzU64(
+        &x73,
+        x3,
+        (arg5[3]),
+        x68,
+    );
+    const x74 = cast(u1, (x22 & cast(
+        u64,
+        0x1,
+    )));
     var x75: u64 = undefined;
-    cmovznzU64(&x75, x74, cast(u64, 0x0), x7);
+    cmovznzU64(&x75, x74, cast(
+        u64,
+        0x0,
+    ), x7);
     var x76: u64 = undefined;
-    cmovznzU64(&x76, x74, cast(u64, 0x0), x8);
+    cmovznzU64(&x76, x74, cast(
+        u64,
+        0x0,
+    ), x8);
     var x77: u64 = undefined;
-    cmovznzU64(&x77, x74, cast(u64, 0x0), x9);
+    cmovznzU64(&x77, x74, cast(
+        u64,
+        0x0,
+    ), x9);
     var x78: u64 = undefined;
-    cmovznzU64(&x78, x74, cast(u64, 0x0), x10);
+    cmovznzU64(&x78, x74, cast(
+        u64,
+        0x0,
+    ), x10);
     var x79: u64 = undefined;
-    cmovznzU64(&x79, x74, cast(u64, 0x0), x11);
+    cmovznzU64(&x79, x74, cast(
+        u64,
+        0x0,
+    ), x11);
     var x80: u64 = undefined;
     var x81: u1 = undefined;
-    addcarryxU64(&x80, &x81, 0x0, x22, x75);
+    addcarryxU64(
+        &x80,
+        &x81,
+        0x0,
+        x22,
+        x75,
+    );
     var x82: u64 = undefined;
     var x83: u1 = undefined;
-    addcarryxU64(&x82, &x83, x81, x23, x76);
+    addcarryxU64(
+        &x82,
+        &x83,
+        x81,
+        x23,
+        x76,
+    );
     var x84: u64 = undefined;
     var x85: u1 = undefined;
-    addcarryxU64(&x84, &x85, x83, x24, x77);
+    addcarryxU64(
+        &x84,
+        &x85,
+        x83,
+        x24,
+        x77,
+    );
     var x86: u64 = undefined;
     var x87: u1 = undefined;
-    addcarryxU64(&x86, &x87, x85, x25, x78);
+    addcarryxU64(
+        &x86,
+        &x87,
+        x85,
+        x25,
+        x78,
+    );
     var x88: u64 = undefined;
     var x89: u1 = undefined;
-    addcarryxU64(&x88, &x89, x87, x26, x79);
+    addcarryxU64(
+        &x88,
+        &x89,
+        x87,
+        x26,
+        x79,
+    );
     var x90: u64 = undefined;
-    cmovznzU64(&x90, x74, cast(u64, 0x0), x27);
+    cmovznzU64(&x90, x74, cast(
+        u64,
+        0x0,
+    ), x27);
     var x91: u64 = undefined;
-    cmovznzU64(&x91, x74, cast(u64, 0x0), x28);
+    cmovznzU64(&x91, x74, cast(
+        u64,
+        0x0,
+    ), x28);
     var x92: u64 = undefined;
-    cmovznzU64(&x92, x74, cast(u64, 0x0), x29);
+    cmovznzU64(&x92, x74, cast(
+        u64,
+        0x0,
+    ), x29);
     var x93: u64 = undefined;
-    cmovznzU64(&x93, x74, cast(u64, 0x0), x30);
+    cmovznzU64(&x93, x74, cast(
+        u64,
+        0x0,
+    ), x30);
     var x94: u64 = undefined;
     var x95: u1 = undefined;
-    addcarryxU64(&x94, &x95, 0x0, x70, x90);
+    addcarryxU64(
+        &x94,
+        &x95,
+        0x0,
+        x70,
+        x90,
+    );
     var x96: u64 = undefined;
     var x97: u1 = undefined;
-    addcarryxU64(&x96, &x97, x95, x71, x91);
+    addcarryxU64(
+        &x96,
+        &x97,
+        x95,
+        x71,
+        x91,
+    );
     var x98: u64 = undefined;
     var x99: u1 = undefined;
-    addcarryxU64(&x98, &x99, x97, x72, x92);
+    addcarryxU64(
+        &x98,
+        &x99,
+        x97,
+        x72,
+        x92,
+    );
     var x100: u64 = undefined;
     var x101: u1 = undefined;
-    addcarryxU64(&x100, &x101, x99, x73, x93);
+    addcarryxU64(
+        &x100,
+        &x101,
+        x99,
+        x73,
+        x93,
+    );
     var x102: u64 = undefined;
     var x103: u1 = undefined;
-    subborrowxU64(&x102, &x103, 0x0, x94, cast(u64, 0x1));
+    subborrowxU64(&x102, &x103, 0x0, x94, cast(
+        u64,
+        0x1,
+    ));
     var x104: u64 = undefined;
     var x105: u1 = undefined;
-    subborrowxU64(&x104, &x105, x103, x96, cast(u64, 0x0));
+    subborrowxU64(&x104, &x105, x103, x96, cast(
+        u64,
+        0x0,
+    ));
     var x106: u64 = undefined;
     var x107: u1 = undefined;
-    subborrowxU64(&x106, &x107, x105, x98, cast(u64, 0x0));
+    subborrowxU64(&x106, &x107, x105, x98, cast(
+        u64,
+        0x0,
+    ));
     var x108: u64 = undefined;
     var x109: u1 = undefined;
-    subborrowxU64(&x108, &x109, x107, x100, 0x800000000000011);
+    subborrowxU64(
+        &x108,
+        &x109,
+        x107,
+        x100,
+        0x800000000000011,
+    );
     var x110: u64 = undefined;
     var x111: u1 = undefined;
-    subborrowxU64(&x110, &x111, x109, cast(u64, x101), cast(u64, 0x0));
+    subborrowxU64(&x110, &x111, x109, cast(
+        u64,
+        x101,
+    ), cast(
+        u64,
+        0x0,
+    ));
     var x112: u64 = undefined;
     var x113: u1 = undefined;
-    addcarryxU64(&x112, &x113, 0x0, x6, cast(u64, 0x1));
+    addcarryxU64(&x112, &x113, 0x0, x6, cast(
+        u64,
+        0x1,
+    ));
     const x114 = ((x80 >> 1) | ((x82 << 63) & 0xffffffffffffffff));
     const x115 = ((x82 >> 1) | ((x84 << 63) & 0xffffffffffffffff));
     const x116 = ((x84 >> 1) | ((x86 << 63) & 0xffffffffffffffff));
     const x117 = ((x86 >> 1) | ((x88 << 63) & 0xffffffffffffffff));
     const x118 = ((x88 & 0x8000000000000000) | (x88 >> 1));
     var x119: u64 = undefined;
-    cmovznzU64(&x119, x48, x39, x31);
+    cmovznzU64(
+        &x119,
+        x48,
+        x39,
+        x31,
+    );
     var x120: u64 = undefined;
-    cmovznzU64(&x120, x48, x41, x33);
+    cmovznzU64(
+        &x120,
+        x48,
+        x41,
+        x33,
+    );
     var x121: u64 = undefined;
-    cmovznzU64(&x121, x48, x43, x35);
+    cmovznzU64(
+        &x121,
+        x48,
+        x43,
+        x35,
+    );
     var x122: u64 = undefined;
-    cmovznzU64(&x122, x48, x45, x37);
+    cmovznzU64(
+        &x122,
+        x48,
+        x45,
+        x37,
+    );
     var x123: u64 = undefined;
-    cmovznzU64(&x123, x111, x102, x94);
+    cmovznzU64(
+        &x123,
+        x111,
+        x102,
+        x94,
+    );
     var x124: u64 = undefined;
-    cmovznzU64(&x124, x111, x104, x96);
+    cmovznzU64(
+        &x124,
+        x111,
+        x104,
+        x96,
+    );
     var x125: u64 = undefined;
-    cmovznzU64(&x125, x111, x106, x98);
+    cmovznzU64(
+        &x125,
+        x111,
+        x106,
+        x98,
+    );
     var x126: u64 = undefined;
-    cmovznzU64(&x126, x111, x108, x100);
+    cmovznzU64(
+        &x126,
+        x111,
+        x108,
+        x100,
+    );
     out1.* = x112;
     out2[0] = x7;
     out2[1] = x8;

--- a/src/utils/log.zig
+++ b/src/utils/log.zig
@@ -48,7 +48,11 @@ pub fn logFn(
     const stderr = std.io.getStdErr().writer();
 
     // Log the header
-    _ = stderr.print("time={s} level={s} ({s}) msg=", .{ time_str, level_str, scope_str }) catch unreachable;
+    _ = stderr.print("time={s} level={s} ({s}) msg=", .{
+        time_str,
+        level_str,
+        scope_str,
+    }) catch unreachable;
 
     // Log the main message
     nosuspend stderr.print(

--- a/src/utils/log.zig
+++ b/src/utils/log.zig
@@ -35,7 +35,10 @@ pub fn logFn(
 
     // Capture the current time in UTC format.
     const utc_format = "YYYY-MM-DDTHH:mm:ss";
-    const time_str = DateTime.now().formatAlloc(allocator, utc_format) catch unreachable;
+    const time_str = DateTime.now().formatAlloc(
+        allocator,
+        utc_format,
+    ) catch unreachable;
     defer allocator.free(time_str); // Free the memory allocated by the allocator in `formatAlloc`.
 
     // Convert the log level and scope to string using @tagName.
@@ -48,7 +51,10 @@ pub fn logFn(
     _ = stderr.print("time={s} level={s} ({s}) msg=", .{ time_str, level_str, scope_str }) catch unreachable;
 
     // Log the main message
-    nosuspend stderr.print(format, args) catch return;
+    nosuspend stderr.print(
+        format,
+        args,
+    ) catch return;
 
     // Write a newline for better readability.
     nosuspend stderr.writeAll("\n") catch return;

--- a/src/utils/time.zig
+++ b/src/utils/time.zig
@@ -369,12 +369,38 @@ pub const DateTime = struct {
                     .MMM => try printLongName(
                         writer,
                         self.months,
-                        &[_]string{ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" },
+                        &[_]string{
+                            "Jan",
+                            "Feb",
+                            "Mar",
+                            "Apr",
+                            "May",
+                            "Jun",
+                            "Jul",
+                            "Aug",
+                            "Sep",
+                            "Oct",
+                            "Nov",
+                            "Dec",
+                        },
                     ),
                     .MMMM => try printLongName(
                         writer,
                         self.months,
-                        &[_]string{ "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" },
+                        &[_]string{
+                            "January",
+                            "February",
+                            "March",
+                            "April",
+                            "May",
+                            "June",
+                            "July",
+                            "August",
+                            "September",
+                            "October",
+                            "November",
+                            "December",
+                        },
                     ),
 
                     .Q => try writer.print(
@@ -425,7 +451,15 @@ pub const DateTime = struct {
                     .dddd => try printLongName(
                         writer,
                         @intFromEnum(self.weekday),
-                        &[_]string{ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" },
+                        &[_]string{
+                            "Sunday",
+                            "Monday",
+                            "Tuesday",
+                            "Wednesday",
+                            "Thursday",
+                            "Friday",
+                            "Saturday",
+                        },
                     ),
                     .e => try writer.print(
                         "{}",
@@ -472,12 +506,18 @@ pub const DateTime = struct {
                     .A => try printLongName(
                         writer,
                         self.hours / 12,
-                        &[_]string{ "AM", "PM" },
+                        &[_]string{
+                            "AM",
+                            "PM",
+                        },
                     ),
                     .a => try printLongName(
                         writer,
                         self.hours / 12,
-                        &[_]string{ "am", "pm" },
+                        &[_]string{
+                            "am",
+                            "pm",
+                        },
                     ),
 
                     .H => try writer.print(
@@ -709,8 +749,34 @@ fn daysInMonth(
     year: u16,
     month: u16,
 ) u16 {
-    const norm = [12]u16{ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
-    const leap = [12]u16{ 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+    const norm = [12]u16{
+        31,
+        28,
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    };
+    const leap = [12]u16{
+        31,
+        29,
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    };
     const month_days = if (!isLeapYear(year)) norm else leap;
     return month_days[month];
 }

--- a/src/utils/time.zig
+++ b/src/utils/time.zig
@@ -48,7 +48,14 @@ pub const DateTime = struct {
     }
 
     /// Caller asserts that this is > epoch
-    pub fn init(year: u16, month: u16, day: u16, hr: u16, min: u16, sec: u16) Self {
+    pub fn init(
+        year: u16,
+        month: u16,
+        day: u16,
+        hr: u16,
+        min: u16,
+        sec: u16,
+    ) Self {
         return epoch_unix
             .addYears(year - epoch_unix.years)
             .addMonths(month)
@@ -59,7 +66,12 @@ pub const DateTime = struct {
     }
 
     pub fn now() Self {
-        return initUnixMs(@as(u64, @intCast(std.time.milliTimestamp())));
+        return initUnixMs(
+            @as(
+                u64,
+                @intCast(std.time.milliTimestamp()),
+            ),
+        );
     }
 
     pub const epoch_unix = Self{
@@ -75,7 +87,10 @@ pub const DateTime = struct {
         .era = .AD,
     };
 
-    pub fn eql(self: Self, other: Self) bool {
+    pub fn eql(
+        self: Self,
+        other: Self,
+    ) bool {
         return self.ms == other.ms and
             self.seconds == other.seconds and
             self.minutes == other.minutes and
@@ -87,35 +102,62 @@ pub const DateTime = struct {
             self.weekday == other.weekday;
     }
 
-    pub fn addMs(self: Self, count: u64) Self {
+    pub fn addMs(
+        self: Self,
+        count: u64,
+    ) Self {
         if (count == 0) return self;
         var result = self;
-        result.ms += @as(u16, @intCast(count % 1000));
+        result.ms += @as(
+            u16,
+            @intCast(count % 1000),
+        );
         return result.addSecs(count / 1000);
     }
 
-    pub fn addSecs(self: Self, count: u64) Self {
+    pub fn addSecs(
+        self: Self,
+        count: u64,
+    ) Self {
         if (count == 0) return self;
         var result = self;
-        result.seconds += @as(u16, @intCast(count % 60));
+        result.seconds += @as(
+            u16,
+            @intCast(count % 60),
+        );
         return result.addMins(count / 60);
     }
 
-    pub fn addMins(self: Self, count: u64) Self {
+    pub fn addMins(
+        self: Self,
+        count: u64,
+    ) Self {
         if (count == 0) return self;
         var result = self;
-        result.minutes += @as(u16, @intCast(count % 60));
+        result.minutes += @as(
+            u16,
+            @intCast(count % 60),
+        );
         return result.addHours(count / 60);
     }
 
-    pub fn addHours(self: Self, count: u64) Self {
+    pub fn addHours(
+        self: Self,
+        count: u64,
+    ) Self {
         if (count == 0) return self;
         var result = self;
-        result.hours += @as(u16, @intCast(count % 24));
+        result.hours += @as(
+            u16,
+            @intCast(count % 24),
+        );
         return result.addDays(count / 24);
     }
 
-    pub fn addDays(self: Self, count: u64) Self {
+    pub fn addDays(
+        self: Self,
+        count: u64,
+    ) Self {
         if (count == 0) return self;
         var result = self;
         var input = count;
@@ -154,7 +196,10 @@ pub const DateTime = struct {
                 result.days = 0;
                 result.incrementWeekday(left);
             }
-            result.days += @as(u16, @intCast(input));
+            result.days += @as(
+                u16,
+                @intCast(input),
+            );
             result.incrementWeekday(input);
 
             if (result.months == 12) {
@@ -166,7 +211,10 @@ pub const DateTime = struct {
         return result;
     }
 
-    pub fn addMonths(self: Self, count: u64) Self {
+    pub fn addMonths(
+        self: Self,
+        count: u64,
+    ) Self {
         if (count == 0) return self;
         var result = self;
         var input = count;
@@ -178,7 +226,10 @@ pub const DateTime = struct {
         return result;
     }
 
-    pub fn addYears(self: Self, count: u64) Self {
+    pub fn addYears(
+        self: Self,
+        count: u64,
+    ) Self {
         if (count == 0) return self;
         return self.addMonths(count * 12);
     }
@@ -195,11 +246,20 @@ pub const DateTime = struct {
         return self.daysInMonth(self.months);
     }
 
-    fn daysInMonth(self: Self, month: u16) u16 {
-        return time.daysInMonth(self.years, month);
+    fn daysInMonth(
+        self: Self,
+        month: u16,
+    ) u16 {
+        return time.daysInMonth(
+            self.years,
+            month,
+        );
     }
 
-    fn incrementWeekday(self: *Self, count: u64) void {
+    fn incrementWeekday(
+        self: *Self,
+        count: u64,
+    ) void {
         var i = count % 7;
         while (i > 0) : (i -= 1) {
             self.weekday = self.weekday.next();
@@ -209,7 +269,12 @@ pub const DateTime = struct {
     pub fn dayOfThisYear(self: Self) u16 {
         var ret: u16 = 0;
         for (0..self.months) |item| {
-            ret += self.daysInMonth(@as(u16, @intCast(item)));
+            ret += self.daysInMonth(
+                @as(
+                    u16,
+                    @intCast(item),
+                ),
+            );
         }
         ret += self.days;
         return ret;
@@ -223,9 +288,18 @@ pub const DateTime = struct {
     pub fn toUnixMilli(self: Self) u64 {
         var res: u64 = 0;
         res += self.ms;
-        res += @as(u64, self.seconds) * std.time.ms_per_s;
-        res += @as(u64, self.minutes) * std.time.ms_per_min;
-        res += @as(u64, self.hours) * std.time.ms_per_hour;
+        res += @as(
+            u64,
+            self.seconds,
+        ) * std.time.ms_per_s;
+        res += @as(
+            u64,
+            self.minutes,
+        ) * std.time.ms_per_min;
+        res += @as(
+            u64,
+            self.hours,
+        ) * std.time.ms_per_hour;
         res += self.daysSinceEpoch() * std.time.ms_per_day;
         return res;
     }
@@ -233,13 +307,28 @@ pub const DateTime = struct {
     fn daysSinceEpoch(self: Self) u64 {
         var res: u64 = 0;
         res += self.days;
-        for (0..self.years - epoch_unix.years) |i| res += time.daysInYear(@as(u16, @intCast(i)));
-        for (0..self.months) |i| res += self.daysInMonth(@as(u16, @intCast(i)));
+        for (0..self.years - epoch_unix.years) |i| res += time.daysInYear(
+            @as(
+                u16,
+                @intCast(i),
+            ),
+        );
+        for (0..self.months) |i| res += self.daysInMonth(
+            @as(
+                u16,
+                @intCast(i),
+            ),
+        );
         return res;
     }
 
     /// fmt is based on https://momentjs.com/docs/#/displaying/format/
-    pub fn format(self: Self, comptime fmt: string, options: std.fmt.FormatOptions, writer: anytype) !void {
+    pub fn format(
+        self: Self,
+        comptime fmt: string,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
         _ = options;
 
         if (fmt.len == 0) @compileError("DateTime: format string can't be empty");
@@ -249,79 +338,216 @@ pub const DateTime = struct {
         comptime var s = 0;
         comptime var e = 0;
         comptime var next: ?FormatSeq = null;
-        inline for (fmt, 0..) |c, i| {
+        inline for (
+            fmt,
+            0..,
+        ) |c, i| {
             e = i + 1;
 
-            if (comptime std.meta.stringToEnum(FormatSeq, fmt[s..e])) |tag| {
+            if (comptime std.meta.stringToEnum(
+                FormatSeq,
+                fmt[s..e],
+            )) |tag| {
                 next = tag;
                 if (i < fmt.len - 1) continue;
             }
 
             if (next) |tag| {
                 switch (tag) {
-                    .MM => try writer.print("{:0>2}", .{self.months + 1}),
-                    .M => try writer.print("{}", .{self.months + 1}),
-                    .Mo => try printOrdinal(writer, self.months + 1),
-                    .MMM => try printLongName(writer, self.months, &[_]string{ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" }),
-                    .MMMM => try printLongName(writer, self.months, &[_]string{ "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" }),
+                    .MM => try writer.print(
+                        "{:0>2}",
+                        .{self.months + 1},
+                    ),
+                    .M => try writer.print(
+                        "{}",
+                        .{self.months + 1},
+                    ),
+                    .Mo => try printOrdinal(
+                        writer,
+                        self.months + 1,
+                    ),
+                    .MMM => try printLongName(
+                        writer,
+                        self.months,
+                        &[_]string{ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" },
+                    ),
+                    .MMMM => try printLongName(
+                        writer,
+                        self.months,
+                        &[_]string{ "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" },
+                    ),
 
-                    .Q => try writer.print("{}", .{self.months / 3 + 1}),
-                    .Qo => try printOrdinal(writer, self.months / 3 + 1),
+                    .Q => try writer.print(
+                        "{}",
+                        .{self.months / 3 + 1},
+                    ),
+                    .Qo => try printOrdinal(
+                        writer,
+                        self.months / 3 + 1,
+                    ),
 
-                    .D => try writer.print("{}", .{self.days + 1}),
-                    .Do => try printOrdinal(writer, self.days + 1),
-                    .DD => try writer.print("{:0>2}", .{self.days + 1}),
+                    .D => try writer.print(
+                        "{}",
+                        .{self.days + 1},
+                    ),
+                    .Do => try printOrdinal(
+                        writer,
+                        self.days + 1,
+                    ),
+                    .DD => try writer.print(
+                        "{:0>2}",
+                        .{self.days + 1},
+                    ),
 
-                    .DDD => try writer.print("{}", .{self.dayOfThisYear() + 1}),
-                    .DDDo => try printOrdinal(writer, self.dayOfThisYear() + 1),
-                    .DDDD => try writer.print("{:0>3}", .{self.dayOfThisYear() + 1}),
+                    .DDD => try writer.print(
+                        "{}",
+                        .{self.dayOfThisYear() + 1},
+                    ),
+                    .DDDo => try printOrdinal(
+                        writer,
+                        self.dayOfThisYear() + 1,
+                    ),
+                    .DDDD => try writer.print(
+                        "{:0>3}",
+                        .{self.dayOfThisYear() + 1},
+                    ),
 
-                    .d => try writer.print("{}", .{@intFromEnum(self.weekday)}),
-                    .do => try printOrdinal(writer, @intFromEnum(self.weekday)),
+                    .d => try writer.print(
+                        "{}",
+                        .{@intFromEnum(self.weekday)},
+                    ),
+                    .do => try printOrdinal(
+                        writer,
+                        @intFromEnum(self.weekday),
+                    ),
                     .dd => try writer.writeAll(@tagName(self.weekday)[0..2]),
                     .ddd => try writer.writeAll(@tagName(self.weekday)),
-                    .dddd => try printLongName(writer, @intFromEnum(self.weekday), &[_]string{ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" }),
-                    .e => try writer.print("{}", .{@intFromEnum(self.weekday)}),
-                    .E => try writer.print("{}", .{@intFromEnum(self.weekday) + 1}),
+                    .dddd => try printLongName(
+                        writer,
+                        @intFromEnum(self.weekday),
+                        &[_]string{ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" },
+                    ),
+                    .e => try writer.print(
+                        "{}",
+                        .{@intFromEnum(self.weekday)},
+                    ),
+                    .E => try writer.print(
+                        "{}",
+                        .{@intFromEnum(self.weekday) + 1},
+                    ),
 
-                    .w => try writer.print("{}", .{self.dayOfThisYear() / 7 + 1}),
-                    .wo => try printOrdinal(writer, self.dayOfThisYear() / 7 + 1),
-                    .ww => try writer.print("{:0>2}", .{self.dayOfThisYear() / 7 + 1}),
+                    .w => try writer.print(
+                        "{}",
+                        .{self.dayOfThisYear() / 7 + 1},
+                    ),
+                    .wo => try printOrdinal(
+                        writer,
+                        self.dayOfThisYear() / 7 + 1,
+                    ),
+                    .ww => try writer.print(
+                        "{:0>2}",
+                        .{self.dayOfThisYear() / 7 + 1},
+                    ),
 
-                    .Y => try writer.print("{}", .{self.years + 10000}),
-                    .YY => try writer.print("{:0>2}", .{self.years % 100}),
-                    .YYY => try writer.print("{}", .{self.years}),
-                    .YYYY => try writer.print("{:0>4}", .{self.years}),
+                    .Y => try writer.print(
+                        "{}",
+                        .{self.years + 10000},
+                    ),
+                    .YY => try writer.print(
+                        "{:0>2}",
+                        .{self.years % 100},
+                    ),
+                    .YYY => try writer.print(
+                        "{}",
+                        .{self.years},
+                    ),
+                    .YYYY => try writer.print(
+                        "{:0>4}",
+                        .{self.years},
+                    ),
 
                     .N => try writer.writeAll(@tagName(self.era)),
                     .NN => try writer.writeAll("Anno Domini"),
 
-                    .A => try printLongName(writer, self.hours / 12, &[_]string{ "AM", "PM" }),
-                    .a => try printLongName(writer, self.hours / 12, &[_]string{ "am", "pm" }),
+                    .A => try printLongName(
+                        writer,
+                        self.hours / 12,
+                        &[_]string{ "AM", "PM" },
+                    ),
+                    .a => try printLongName(
+                        writer,
+                        self.hours / 12,
+                        &[_]string{ "am", "pm" },
+                    ),
 
-                    .H => try writer.print("{}", .{self.hours}),
-                    .HH => try writer.print("{:0>2}", .{self.hours}),
-                    .h => try writer.print("{}", .{wrap(self.hours, 12)}),
-                    .hh => try writer.print("{:0>2}", .{wrap(self.hours, 12)}),
-                    .k => try writer.print("{}", .{wrap(self.hours, 24)}),
-                    .kk => try writer.print("{:0>2}", .{wrap(self.hours, 24)}),
+                    .H => try writer.print(
+                        "{}",
+                        .{self.hours},
+                    ),
+                    .HH => try writer.print(
+                        "{:0>2}",
+                        .{self.hours},
+                    ),
+                    .h => try writer.print("{}", .{wrap(
+                        self.hours,
+                        12,
+                    )}),
+                    .hh => try writer.print("{:0>2}", .{wrap(
+                        self.hours,
+                        12,
+                    )}),
+                    .k => try writer.print("{}", .{wrap(
+                        self.hours,
+                        24,
+                    )}),
+                    .kk => try writer.print("{:0>2}", .{wrap(
+                        self.hours,
+                        24,
+                    )}),
 
-                    .m => try writer.print("{}", .{self.minutes}),
-                    .mm => try writer.print("{:0>2}", .{self.minutes}),
+                    .m => try writer.print(
+                        "{}",
+                        .{self.minutes},
+                    ),
+                    .mm => try writer.print(
+                        "{:0>2}",
+                        .{self.minutes},
+                    ),
 
-                    .s => try writer.print("{}", .{self.seconds}),
-                    .ss => try writer.print("{:0>2}", .{self.seconds}),
+                    .s => try writer.print(
+                        "{}",
+                        .{self.seconds},
+                    ),
+                    .ss => try writer.print(
+                        "{:0>2}",
+                        .{self.seconds},
+                    ),
 
-                    .S => try writer.print("{}", .{self.ms / 100}),
-                    .SS => try writer.print("{:0>2}", .{self.ms / 10}),
-                    .SSS => try writer.print("{:0>3}", .{self.ms}),
+                    .S => try writer.print(
+                        "{}",
+                        .{self.ms / 100},
+                    ),
+                    .SS => try writer.print(
+                        "{:0>2}",
+                        .{self.ms / 10},
+                    ),
+                    .SSS => try writer.print(
+                        "{:0>3}",
+                        .{self.ms},
+                    ),
 
                     .z => try writer.writeAll(@tagName(self.timezone)),
                     .Z => try writer.writeAll("+00:00"),
                     .ZZ => try writer.writeAll("+0000"),
 
-                    .x => try writer.print("{}", .{self.toUnixMilli()}),
-                    .X => try writer.print("{}", .{self.toUnix()}),
+                    .x => try writer.print(
+                        "{}",
+                        .{self.toUnixMilli()},
+                    ),
+                    .X => try writer.print(
+                        "{}",
+                        .{self.toUnix()},
+                    ),
                 }
                 next = null;
                 s = i;
@@ -345,11 +571,19 @@ pub const DateTime = struct {
         }
     }
 
-    pub fn formatAlloc(self: Self, alloc: std.mem.Allocator, comptime fmt: string) !string {
+    pub fn formatAlloc(
+        self: Self,
+        alloc: std.mem.Allocator,
+        comptime fmt: string,
+    ) !string {
         var list = std.ArrayList(u8).init(alloc);
         defer list.deinit();
 
-        try self.format(fmt, .{}, list.writer());
+        try self.format(
+            fmt,
+            .{},
+            list.writer(),
+        );
         return list.toOwnedSlice();
     }
 
@@ -405,7 +639,10 @@ pub const DateTime = struct {
         X, // unix
     };
 
-    pub fn since(self: Self, other_in_the_past: Self) Duration {
+    pub fn since(
+        self: Self,
+        other_in_the_past: Self,
+    ) Duration {
         return Duration{
             .ms = self.toUnixMilli() - other_in_the_past.toUnixMilli(),
         };
@@ -468,15 +705,24 @@ pub fn daysInYear(year: u16) u16 {
     return if (isLeapYear(year)) 366 else 365;
 }
 
-fn daysInMonth(year: u16, month: u16) u16 {
+fn daysInMonth(
+    year: u16,
+    month: u16,
+) u16 {
     const norm = [12]u16{ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
     const leap = [12]u16{ 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
     const month_days = if (!isLeapYear(year)) norm else leap;
     return month_days[month];
 }
 
-fn printOrdinal(writer: anytype, num: u16) !void {
-    try writer.print("{}", .{num});
+fn printOrdinal(
+    writer: anytype,
+    num: u16,
+) !void {
+    try writer.print(
+        "{}",
+        .{num},
+    );
     try writer.writeAll(switch (num) {
         1 => "st",
         2 => "nd",
@@ -485,11 +731,18 @@ fn printOrdinal(writer: anytype, num: u16) !void {
     });
 }
 
-fn printLongName(writer: anytype, index: u16, names: []const string) !void {
+fn printLongName(
+    writer: anytype,
+    index: u16,
+    names: []const string,
+) !void {
     try writer.writeAll(names[index]);
 }
 
-fn wrap(val: u16, at: u16) u16 {
+fn wrap(
+    val: u16,
+    at: u16,
+) u16 {
     var tmp = val % at;
     return if (tmp == 0) at else tmp;
 }
@@ -507,8 +760,15 @@ test "time format" {
     var allocator = std.testing.allocator;
     const utc_format = "YYYY-MM-DDTHH:mm:ss";
     const dt = DateTime.initUnix(1697696484);
-    const formatted_dt = try dt.formatAlloc(allocator, utc_format);
+    const formatted_dt = try dt.formatAlloc(
+        allocator,
+        utc_format,
+    );
     defer allocator.free(formatted_dt); // Free the memory allocated by the allocator.
     const expected_formatted_dt = "2023-10-19T06:21:24";
-    try expect(std.mem.eql(u8, formatted_dt, expected_formatted_dt));
+    try expect(std.mem.eql(
+        u8,
+        formatted_dt,
+        expected_formatted_dt,
+    ));
 }

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -68,7 +68,10 @@ pub const CairoVM = struct {
     pub fn step(self: *CairoVM) !void {
         // TODO: Run hints.
 
-        std.log.debug("Running instruction at pc: {}", .{self.run_context.pc.*});
+        std.log.debug(
+            "Running instruction at pc: {}",
+            .{self.run_context.pc.*},
+        );
 
         // ************************************************************
         // *                    FETCH                                 *
@@ -101,7 +104,10 @@ pub const CairoVM = struct {
     /// Run a specific instruction.
     // # Arguments
     /// - `instruction`: The instruction to run.
-    pub fn runInstruction(self: *CairoVM, instruction: *const instructions.Instruction) !void {
+    pub fn runInstruction(
+        self: *CairoVM,
+        instruction: *const instructions.Instruction,
+    ) !void {
         const operands_result = try self.computeOperands(instruction);
         _ = operands_result;
     }
@@ -111,7 +117,10 @@ pub const CairoVM = struct {
     /// - `instruction`: The instruction to compute the operands for.
     /// # Returns
     /// - `Operands`: The operands for the instruction.
-    pub fn computeOperands(self: *CairoVM, instruction: *const instructions.Instruction) !OperandsResult {
+    pub fn computeOperands(
+        self: *CairoVM,
+        instruction: *const instructions.Instruction,
+    ) !OperandsResult {
         // Compute the destination address and get value from the memory.
         const dst_addr = try self.run_context.compute_dst_addr(instruction);
         const dst = try self.segments.memory.get(dst_addr);
@@ -123,7 +132,10 @@ pub const CairoVM = struct {
         const op_0_op = self.segments.memory.get(op_0_addr) catch null;
 
         // Compute the OP 1 address and get value from the memory.
-        const op_1_addr = try self.run_context.compute_op_1_addr(instruction, op_0_op);
+        const op_1_addr = try self.run_context.compute_op_1_addr(
+            instruction,
+            op_0_op,
+        );
         const op_1_op = try self.segments.memory.get(op_1_addr);
         _ = op_1_op;
 
@@ -147,7 +159,13 @@ pub const CairoVM = struct {
     /// - `instruction`: The instruction to deduce the operand for.
     /// - `dst`: The destination.
     /// - `op1`: The op1.
-    pub fn computeOp0Deductions(self: *CairoVM, op_0_addr: relocatable.MaybeRelocatable, instruction: *const instructions.Instruction, dst: ?relocatable.MaybeRelocatable, op1: ?relocatable.MaybeRelocatable) void {
+    pub fn computeOp0Deductions(
+        self: *CairoVM,
+        op_0_addr: relocatable.MaybeRelocatable,
+        instruction: *const instructions.Instruction,
+        dst: ?relocatable.MaybeRelocatable,
+        op1: ?relocatable.MaybeRelocatable,
+    ) void {
         _ = op1;
         _ = dst;
         _ = instruction;
@@ -162,7 +180,10 @@ pub const CairoVM = struct {
     /// # Returns
     /// - `MaybeRelocatable`: The deduced value.
     /// TODO: Implement this.
-    pub fn deduceMemoryCell(self: *CairoVM, address: relocatable.Relocatable) !?relocatable.MaybeRelocatable {
+    pub fn deduceMemoryCell(
+        self: *CairoVM,
+        address: relocatable.Relocatable,
+    ) !?relocatable.MaybeRelocatable {
         _ = address;
         _ = self;
         return null;
@@ -172,7 +193,11 @@ pub const CairoVM = struct {
     /// # Arguments
     /// - `instruction`: The instruction that was executed.
     /// - `operands`: The operands of the instruction.
-    pub fn updatePc(self: *CairoVM, instruction: *const instructions.Instruction, operands: OperandsResult) !void {
+    pub fn updatePc(
+        self: *CairoVM,
+        instruction: *const instructions.Instruction,
+        operands: OperandsResult,
+    ) !void {
         switch (instruction.pc_update) {
             // ************************************************************
             // *                PC UPDATE REGULAR                         *
@@ -230,7 +255,11 @@ pub const CairoVM = struct {
     /// # Arguments
     /// - `instruction`: The instruction that was executed.
     /// - `operands`: The operands of the instruction.
-    pub fn updateAp(self: *CairoVM, instruction: *const instructions.Instruction, operands: OperandsResult) !void {
+    pub fn updateAp(
+        self: *CairoVM,
+        instruction: *const instructions.Instruction,
+        operands: OperandsResult,
+    ) !void {
         switch (instruction.ap_update) {
             // *********************************************************
             // *                      AP UPDATE ADD                    *
@@ -263,7 +292,11 @@ pub const CairoVM = struct {
     /// # Arguments
     /// - `instruction`: The instruction that was executed.
     /// - `operands`: The operands of the instruction.
-    pub fn updateFp(self: *CairoVM, instruction: *const instructions.Instruction, operands: OperandsResult) !void {
+    pub fn updateFp(
+        self: *CairoVM,
+        instruction: *const instructions.Instruction,
+        operands: OperandsResult,
+    ) !void {
         switch (instruction.fp_update) {
             // *********************************************************
             // *                FP UPDATE AP PLUS 2                    *
@@ -379,13 +412,19 @@ test "update pc regular no imm" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try vm.updatePc(&instruction, operands);
+    try vm.updatePc(
+        &instruction,
+        operands,
+    );
 
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
     const pc = vm.getPc();
-    try expectEqual(pc.offset, 1);
+    try expectEqual(
+        pc.offset,
+        1,
+    );
 }
 
 test "update pc regular with imm" {
@@ -406,13 +445,19 @@ test "update pc regular with imm" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try vm.updatePc(&instruction, operands);
+    try vm.updatePc(
+        &instruction,
+        operands,
+    );
 
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
     const pc = vm.getPc();
-    try expectEqual(pc.offset, 2);
+    try expectEqual(
+        pc.offset,
+        2,
+    );
 }
 
 test "update pc jump with operands res null" {
@@ -433,7 +478,10 @@ test "update pc jump with operands res null" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try expectError(error.ResUnconstrainedUsedWithPcUpdateJump, vm.updatePc(&instruction, operands));
+    try expectError(error.ResUnconstrainedUsedWithPcUpdateJump, vm.updatePc(
+        &instruction,
+        operands,
+    ));
 }
 
 test "update pc jump with operands res not relocatable" {
@@ -454,7 +502,10 @@ test "update pc jump with operands res not relocatable" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try expectError(error.PcUpdateJumpResNotRelocatable, vm.updatePc(&instruction, operands));
+    try expectError(error.PcUpdateJumpResNotRelocatable, vm.updatePc(
+        &instruction,
+        operands,
+    ));
 }
 
 test "update pc jump with operands res relocatable" {
@@ -467,7 +518,10 @@ test "update pc jump with operands res relocatable" {
     var instruction = instructions.Instruction.default();
     instruction.pc_update = instructions.PcUpdate.Jump;
     var operands = OperandsResult.default();
-    operands.res = relocatable.newFromRelocatable(relocatable.Relocatable.new(0, 42));
+    operands.res = relocatable.newFromRelocatable(relocatable.Relocatable.new(
+        0,
+        42,
+    ));
     // Create a new VM instance.
     var vm = try CairoVM.init(&allocator);
     defer vm.deinit();
@@ -475,13 +529,19 @@ test "update pc jump with operands res relocatable" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try vm.updatePc(&instruction, operands);
+    try vm.updatePc(
+        &instruction,
+        operands,
+    );
 
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
     const pc = vm.getPc();
-    try expectEqual(pc.offset, 42);
+    try expectEqual(
+        pc.offset,
+        42,
+    );
 }
 
 test "update pc jump rel with operands res null" {
@@ -502,7 +562,10 @@ test "update pc jump rel with operands res null" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try expectError(error.ResUnconstrainedUsedWithPcUpdateJumpRel, vm.updatePc(&instruction, operands));
+    try expectError(error.ResUnconstrainedUsedWithPcUpdateJumpRel, vm.updatePc(
+        &instruction,
+        operands,
+    ));
 }
 
 test "update pc jump rel with operands res not felt" {
@@ -515,7 +578,10 @@ test "update pc jump rel with operands res not felt" {
     var instruction = instructions.Instruction.default();
     instruction.pc_update = instructions.PcUpdate.JumpRel;
     var operands = OperandsResult.default();
-    operands.res = relocatable.newFromRelocatable(relocatable.Relocatable.new(0, 42));
+    operands.res = relocatable.newFromRelocatable(relocatable.Relocatable.new(
+        0,
+        42,
+    ));
     // Create a new VM instance.
     var vm = try CairoVM.init(&allocator);
     defer vm.deinit();
@@ -523,7 +589,10 @@ test "update pc jump rel with operands res not felt" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try expectError(error.PcUpdateJumpRelResNotFelt, vm.updatePc(&instruction, operands));
+    try expectError(error.PcUpdateJumpRelResNotFelt, vm.updatePc(
+        &instruction,
+        operands,
+    ));
 }
 
 test "update pc jump rel with operands res felt" {
@@ -544,13 +613,19 @@ test "update pc jump rel with operands res felt" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try vm.updatePc(&instruction, operands);
+    try vm.updatePc(
+        &instruction,
+        operands,
+    );
 
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
     const pc = vm.getPc();
-    try expectEqual(pc.offset, 42);
+    try expectEqual(
+        pc.offset,
+        42,
+    );
 }
 
 test "update pc update jnz with operands dst zero" {
@@ -571,13 +646,19 @@ test "update pc update jnz with operands dst zero" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try vm.updatePc(&instruction, operands);
+    try vm.updatePc(
+        &instruction,
+        operands,
+    );
 
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
     const pc = vm.getPc();
-    try expectEqual(pc.offset, 2);
+    try expectEqual(
+        pc.offset,
+        2,
+    );
 }
 
 test "update pc update jnz with operands dst not zero op1 not felt" {
@@ -591,7 +672,10 @@ test "update pc update jnz with operands dst not zero op1 not felt" {
     instruction.pc_update = instructions.PcUpdate.Jnz;
     var operands = OperandsResult.default();
     operands.dst = relocatable.fromU64(1);
-    operands.op_1 = relocatable.newFromRelocatable(relocatable.Relocatable.new(0, 42));
+    operands.op_1 = relocatable.newFromRelocatable(relocatable.Relocatable.new(
+        0,
+        42,
+    ));
     // Create a new VM instance.
     var vm = try CairoVM.init(&allocator);
     defer vm.deinit();
@@ -599,7 +683,10 @@ test "update pc update jnz with operands dst not zero op1 not felt" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try expectError(error.TypeMismatchNotFelt, vm.updatePc(&instruction, operands));
+    try expectError(error.TypeMismatchNotFelt, vm.updatePc(
+        &instruction,
+        operands,
+    ));
 }
 
 test "update pc update jnz with operands dst not zero op1 felt" {
@@ -621,13 +708,19 @@ test "update pc update jnz with operands dst not zero op1 felt" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try vm.updatePc(&instruction, operands);
+    try vm.updatePc(
+        &instruction,
+        operands,
+    );
 
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
     const pc = vm.getPc();
-    try expectEqual(pc.offset, 42);
+    try expectEqual(
+        pc.offset,
+        42,
+    );
 }
 
 test "update ap add with operands res unconstrained" {
@@ -647,7 +740,10 @@ test "update ap add with operands res unconstrained" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try expectError(error.ApUpdateAddResUnconstrained, vm.updateAp(&instruction, operands));
+    try expectError(error.ApUpdateAddResUnconstrained, vm.updateAp(
+        &instruction,
+        operands,
+    ));
 }
 
 test "update ap add1" {
@@ -666,14 +762,20 @@ test "update ap add1" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try vm.updateAp(&instruction, operands);
+    try vm.updateAp(
+        &instruction,
+        operands,
+    );
 
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
     // Verify the AP offset was incremented by 1.
     const ap = vm.getAp();
-    try expectEqual(ap.offset, 1);
+    try expectEqual(
+        ap.offset,
+        1,
+    );
 }
 
 test "update ap add2" {
@@ -692,14 +794,20 @@ test "update ap add2" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try vm.updateAp(&instruction, operands);
+    try vm.updateAp(
+        &instruction,
+        operands,
+    );
 
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
     // Verify the AP offset was incremented by 2.
     const ap = vm.getAp();
-    try expectEqual(ap.offset, 2);
+    try expectEqual(
+        ap.offset,
+        2,
+    );
 }
 
 test "update fp appplus2" {
@@ -718,14 +826,20 @@ test "update fp appplus2" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try vm.updateFp(&instruction, operands);
+    try vm.updateFp(
+        &instruction,
+        operands,
+    );
 
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
     // Verify the FP offset was incremented by 2.
     const fp = vm.getFp();
-    try expectEqual(fp.offset, 2);
+    try expectEqual(
+        fp.offset,
+        2,
+    );
 }
 
 test "update fp dst relocatable" {
@@ -737,7 +851,10 @@ test "update fp dst relocatable" {
     var instruction = instructions.Instruction.default();
     instruction.fp_update = instructions.FpUpdate.Dst;
     var operands = OperandsResult.default();
-    operands.dst = relocatable.newFromRelocatable(relocatable.Relocatable.new(0, 42));
+    operands.dst = relocatable.newFromRelocatable(relocatable.Relocatable.new(
+        0,
+        42,
+    ));
     // Create a new VM instance.
     var vm = try CairoVM.init(&allocator);
     defer vm.deinit();
@@ -745,14 +862,20 @@ test "update fp dst relocatable" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try vm.updateFp(&instruction, operands);
+    try vm.updateFp(
+        &instruction,
+        operands,
+    );
 
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
     // Verify the FP offset was incremented by 2.
     const fp = vm.getFp();
-    try expectEqual(fp.offset, 42);
+    try expectEqual(
+        fp.offset,
+        42,
+    );
 }
 
 test "update fp dst felt" {
@@ -772,12 +895,18 @@ test "update fp dst felt" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try vm.updateFp(&instruction, operands);
+    try vm.updateFp(
+        &instruction,
+        operands,
+    );
 
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
     // Verify the FP offset was incremented by 2.
     const fp = vm.getFp();
-    try expectEqual(fp.offset, 42);
+    try expectEqual(
+        fp.offset,
+        42,
+    );
 }

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -683,10 +683,13 @@ test "update pc update jnz with operands dst not zero op1 not felt" {
     // ************************************************************
     // *                      TEST BODY                           *
     // ************************************************************
-    try expectError(error.TypeMismatchNotFelt, vm.updatePc(
-        &instruction,
-        operands,
-    ));
+    try expectError(
+        error.TypeMismatchNotFelt,
+        vm.updatePc(
+            &instruction,
+            operands,
+        ),
+    );
 }
 
 test "update pc update jnz with operands dst not zero op1 felt" {

--- a/src/vm/instructions.zig
+++ b/src/vm/instructions.zig
@@ -91,23 +91,69 @@ pub const Instruction = struct {
 /// Decoded Instruction struct, or an error if decoding fails
 pub fn decode(encoded_instruction: u64) Error!Instruction {
     if (encoded_instruction & (1 << 63) != 0) return Error.NonZeroHighBit;
-    const flags = @as(u16, @truncate(encoded_instruction >> 48));
-    const offsets = @as(u48, @truncate(encoded_instruction));
-    const parsedNum = @as(u8, @truncate((flags >> 12) & 7));
+    const flags = @as(
+        u16,
+        @truncate(encoded_instruction >> 48),
+    );
+    const offsets = @as(
+        u48,
+        @truncate(encoded_instruction),
+    );
+    const parsedNum = @as(
+        u8,
+        @truncate((flags >> 12) & 7),
+    );
     const opcode = try parseOpcode(parsedNum);
 
-    const pc_update = try parsePcUpdate(@as(u8, @truncate((flags >> 7) & 7)));
+    const pc_update = try parsePcUpdate(
+        @as(
+            u8,
+            @truncate((flags >> 7) & 7),
+        ),
+    );
 
     return Instruction{
-        .off_0 = fromBiasedRepresentation(@as(u16, @truncate(offsets))),
-        .off_1 = fromBiasedRepresentation(@as(u16, @truncate(offsets >> 16))),
-        .off_2 = fromBiasedRepresentation(@as(u16, @truncate(offsets >> 32))),
+        .off_0 = fromBiasedRepresentation(
+            @as(
+                u16,
+                @truncate(offsets),
+            ),
+        ),
+        .off_1 = fromBiasedRepresentation(
+            @as(
+                u16,
+                @truncate(offsets >> 16),
+            ),
+        ),
+        .off_2 = fromBiasedRepresentation(
+            @as(
+                u16,
+                @truncate(offsets >> 32),
+            ),
+        ),
         .dst_reg = if (flags & 1 != 0) Register.FP else Register.AP,
         .op_0_reg = if (flags & 2 != 0) Register.FP else Register.AP,
-        .op_1_addr = try parseOp1Src(@as(u8, @truncate((flags >> 2) & 7))),
-        .res_logic = try parseResLogic(@as(u8, @truncate((flags >> 5) & 3)), pc_update),
+        .op_1_addr = try parseOp1Src(
+            @as(
+                u8,
+                @truncate((flags >> 2) & 7),
+            ),
+        ),
+        .res_logic = try parseResLogic(
+            @as(
+                u8,
+                @truncate((flags >> 5) & 3),
+            ),
+            pc_update,
+        ),
         .pc_update = pc_update,
-        .ap_update = try parseApUpdate(@as(u8, @truncate((flags >> 10) & 3)), opcode),
+        .ap_update = try parseApUpdate(
+            @as(
+                u8,
+                @truncate((flags >> 10) & 3),
+            ),
+            opcode,
+        ),
         .opcode = opcode,
         .fp_update = parseFpUpdate(opcode),
     };
@@ -149,7 +195,10 @@ fn parseOp1Src(op1_src_num: u8) Error!Op1Src {
 /// - pc_update: pc_update value of the current instruction
 /// # Returns
 /// Parsed res_logic value, or an error if invalid
-fn parseResLogic(res_logic_num: u8, pc_update: PcUpdate) Error!ResLogic {
+fn parseResLogic(
+    res_logic_num: u8,
+    pc_update: PcUpdate,
+) Error!ResLogic {
     return switch (res_logic_num) {
         0 => {
             if (pc_update == PcUpdate.Jnz) {
@@ -185,7 +234,10 @@ fn parsePcUpdate(pc_update_num: u8) Error!PcUpdate {
 /// - opcode: Opcode of the current instruction
 /// # Returns
 /// Parsed ap_update value, or an error if invalid
-fn parseApUpdate(ap_update_num: u8, opcode: Opcode) Error!ApUpdate {
+fn parseApUpdate(
+    ap_update_num: u8,
+    opcode: Opcode,
+) Error!ApUpdate {
     return switch (ap_update_num) {
         0 => if (opcode == Opcode.Call) {
             return ApUpdate.Add2;
@@ -217,8 +269,14 @@ fn parseFpUpdate(opcode: Opcode) FpUpdate {
 /// # Returns
 /// 16-bit signed integer
 pub fn fromBiasedRepresentation(biased_repr: u16) i16 {
-    const as_i32 = @as(i32, @intCast(biased_repr));
-    return @as(i16, @intCast(as_i32 - 32768));
+    const as_i32 = @as(
+        i32,
+        @intCast(biased_repr),
+    );
+    return @as(
+        i16,
+        @intCast(as_i32 - 32768),
+    );
 }
 
 // ************************************************************
@@ -238,14 +296,38 @@ test "decode flags call add jmp add imm fp fp" {
     const encoded_instruction: u64 = 0x14A7800080008000;
     const decoded_instruction = try decode(encoded_instruction);
 
-    try expectEqual(Register.FP, decoded_instruction.dst_reg);
-    try expectEqual(Register.FP, decoded_instruction.op_0_reg);
-    try expectEqual(Op1Src.Imm, decoded_instruction.op_1_addr);
-    try expectEqual(ResLogic.Add, decoded_instruction.res_logic);
-    try expectEqual(PcUpdate.Jump, decoded_instruction.pc_update);
-    try expectEqual(ApUpdate.Add, decoded_instruction.ap_update);
-    try expectEqual(Opcode.Call, decoded_instruction.opcode);
-    try expectEqual(FpUpdate.APPlus2, decoded_instruction.fp_update);
+    try expectEqual(
+        Register.FP,
+        decoded_instruction.dst_reg,
+    );
+    try expectEqual(
+        Register.FP,
+        decoded_instruction.op_0_reg,
+    );
+    try expectEqual(
+        Op1Src.Imm,
+        decoded_instruction.op_1_addr,
+    );
+    try expectEqual(
+        ResLogic.Add,
+        decoded_instruction.res_logic,
+    );
+    try expectEqual(
+        PcUpdate.Jump,
+        decoded_instruction.pc_update,
+    );
+    try expectEqual(
+        ApUpdate.Add,
+        decoded_instruction.ap_update,
+    );
+    try expectEqual(
+        Opcode.Call,
+        decoded_instruction.opcode,
+    );
+    try expectEqual(
+        FpUpdate.APPlus2,
+        decoded_instruction.fp_update,
+    );
 }
 
 test "decode flags ret add1 jmp rel mul fp ap ap" {
@@ -260,14 +342,38 @@ test "decode flags ret add1 jmp rel mul fp ap ap" {
     const encoded_instruction: u64 = 0x2948800080008000;
     const decoded_instruction = try decode(encoded_instruction);
 
-    try expectEqual(Register.AP, decoded_instruction.dst_reg);
-    try expectEqual(Register.AP, decoded_instruction.op_0_reg);
-    try expectEqual(Op1Src.FP, decoded_instruction.op_1_addr);
-    try expectEqual(ResLogic.Mul, decoded_instruction.res_logic);
-    try expectEqual(PcUpdate.JumpRel, decoded_instruction.pc_update);
-    try expectEqual(ApUpdate.Add1, decoded_instruction.ap_update);
-    try expectEqual(Opcode.Ret, decoded_instruction.opcode);
-    try expectEqual(FpUpdate.Dst, decoded_instruction.fp_update);
+    try expectEqual(
+        Register.AP,
+        decoded_instruction.dst_reg,
+    );
+    try expectEqual(
+        Register.AP,
+        decoded_instruction.op_0_reg,
+    );
+    try expectEqual(
+        Op1Src.FP,
+        decoded_instruction.op_1_addr,
+    );
+    try expectEqual(
+        ResLogic.Mul,
+        decoded_instruction.res_logic,
+    );
+    try expectEqual(
+        PcUpdate.JumpRel,
+        decoded_instruction.pc_update,
+    );
+    try expectEqual(
+        ApUpdate.Add1,
+        decoded_instruction.ap_update,
+    );
+    try expectEqual(
+        Opcode.Ret,
+        decoded_instruction.opcode,
+    );
+    try expectEqual(
+        FpUpdate.Dst,
+        decoded_instruction.fp_update,
+    );
 }
 
 test "decode flags assert add jnz mul ap ap ap" {
@@ -280,14 +386,38 @@ test "decode flags assert add jnz mul ap ap ap" {
     const encoded_instruction: u64 = 0x4A50800080008000;
     const decoded_instruction = try decode(encoded_instruction);
 
-    try expectEqual(Register.AP, decoded_instruction.dst_reg);
-    try expectEqual(Register.AP, decoded_instruction.op_0_reg);
-    try expectEqual(Op1Src.AP, decoded_instruction.op_1_addr);
-    try expectEqual(ResLogic.Mul, decoded_instruction.res_logic);
-    try expectEqual(PcUpdate.Jnz, decoded_instruction.pc_update);
-    try expectEqual(ApUpdate.Add1, decoded_instruction.ap_update);
-    try expectEqual(Opcode.AssertEq, decoded_instruction.opcode);
-    try expectEqual(FpUpdate.Regular, decoded_instruction.fp_update);
+    try expectEqual(
+        Register.AP,
+        decoded_instruction.dst_reg,
+    );
+    try expectEqual(
+        Register.AP,
+        decoded_instruction.op_0_reg,
+    );
+    try expectEqual(
+        Op1Src.AP,
+        decoded_instruction.op_1_addr,
+    );
+    try expectEqual(
+        ResLogic.Mul,
+        decoded_instruction.res_logic,
+    );
+    try expectEqual(
+        PcUpdate.Jnz,
+        decoded_instruction.pc_update,
+    );
+    try expectEqual(
+        ApUpdate.Add1,
+        decoded_instruction.ap_update,
+    );
+    try expectEqual(
+        Opcode.AssertEq,
+        decoded_instruction.opcode,
+    );
+    try expectEqual(
+        FpUpdate.Regular,
+        decoded_instruction.fp_update,
+    );
 }
 
 test "decode flags assert add2 jnz uncon op0 ap ap" {
@@ -301,14 +431,38 @@ test "decode flags assert add2 jnz uncon op0 ap ap" {
     const encoded_instruction: u64 = 0x4200800080008000;
     const decoded_instruction = try decode(encoded_instruction);
 
-    try expectEqual(Register.AP, decoded_instruction.dst_reg);
-    try expectEqual(Register.AP, decoded_instruction.op_0_reg);
-    try expectEqual(Op1Src.Op0, decoded_instruction.op_1_addr);
-    try expectEqual(ResLogic.Unconstrained, decoded_instruction.res_logic);
-    try expectEqual(PcUpdate.Jnz, decoded_instruction.pc_update);
-    try expectEqual(ApUpdate.Regular, decoded_instruction.ap_update);
-    try expectEqual(Opcode.AssertEq, decoded_instruction.opcode);
-    try expectEqual(FpUpdate.Regular, decoded_instruction.fp_update);
+    try expectEqual(
+        Register.AP,
+        decoded_instruction.dst_reg,
+    );
+    try expectEqual(
+        Register.AP,
+        decoded_instruction.op_0_reg,
+    );
+    try expectEqual(
+        Op1Src.Op0,
+        decoded_instruction.op_1_addr,
+    );
+    try expectEqual(
+        ResLogic.Unconstrained,
+        decoded_instruction.res_logic,
+    );
+    try expectEqual(
+        PcUpdate.Jnz,
+        decoded_instruction.pc_update,
+    );
+    try expectEqual(
+        ApUpdate.Regular,
+        decoded_instruction.ap_update,
+    );
+    try expectEqual(
+        Opcode.AssertEq,
+        decoded_instruction.opcode,
+    );
+    try expectEqual(
+        FpUpdate.Regular,
+        decoded_instruction.fp_update,
+    );
 }
 
 test "decode flags nop regular regular op1 op0 ap ap" {
@@ -322,50 +476,101 @@ test "decode flags nop regular regular op1 op0 ap ap" {
     const encoded_instruction: u64 = 0x0000800080008000;
     const decoded_instruction = try decode(encoded_instruction);
 
-    try expectEqual(Register.AP, decoded_instruction.dst_reg);
-    try expectEqual(Register.AP, decoded_instruction.op_0_reg);
-    try expectEqual(Op1Src.Op0, decoded_instruction.op_1_addr);
-    try expectEqual(ResLogic.Op1, decoded_instruction.res_logic);
-    try expectEqual(PcUpdate.Regular, decoded_instruction.pc_update);
-    try expectEqual(ApUpdate.Regular, decoded_instruction.ap_update);
-    try expectEqual(Opcode.NOp, decoded_instruction.opcode);
-    try expectEqual(FpUpdate.Regular, decoded_instruction.fp_update);
+    try expectEqual(
+        Register.AP,
+        decoded_instruction.dst_reg,
+    );
+    try expectEqual(
+        Register.AP,
+        decoded_instruction.op_0_reg,
+    );
+    try expectEqual(
+        Op1Src.Op0,
+        decoded_instruction.op_1_addr,
+    );
+    try expectEqual(
+        ResLogic.Op1,
+        decoded_instruction.res_logic,
+    );
+    try expectEqual(
+        PcUpdate.Regular,
+        decoded_instruction.pc_update,
+    );
+    try expectEqual(
+        ApUpdate.Regular,
+        decoded_instruction.ap_update,
+    );
+    try expectEqual(
+        Opcode.NOp,
+        decoded_instruction.opcode,
+    );
+    try expectEqual(
+        FpUpdate.Regular,
+        decoded_instruction.fp_update,
+    );
 }
 
 test "decode offset negative" {
     const encoded_instruction: u64 = 0x0000800180007FFF;
     const decoded_instruction = try decode(encoded_instruction);
-    try expectEqual(@as(i16, -1), decoded_instruction.off_0);
-    try expectEqual(@as(i16, 0), decoded_instruction.off_1);
-    try expectEqual(@as(i16, 1), decoded_instruction.off_2);
+    try expectEqual(@as(
+        i16,
+        -1,
+    ), decoded_instruction.off_0);
+    try expectEqual(@as(
+        i16,
+        0,
+    ), decoded_instruction.off_1);
+    try expectEqual(@as(
+        i16,
+        1,
+    ), decoded_instruction.off_2);
 }
 
 test "non zero high bit" {
     const encoded_instruction: u64 = 0x94A7800080008000;
-    try expectError(Error.NonZeroHighBit, decode(encoded_instruction));
+    try expectError(
+        Error.NonZeroHighBit,
+        decode(encoded_instruction),
+    );
 }
 
 test "invalid op1 reg" {
     const encoded_instruction: u64 = 0x294F800080008000;
-    try expectError(Error.InvalidOp1Reg, decode(encoded_instruction));
+    try expectError(
+        Error.InvalidOp1Reg,
+        decode(encoded_instruction),
+    );
 }
 
 test "invalid pc update" {
     const encoded_instruction: u64 = 0x29A8800080008000;
-    try expectError(Error.Invalidpc_update, decode(encoded_instruction));
+    try expectError(
+        Error.Invalidpc_update,
+        decode(encoded_instruction),
+    );
 }
 
 test "invalid res logic" {
     const encoded_instruction: u64 = 0x2968800080008000;
-    try expectError(Error.Invalidres_logic, decode(encoded_instruction));
+    try expectError(
+        Error.Invalidres_logic,
+        decode(encoded_instruction),
+    );
 }
 
 test "invalid opcode" {
     const encoded_instruction: u64 = 0x3948800080008000;
-    try expectError(Error.InvalidOpcode, decode(encoded_instruction));
+    try expectError(
+        Error.InvalidOpcode,
+        decode(encoded_instruction),
+    );
 }
 
 test "invalid ap update" {
     const encoded_instruction: u64 = 0x2D48800080008000;
-    try expectError(Error.Invalidap_update, decode(encoded_instruction));
+    try expectError(
+        Error.Invalidap_update,
+        decode(encoded_instruction),
+    );
 }

--- a/src/vm/instructions.zig
+++ b/src/vm/instructions.zig
@@ -34,19 +34,51 @@ pub const Error = error{
 // *                      CUSTOM TYPES DEFINITIONS                              *
 // *****************************************************************************
 
-pub const Register = enum { AP, FP };
+pub const Register = enum {
+    AP,
+    FP,
+};
 
-pub const Op1Src = enum { Imm, AP, FP, Op0 };
+pub const Op1Src = enum {
+    Imm,
+    AP,
+    FP,
+    Op0,
+};
 
-pub const ResLogic = enum { Op1, Add, Mul, Unconstrained };
+pub const ResLogic = enum {
+    Op1,
+    Add,
+    Mul,
+    Unconstrained,
+};
 
-pub const PcUpdate = enum { Regular, Jump, JumpRel, Jnz };
+pub const PcUpdate = enum {
+    Regular,
+    Jump,
+    JumpRel,
+    Jnz,
+};
 
-pub const ApUpdate = enum { Regular, Add, Add1, Add2 };
+pub const ApUpdate = enum {
+    Regular,
+    Add,
+    Add1,
+    Add2,
+};
 
-pub const FpUpdate = enum { Regular, APPlus2, Dst };
+pub const FpUpdate = enum {
+    Regular,
+    APPlus2,
+    Dst,
+};
 
-pub const Opcode = enum { NOp, AssertEq, Call, Ret };
+pub const Opcode = enum {
+    NOp,
+    AssertEq,
+    Call,
+    Ret,
+};
 
 /// Represents a decoded instruction.
 pub const Instruction = struct {

--- a/src/vm/memory/memory.zig
+++ b/src/vm/memory/memory.zig
@@ -16,12 +16,22 @@ pub const Memory = struct {
     /// The allocator used to allocate the memory.
     allocator: *const Allocator,
     // The data in the memory.
-    data: std.HashMap(relocatable.Relocatable, relocatable.MaybeRelocatable, std.hash_map.AutoContext(relocatable.Relocatable), std.hash_map.default_max_load_percentage),
+    data: std.HashMap(
+        relocatable.Relocatable,
+        relocatable.MaybeRelocatable,
+        std.hash_map.AutoContext(relocatable.Relocatable),
+        std.hash_map.default_max_load_percentage,
+    ),
     // The number of segments in the memory.
     num_segments: u32,
     // Validated addresses are addresses that have been validated.
     // TODO: Consider merging this with `data` and benchmarking.
-    validated_addresses: std.HashMap(relocatable.Relocatable, bool, std.hash_map.AutoContext(relocatable.Relocatable), std.hash_map.default_max_load_percentage),
+    validated_addresses: std.HashMap(
+        relocatable.Relocatable,
+        bool,
+        std.hash_map.AutoContext(relocatable.Relocatable),
+        std.hash_map.default_max_load_percentage,
+    ),
 
     // ************************************************************
     // *             MEMORY ALLOCATION AND DEALLOCATION           *
@@ -37,9 +47,15 @@ pub const Memory = struct {
 
         memory.* = Memory{
             .allocator = allocator,
-            .data = std.AutoHashMap(relocatable.Relocatable, relocatable.MaybeRelocatable).init(allocator.*),
+            .data = std.AutoHashMap(
+                relocatable.Relocatable,
+                relocatable.MaybeRelocatable,
+            ).init(allocator.*),
             .num_segments = 0,
-            .validated_addresses = std.AutoHashMap(relocatable.Relocatable, bool).init(allocator.*),
+            .validated_addresses = std.AutoHashMap(
+                relocatable.Relocatable,
+                bool,
+            ).init(allocator.*),
         };
         return memory;
     }
@@ -61,7 +77,11 @@ pub const Memory = struct {
     // # Arguments
     // - `address` - The address to insert the value at.
     // - `value` - The value to insert.
-    pub fn set(self: *Memory, address: relocatable.Relocatable, value: relocatable.MaybeRelocatable) error{ InvalidMemoryAddress, MemoryOutOfBounds }!void {
+    pub fn set(
+        self: *Memory,
+        address: relocatable.Relocatable,
+        value: relocatable.MaybeRelocatable,
+    ) error{ InvalidMemoryAddress, MemoryOutOfBounds }!void {
 
         // Check if the address is valid.
         if (address.segment_index < 0) {
@@ -69,7 +89,10 @@ pub const Memory = struct {
         }
 
         // Insert the value into the memory.
-        self.data.put(address, value) catch {
+        self.data.put(
+            address,
+            value,
+        ) catch {
             return CairoVMError.MemoryOutOfBounds;
         };
 
@@ -81,7 +104,10 @@ pub const Memory = struct {
     // - `address` - The address to get the value from.
     // # Returns
     // The value at the given address.
-    pub fn get(self: *Memory, address: relocatable.Relocatable) error{MemoryOutOfBounds}!relocatable.MaybeRelocatable {
+    pub fn get(
+        self: *Memory,
+        address: relocatable.Relocatable,
+    ) error{MemoryOutOfBounds}!relocatable.MaybeRelocatable {
         var maybe_value = self.data.get(address);
         if (maybe_value == null) {
             return CairoVMError.MemoryOutOfBounds;
@@ -99,7 +125,10 @@ test "memory get without value raises error" {
     defer memory.deinit();
 
     // Get a value from the memory at an address that doesn't exist.
-    _ = memory.get(relocatable.Relocatable.new(0, 0)) catch |err| {
+    _ = memory.get(relocatable.Relocatable.new(
+        0,
+        0,
+    )) catch |err| {
         // Assert that the error is the expected error.
         try expect(err == error.MemoryOutOfBounds);
         return;
@@ -114,11 +143,17 @@ test "memory set and get" {
     var memory = try Memory.init(&allocator);
     defer memory.deinit();
 
-    const address_1 = relocatable.Relocatable.new(0, 0);
+    const address_1 = relocatable.Relocatable.new(
+        0,
+        0,
+    );
     const value_1 = relocatable.fromFelt(starknet_felt.Felt252.one());
 
     // Set a value into the memory.
-    _ = try memory.set(address_1, value_1);
+    _ = try memory.set(
+        address_1,
+        value_1,
+    );
 
     // Get the value from the memory.
     const maybe_value_1 = try memory.get(address_1);

--- a/src/vm/memory/memory.zig
+++ b/src/vm/memory/memory.zig
@@ -81,7 +81,10 @@ pub const Memory = struct {
         self: *Memory,
         address: relocatable.Relocatable,
         value: relocatable.MaybeRelocatable,
-    ) error{ InvalidMemoryAddress, MemoryOutOfBounds }!void {
+    ) error{
+        InvalidMemoryAddress,
+        MemoryOutOfBounds,
+    }!void {
 
         // Check if the address is valid.
         if (address.segment_index < 0) {

--- a/src/vm/memory/relocatable.zig
+++ b/src/vm/memory/relocatable.zig
@@ -195,7 +195,10 @@ pub const MaybeRelocatable = union(enum) {
     /// Return the value of the MaybeRelocatable as a felt or error.
     /// # Returns
     /// The value of the MaybeRelocatable as a Relocatable felt or error.
-    pub fn tryIntoU64(self: MaybeRelocatable) error{ TypeMismatchNotFelt, ValueTooLarge }!u64 {
+    pub fn tryIntoU64(self: MaybeRelocatable) error{
+        TypeMismatchNotFelt,
+        ValueTooLarge,
+    }!u64 {
         return switch (self) {
             .relocatable => CairoVMError.TypeMismatchNotFelt,
             .felt => |felt| felt.tryIntoU64(),

--- a/src/vm/memory/relocatable.zig
+++ b/src/vm/memory/relocatable.zig
@@ -28,7 +28,10 @@ pub const Relocatable = struct {
     // - offset - The offset in the memory segment.
     // # Returns
     // A new Relocatable.
-    pub fn new(segment_index: u64, offset: u64) Relocatable {
+    pub fn new(
+        segment_index: u64,
+        offset: u64,
+    ) Relocatable {
         return Relocatable{
             .segment_index = segment_index,
             .offset = offset,
@@ -40,7 +43,10 @@ pub const Relocatable = struct {
     // - other: The other Relocatable to compare to.
     // # Returns
     // `true` if they are equal, `false` otherwise.
-    pub fn eq(self: Relocatable, other: Relocatable) bool {
+    pub fn eq(
+        self: Relocatable,
+        other: Relocatable,
+    ) bool {
         return self.segment_index == other.segment_index and self.offset == other.offset;
     }
 
@@ -49,7 +55,10 @@ pub const Relocatable = struct {
     // - other: The u64 to substract.
     // # Returns
     // A new Relocatable.
-    pub fn subUint(self: Relocatable, other: u64) !Relocatable {
+    pub fn subUint(
+        self: Relocatable,
+        other: u64,
+    ) !Relocatable {
         if (self.offset < other) {
             return error.RelocatableSubUsizeNegOffset;
         }
@@ -64,7 +73,10 @@ pub const Relocatable = struct {
     // - other: The u64 to add.
     // # Returns
     // A new Relocatable.
-    pub fn addUint(self: Relocatable, other: u64) !Relocatable {
+    pub fn addUint(
+        self: Relocatable,
+        other: u64,
+    ) !Relocatable {
         return Relocatable{
             .segment_index = self.segment_index,
             .offset = self.offset + other,
@@ -75,7 +87,10 @@ pub const Relocatable = struct {
     /// # Arguments
     /// - self: Pointer to the Relocatable object to modify.
     /// - other: The u64 to add to `self.offset`.
-    pub fn addUintInPlace(self: *Relocatable, other: u64) void {
+    pub fn addUintInPlace(
+        self: *Relocatable,
+        other: u64,
+    ) void {
         // Modify the offset of the existing Relocatable object
         self.offset += other;
     }
@@ -85,19 +100,32 @@ pub const Relocatable = struct {
     // - other: The i64 to add.
     // # Returns
     // A new Relocatable.
-    pub fn addInt(self: Relocatable, other: i64) !Relocatable {
+    pub fn addInt(
+        self: Relocatable,
+        other: i64,
+    ) !Relocatable {
         if (other < 0) {
-            return self.subUint(@as(u64, @intCast(-other)));
+            return self.subUint(@as(u64, @intCast(
+                -other,
+            )));
         }
-        return self.addUint(@as(u64, @intCast(other)));
+        return self.addUint(@as(u64, @intCast(
+            other,
+        )));
     }
 
     /// Add a felt to this Relocatable, modifying it in place.
     /// # Arguments
     /// - self: Pointer to the Relocatable object to modify.
     /// - other: The felt to add to `self.offset`.
-    pub fn addFeltInPlace(self: *Relocatable, other: Felt252) !void {
-        const new_offset_felt = Felt252.fromInteger(@as(u256, self.offset)).add(other);
+    pub fn addFeltInPlace(
+        self: *Relocatable,
+        other: Felt252,
+    ) !void {
+        const new_offset_felt = Felt252.fromInteger(@as(
+            u256,
+            self.offset,
+        )).add(other);
         const new_offset = try new_offset_felt.tryIntoU64();
         self.offset = new_offset;
     }
@@ -105,7 +133,10 @@ pub const Relocatable = struct {
     /// Performs additions if other contains a Felt value, fails otherwise.
     /// # Arguments
     /// - other - The other MaybeRelocatable to add.
-    pub fn addMaybeRelocatableInplace(self: *Relocatable, other: MaybeRelocatable) !void {
+    pub fn addMaybeRelocatableInplace(
+        self: *Relocatable,
+        other: MaybeRelocatable,
+    ) !void {
         const other_as_felt = try other.tryIntoFelt();
         try self.addFeltInPlace(other_as_felt);
     }
@@ -128,7 +159,10 @@ pub const MaybeRelocatable = union(enum) {
     /// ## Returns:
     ///   * `true` if the two instances are equal.
     ///   * `false` otherwise.
-    pub fn eq(self: MaybeRelocatable, other: MaybeRelocatable) bool {
+    pub fn eq(
+        self: MaybeRelocatable,
+        other: MaybeRelocatable,
+    ) bool {
         // Switch on the type of `self`
         return switch (self) {
             // If `self` is of type `relocatable`
@@ -222,7 +256,10 @@ pub fn fromU256(value: u256) MaybeRelocatable {
 // # Returns
 // A new MaybeRelocatable.
 pub fn fromU64(value: u64) MaybeRelocatable {
-    return fromU256(@as(u256, value));
+    return fromU256(@as(
+        u256,
+        value,
+    ));
 }
 
 // ************************************************************
@@ -233,35 +270,77 @@ const expectEqual = std.testing.expectEqual;
 const expectError = std.testing.expectError;
 
 test "add uint" {
-    const relocatable = Relocatable.new(2, 4);
+    const relocatable = Relocatable.new(
+        2,
+        4,
+    );
     const result = relocatable.addUint(24);
-    const expected = Relocatable.new(2, 28);
-    try expectEqual(result, expected);
+    const expected = Relocatable.new(
+        2,
+        28,
+    );
+    try expectEqual(
+        result,
+        expected,
+    );
 }
 
 test "add int" {
-    const relocatable = Relocatable.new(2, 4);
+    const relocatable = Relocatable.new(
+        2,
+        4,
+    );
     const result = relocatable.addInt(24);
-    const expected = Relocatable.new(2, 28);
-    try expectEqual(result, expected);
+    const expected = Relocatable.new(
+        2,
+        28,
+    );
+    try expectEqual(
+        result,
+        expected,
+    );
 }
 
 test "add int negative" {
-    const relocatable = Relocatable.new(2, 4);
+    const relocatable = Relocatable.new(
+        2,
+        4,
+    );
     const result = relocatable.addInt(-4);
-    const expected = Relocatable.new(2, 0);
-    try expectEqual(result, expected);
+    const expected = Relocatable.new(
+        2,
+        0,
+    );
+    try expectEqual(
+        result,
+        expected,
+    );
 }
 
 test "sub uint" {
-    const relocatable = Relocatable.new(2, 4);
+    const relocatable = Relocatable.new(
+        2,
+        4,
+    );
     const result = relocatable.subUint(2);
-    const expected = Relocatable.new(2, 2);
-    try expectEqual(result, expected);
+    const expected = Relocatable.new(
+        2,
+        2,
+    );
+    try expectEqual(
+        result,
+        expected,
+    );
 }
 
 test "sub uint negative" {
-    const relocatable = Relocatable.new(2, 4);
+    const relocatable = Relocatable.new(
+        2,
+        4,
+    );
     const result = relocatable.subUint(6);
-    try expectError(error.RelocatableSubUsizeNegOffset, result);
+    try expectError(
+        error.RelocatableSubUsizeNegOffset,
+        result,
+    );
 }

--- a/src/vm/memory/segments.zig
+++ b/src/vm/memory/segments.zig
@@ -66,7 +66,7 @@ pub const MemorySegmentManager = struct {
             ).init(allocator.*),
             // Initialize the memory pointer.
             .memory = try Memory.init(allocator),
-            .public_memory_offsets = std.AutoHashMap,
+            .public_memory_offsets = std.AutoHashMap(u32, u32).init(allocator.*),
         };
         // Return the pointer to the MemorySegmentManager.
         return segment_manager;

--- a/src/vm/memory/segments.zig
+++ b/src/vm/memory/segments.zig
@@ -17,14 +17,29 @@ pub const MemorySegmentManager = struct {
     /// The allocator used to allocate the memory.
     allocator: *const Allocator,
     // The size of the used segments.
-    segment_used_sizes: std.HashMap(u32, u32, std.hash_map.AutoContext(u32), std.hash_map.default_max_load_percentage),
+    segment_used_sizes: std.HashMap(
+        u32,
+        u32,
+        std.hash_map.AutoContext(u32),
+        std.hash_map.default_max_load_percentage,
+    ),
     // The size of the segments.
-    segment_sizes: std.HashMap(u32, u32, std.hash_map.AutoContext(u32), std.hash_map.default_max_load_percentage),
+    segment_sizes: std.HashMap(
+        u32,
+        u32,
+        std.hash_map.AutoContext(u32),
+        std.hash_map.default_max_load_percentage,
+    ),
     // The memory.
     memory: *Memory,
     // The public memory offsets.
     // TODO: Use correct type for this.
-    public_memory_offsets: std.HashMap(u32, u32, std.hash_map.AutoContext(u32), std.hash_map.default_max_load_percentage),
+    public_memory_offsets: std.HashMap(
+        u32,
+        u32,
+        std.hash_map.AutoContext(u32),
+        std.hash_map.default_max_load_percentage,
+    ),
 
     // ************************************************************
     // *             MEMORY ALLOCATION AND DEALLOCATION           *
@@ -41,11 +56,17 @@ pub const MemorySegmentManager = struct {
         // Initialize the values of the MemorySegmentManager struct.
         segment_manager.* = MemorySegmentManager{
             .allocator = allocator,
-            .segment_used_sizes = std.AutoHashMap(u32, u32).init(allocator.*),
-            .segment_sizes = std.AutoHashMap(u32, u32).init(allocator.*),
+            .segment_used_sizes = std.AutoHashMap(
+                u32,
+                u32,
+            ).init(allocator.*),
+            .segment_sizes = std.AutoHashMap(
+                u32,
+                u32,
+            ).init(allocator.*),
             // Initialize the memory pointer.
             .memory = try Memory.init(allocator),
-            .public_memory_offsets = std.AutoHashMap(u32, u32).init(allocator.*),
+            .public_memory_offsets = std.AutoHashMap,
         };
         // Return the pointer to the MemorySegmentManager.
         return segment_manager;

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -205,7 +205,19 @@ test "compute_op1_addr for fp op1 addr" {
     var allocator = std.testing.allocator;
 
     const instruction =
-        Instruction{ .off_0 = 1, .off_1 = 2, .off_2 = 3, .dst_reg = .FP, .op_0_reg = .AP, .op_1_addr = .FP, .res_logic = .Add, .pc_update = .Regular, .ap_update = .Regular, .fp_update = .Regular, .opcode = .NOp };
+        Instruction{
+        .off_0 = 1,
+        .off_1 = 2,
+        .off_2 = 3,
+        .dst_reg = .FP,
+        .op_0_reg = .AP,
+        .op_1_addr = .FP,
+        .res_logic = .Add,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .NOp,
+    };
 
     const run_context = try RunContext.init_with_values(
         &allocator,

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -61,7 +61,12 @@ pub const RunContext = struct {
     /// - The initialized run context.
     /// # Errors
     /// - If a memory allocation fails.
-    pub fn init_with_values(allocator: *Allocator, pc: Relocatable, ap: Relocatable, fp: Relocatable) !*RunContext {
+    pub fn init_with_values(
+        allocator: *Allocator,
+        pc: Relocatable,
+        ap: Relocatable,
+        fp: Relocatable,
+    ) !*RunContext {
         var run_context = try RunContext.init(allocator);
         run_context.pc.* = pc;
         run_context.ap.* = ap;
@@ -84,7 +89,10 @@ pub const RunContext = struct {
     /// - instruction: The instruction to compute the dst address for.
     /// # Returns
     /// - The computed dst address.
-    pub fn compute_dst_addr(self: *RunContext, instruction: *const Instruction) !Relocatable {
+    pub fn compute_dst_addr(
+        self: *RunContext,
+        instruction: *const Instruction,
+    ) !Relocatable {
         var base_addr = switch (instruction.dst_reg) {
             .AP => self.ap.*,
             .FP => self.fp.*,
@@ -92,11 +100,17 @@ pub const RunContext = struct {
 
         if (instruction.off_0 < 0) {
             // Convert i16 to u64 safely and then negate
-            const abs_offset = @as(u64, @intCast(-instruction.off_0));
+            const abs_offset = @as(
+                u64,
+                @intCast(-instruction.off_0),
+            );
             return try base_addr.subUint(abs_offset);
         } else {
             // Convert i16 to u64 safely
-            const offset = @as(u64, @intCast(instruction.off_2));
+            const offset = @as(
+                u64,
+                @intCast(instruction.off_2),
+            );
             return try base_addr.addUint(offset);
         }
     }
@@ -106,7 +120,10 @@ pub const RunContext = struct {
     /// - instruction: The instruction to compute the OP 0 address for.
     /// # Returns
     /// - The computed OP 0 address.
-    pub fn compute_op_0_addr(self: *RunContext, instruction: *const Instruction) !Relocatable {
+    pub fn compute_op_0_addr(
+        self: *RunContext,
+        instruction: *const Instruction,
+    ) !Relocatable {
         var base_addr = switch (instruction.op_0_reg) {
             .AP => self.ap.*,
             .FP => self.fp.*,
@@ -114,11 +131,17 @@ pub const RunContext = struct {
 
         if (instruction.off_1 < 0) {
             // Convert i16 to u64 safely and then negate
-            const abs_offset = @as(u64, @intCast(-instruction.off_1));
+            const abs_offset = @as(
+                u64,
+                @intCast(-instruction.off_1),
+            );
             return try base_addr.subUint(abs_offset);
         } else {
             // Convert i16 to u64 safely
-            const offset = @as(u64, @intCast(instruction.off_1));
+            const offset = @as(
+                u64,
+                @intCast(instruction.off_1),
+            );
             return try base_addr.addUint(offset);
         }
     }
@@ -128,7 +151,11 @@ pub const RunContext = struct {
     /// - instruction: The instruction to compute the OP 1 address for.
     /// # Returns
     /// - The computed OP 1 address.
-    pub fn compute_op_1_addr(self: *RunContext, instruction: *const Instruction, op_0: ?MaybeRelocatable) !Relocatable {
+    pub fn compute_op_1_addr(
+        self: *RunContext,
+        instruction: *const Instruction,
+        op_0: ?MaybeRelocatable,
+    ) !Relocatable {
         var base_addr: Relocatable = undefined;
         switch (instruction.op_1_addr) {
             .FP => base_addr = self.fp.*,
@@ -151,11 +178,17 @@ pub const RunContext = struct {
 
         if (instruction.off_2 < 0) {
             // Convert i16 to u64 safely and then negate
-            const abs_offset = @as(u64, @intCast(-instruction.off_2));
+            const abs_offset = @as(
+                u64,
+                @intCast(-instruction.off_2),
+            );
             return try base_addr.subUint(abs_offset);
         } else {
             // Convert i16 to u64 safely
-            const offset = @as(u64, @intCast(instruction.off_2));
+            const offset = @as(
+                u64,
+                @intCast(instruction.off_2),
+            );
             return try base_addr.addUint(offset);
         }
     }
@@ -174,9 +207,24 @@ test "compute_op1_addr for fp op1 addr" {
     const instruction =
         Instruction{ .off_0 = 1, .off_1 = 2, .off_2 = 3, .dst_reg = .FP, .op_0_reg = .AP, .op_1_addr = .FP, .res_logic = .Add, .pc_update = .Regular, .ap_update = .Regular, .fp_update = .Regular, .opcode = .NOp };
 
-    const run_context = try RunContext.init_with_values(&allocator, Relocatable.new(0, 4), Relocatable.new(0, 5), Relocatable.new(0, 6));
+    const run_context = try RunContext.init_with_values(&allocator, Relocatable.new(
+        0,
+        4,
+    ), Relocatable.new(
+        0,
+        5,
+    ), Relocatable.new(
+        0,
+        6,
+    ));
     defer run_context.deinit();
-    const relocatable_addr = try run_context.compute_op_1_addr(&instruction, null);
+    const relocatable_addr = try run_context.compute_op_1_addr(
+        &instruction,
+        null,
+    );
 
-    try expect(relocatable_addr.eq(Relocatable.new(0, 9)));
+    try expect(relocatable_addr.eq(Relocatable.new(
+        0,
+        9,
+    )));
 }

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -207,16 +207,21 @@ test "compute_op1_addr for fp op1 addr" {
     const instruction =
         Instruction{ .off_0 = 1, .off_1 = 2, .off_2 = 3, .dst_reg = .FP, .op_0_reg = .AP, .op_1_addr = .FP, .res_logic = .Add, .pc_update = .Regular, .ap_update = .Regular, .fp_update = .Regular, .opcode = .NOp };
 
-    const run_context = try RunContext.init_with_values(&allocator, Relocatable.new(
-        0,
-        4,
-    ), Relocatable.new(
-        0,
-        5,
-    ), Relocatable.new(
-        0,
-        6,
-    ));
+    const run_context = try RunContext.init_with_values(
+        &allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            5,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
     defer run_context.deinit();
     const relocatable_addr = try run_context.compute_op_1_addr(
         &instruction,


### PR DESCRIPTION
According to the Ziglang formatting rules, 

> If a list of things is longer than 2, put each item on its own line and exercise the ability to put an extra comma at the end.


This PR is therefore part of #21 regarding the rules usual formatting for Ziglang.