### PR TITLE
perf(vm): use dynamic dispatch to enable/disable tracing of instructions

### DIFF
--- a/src/build_options.zig
+++ b/src/build_options.zig
@@ -1,0 +1,7 @@
+/// Whether tracing should be disabled globally. This prevents the
+/// user from enabling tracing via the command line but it might
+/// improve performance slightly.
+pub const trace_disable = true;
+/// The initial capacity of the buffer responsible for gathering execution trace
+/// data.
+pub const trace_initial_capacity: usize = 4096;

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -11,6 +11,7 @@ const vm_core = @import("../vm/core.zig");
 const RunContext = @import("../vm/run_context.zig").RunContext;
 const relocatable = @import("../vm/memory/relocatable.zig");
 const Config = @import("../vm/config.zig").Config;
+const build_options = @import("../main.zig").build_options;
 
 // ************************************************************
 // *                 GLOBAL VARIABLES                         *
@@ -88,6 +89,11 @@ fn execute(_: []const []const u8) !void {
         "Running Cairo VM...\n",
         .{},
     );
+
+    if (build_options.disable_tracing and config.enable_trace) {
+        std.log.err("Tracing is disabled in this build.\n", .{});
+        return;
+    }
 
     // Create a new VM instance.
     var vm = try vm_core.CairoVM.init(&gpa_allocator, config);

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -88,7 +88,7 @@ const UsageError = error{
     /// Occurs when the user requests a config that is not supported by the current build.
     ///
     /// For example because execution traces are globally disabled.
-    incompatibleBuildOptions,
+    IncompatibleBuildOptions,
 };
 
 // execute entrypoint
@@ -100,7 +100,7 @@ fn execute(_: []const []const u8) !void {
 
     if (build_options.trace_disable and config.enable_trace) {
         std.log.err("Tracing is disabled in this build.\n", .{});
-        return UsageError.incompatibleBuildOptions;
+        return UsageError.IncompatibleBuildOptions;
     }
 
     // Create a new VM instance.

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -11,7 +11,7 @@ const vm_core = @import("../vm/core.zig");
 const RunContext = @import("../vm/run_context.zig").RunContext;
 const relocatable = @import("../vm/memory/relocatable.zig");
 const Config = @import("../vm/config.zig").Config;
-const build_options = @import("../main.zig").build_options;
+const build_options = @import("../build_options.zig");
 
 // ************************************************************
 // *                 GLOBAL VARIABLES                         *

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -83,6 +83,14 @@ pub fn run() !void {
 // *                       CLI COMMANDS                       *
 // ************************************************************
 
+/// Errors that occur because the user misused the CLI.
+const UsageError = error{
+    /// Occurs when the user requests a config that is not supported by the current build.
+    ///
+    /// For example because execution traces are globally disabled.
+    incompatibleBuildOptions,
+};
+
 // execute entrypoint
 fn execute(_: []const []const u8) !void {
     std.log.debug(
@@ -92,7 +100,7 @@ fn execute(_: []const []const u8) !void {
 
     if (build_options.trace_disable and config.enable_trace) {
         std.log.err("Tracing is disabled in this build.\n", .{});
-        return;
+        return UsageError.incompatibleBuildOptions;
     }
 
     // Create a new VM instance.

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -4,6 +4,7 @@ pub const vm = struct {
     pub usingnamespace @import("vm/error.zig");
     pub usingnamespace @import("vm/instructions.zig");
     pub usingnamespace @import("vm/run_context.zig");
+    pub usingnamespace @import("vm/trace_context.zig");
     pub usingnamespace @import("vm/memory/memory.zig");
     pub usingnamespace @import("vm/memory/relocatable.zig");
     pub usingnamespace @import("vm/memory/segments.zig");
@@ -19,3 +20,5 @@ pub const utils = struct {
     pub usingnamespace @import("utils/log.zig");
     pub usingnamespace @import("utils/time.zig");
 };
+
+pub const build_options = @import("build_options.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -21,17 +21,6 @@ pub const std_options = struct {
     pub const logFn = customlogFn;
 };
 
-/// Global compilation flags for the project.
-pub const build_options = struct {
-    /// Whether tracing should be disabled globally. This prevents the
-    /// user from enabling tracing via the command line but it might
-    /// improve performance slightly.
-    pub const trace_disable = true;
-    /// The initial capacity of the buffer responsible for gathering execution trace
-    /// data.
-    pub const trace_initial_capacity: usize = 4096;
-};
-
 // *****************************************************************************
 // *                     MAIN ENTRY POINT                                      *
 // *****************************************************************************

--- a/src/main.zig
+++ b/src/main.zig
@@ -21,6 +21,14 @@ pub const std_options = struct {
     pub const logFn = customlogFn;
 };
 
+/// Global compilation flags for the project.
+pub const build_options = struct {
+    /// Whether tracing should be disabled globally. This prevents the
+    /// user from enabling tracing via the command line but it might
+    /// improve performance slightly.
+    pub const disable_tracing = true;
+};
+
 // *****************************************************************************
 // *                     MAIN ENTRY POINT                                      *
 // *****************************************************************************

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -952,7 +952,7 @@ test "trace is enabled" {
     // *                      TEST CHECKS                         *
     // ************************************************************
     // Check that trace was initialized
-    if (!vm.trace_context.enabled) {
+    if (!vm.trace_context.isEnabled()) {
         return error.TraceShouldHaveBeenEnabled;
     }
 }
@@ -977,7 +977,7 @@ test "trace is disabled" {
     // *                      TEST CHECKS                         *
     // ************************************************************
     // Check that trace was initialized
-    if (vm.trace_context.enabled) {
+    if (vm.trace_context.isEnabled()) {
         return error.TraceShouldHaveBeenDisabled;
     }
 }

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -12,6 +12,7 @@ const RunContext = @import("run_context.zig").RunContext;
 const CairoVMError = @import("error.zig").CairoVMError;
 const Config = @import("config.zig").Config;
 const TraceContext = @import("trace_context.zig").TraceContext;
+const build_options = @import("../main.zig").build_options;
 
 /// Represents the Cairo VM.
 pub const CairoVM = struct {
@@ -119,11 +120,14 @@ pub const CairoVM = struct {
         self: *CairoVM,
         instruction: *const instructions.Instruction,
     ) !void {
-        try self.trace_context.traceInstruction(.{
-            .pc = self.run_context.pc,
-            .ap = self.run_context.ap,
-            .fp = self.run_context.fp,
-        });
+        if (!build_options.disable_tracing) {
+            try self.trace_context.traceInstruction(.{
+                .pc = self.run_context.pc,
+                .ap = self.run_context.ap,
+                .fp = self.run_context.fp,
+            });
+        }
+
         const operands_result = try self.computeOperands(instruction);
         _ = operands_result;
     }

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -950,7 +950,6 @@ test "trace is enabled" {
     var vm = try CairoVM.init(
         &allocator,
         config,
-        4096,
     );
     defer vm.deinit();
 

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -12,7 +12,7 @@ const RunContext = @import("run_context.zig").RunContext;
 const CairoVMError = @import("error.zig").CairoVMError;
 const Config = @import("config.zig").Config;
 const TraceContext = @import("trace_context.zig").TraceContext;
-const build_options = @import("../main.zig").build_options;
+const build_options = @import("../build_options.zig");
 
 /// Represents the Cairo VM.
 pub const CairoVM = struct {

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -11,6 +11,7 @@ const instructions = @import("instructions.zig");
 const RunContext = @import("run_context.zig").RunContext;
 const CairoVMError = @import("error.zig").CairoVMError;
 const Config = @import("config.zig").Config;
+const TraceContext = @import("trace_context.zig").TraceContext;
 
 /// Represents the Cairo VM.
 pub const CairoVM = struct {
@@ -28,7 +29,7 @@ pub const CairoVM = struct {
     /// Whether the run is finished or not.
     is_run_finished: bool,
     /// VM trace
-    trace: ?ArrayList(TraceEntry),
+    trace_context: TraceContext,
 
     // ************************************************************
     // *             MEMORY ALLOCATION AND DEALLOCATION           *
@@ -47,19 +48,15 @@ pub const CairoVM = struct {
         const memory_segment_manager = try segments.MemorySegmentManager.init(allocator);
         // Initialize the run context.
         const run_context = try RunContext.init(allocator);
-
-        var trace: ?ArrayList(TraceEntry) = null;
-        if (config.enable_trace) {
-            // FIXME: https://github.com/keep-starknet-strange/cairo-zig/issues/30
-            trace = try ArrayList(TraceEntry).initCapacity(allocator.*, 4096);
-        }
+        // Initialize the trace context.
+        const trace_context = try TraceContext.init(allocator.*, config.enable_trace);
 
         return CairoVM{
             .allocator = allocator,
             .run_context = run_context,
             .segments = memory_segment_manager,
             .is_run_finished = false,
-            .trace = trace,
+            .trace_context = trace_context,
         };
     }
 
@@ -70,9 +67,7 @@ pub const CairoVM = struct {
         // Deallocate the run context.
         self.run_context.deinit();
         // Deallocate trace
-        if (self.trace) |trace| {
-            trace.deinit();
-        }
+        self.trace_context.deinit();
     }
 
     // ************************************************************
@@ -124,14 +119,11 @@ pub const CairoVM = struct {
         self: *CairoVM,
         instruction: *const instructions.Instruction,
     ) !void {
-        if (self.trace) |tracer| {
-            var mut_tracer = tracer;
-            try mut_tracer.append(TraceEntry{
-                .pc = self.run_context.pc,
-                .ap = self.run_context.ap,
-                .fp = self.run_context.fp,
-            });
-        }
+        try self.trace_context.traceInstruction(.{
+            .pc = self.run_context.pc,
+            .ap = self.run_context.ap,
+            .fp = self.run_context.fp,
+        });
         const operands_result = try self.computeOperands(instruction);
         _ = operands_result;
     }
@@ -410,12 +402,6 @@ const OperandsResult = struct {
             .op_1_addr = relocatable.fromU64(0),
         };
     }
-};
-
-const TraceEntry = struct {
-    pc: *relocatable.Relocatable,
-    ap: *relocatable.Relocatable,
-    fp: *relocatable.Relocatable,
 };
 
 // ************************************************************
@@ -966,9 +952,7 @@ test "trace is enabled" {
     // *                      TEST CHECKS                         *
     // ************************************************************
     // Check that trace was initialized
-    const trace = vm.trace;
-
-    if (trace == null) {
+    if (!vm.trace_context.enabled) {
         return error.TraceShouldHaveBeenEnabled;
     }
 }
@@ -993,9 +977,7 @@ test "trace is disabled" {
     // *                      TEST CHECKS                         *
     // ************************************************************
     // Check that trace was initialized
-    const trace = vm.trace;
-
-    if (trace != null) {
+    if (vm.trace_context.enabled) {
         return error.TraceShouldHaveBeenDisabled;
     }
 }

--- a/src/vm/trace_context.zig
+++ b/src/vm/trace_context.zig
@@ -1,0 +1,134 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArrayList = std.ArrayList;
+
+const Relocatable = @import("./memory/relocatable.zig").Relocatable;
+
+/// The inner state of the `TraceContext`.
+///
+/// It's either something, or nothing. But no tag is kept around to remember which one it is. This
+/// "memory" comes from dynamic dispatch.
+const State = union {
+    enabled: TraceEnabled,
+    disabled: TraceDisabled,
+
+    /// A function that records a new entry in the tracing context.
+    const TraceInstructionFn = fn (state: *State, entry: TraceContext.Entry) Allocator.Error!void;
+    /// A function that frees the resources owned by the tracing context.
+    const DeinitFn = fn (state: *State) void;
+};
+
+/// Contains the state required to trace the execution of the Cairo VM.
+///
+/// This includes a big array with `TraceEntry` instances.
+pub const TraceContext = struct {
+    /// An entry recorded representing the state of the VM at a given point in time.
+    pub const Entry = struct {
+        pc: *Relocatable,
+        ap: *Relocatable,
+        fp: *Relocatable,
+    };
+
+    /// This boolean should generally not be used directly. Instead, function dispatch should
+    /// be used.
+    ///
+    /// This is mainly used for actors outside of the tracing system to know whether it is
+    /// enabled or not (e.g. tests).
+    enabled: bool,
+    /// The current state of the tracing context.
+    state: State,
+
+    //
+    // DYNAMIC DISPATCH FUNCTIONS
+    //
+    // The following functions "remember" whether `state` is in an intialized or deinitialized
+    // state and properly act accordingly.
+    //
+
+    /// A function to call when a new entry is recorded.
+    traceInstructionFn: *const State.TraceInstructionFn,
+    /// A functio to call
+    deinitFn: *const State.DeinitFn,
+
+    /// Initializes a new instance of `TraceContext`.
+    ///
+    /// # Arguments
+    ///
+    /// - `allocator`: the allocator to use for allocating the resources used by the tracing
+    ///   context.
+    ///
+    /// - `enable`: Whether tracing should be enabled in the first place. When `false`, the
+    ///   API exposed by `TraceContext` becomes essentially a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Fails in case of memory allocation errors.
+    pub fn init(allocator: Allocator, enable: bool) !TraceContext {
+        var state: State = undefined;
+        var traceInstructionFn: *const State.TraceInstructionFn = undefined;
+        var deinitFn: *const State.DeinitFn = undefined;
+
+        if (enable) {
+            state = State{ .enabled = try TraceEnabled.init(allocator) };
+            traceInstructionFn = TraceEnabled.traceInstruction;
+            deinitFn = TraceEnabled.deinit;
+        } else {
+            state = State{ .disabled = TraceDisabled{} };
+            traceInstructionFn = TraceDisabled.traceInstruction;
+            deinitFn = TraceDisabled.deinit;
+        }
+
+        return TraceContext{
+            .enabled = enable,
+            .state = state,
+            .traceInstructionFn = traceInstructionFn,
+            .deinitFn = deinitFn,
+        };
+    }
+
+    /// Frees the resources owned by this instance of `TraceContext`.
+    pub fn deinit(self: *TraceContext) void {
+        self.deinitFn(&self.state);
+    }
+
+    /// Records a new entry in the tracing context.
+    pub fn traceInstruction(self: *TraceContext, entry: TraceContext.Entry) !void {
+        try self.traceInstructionFn(&self.state, entry);
+    }
+};
+
+/// The state of the tracing system when it's enabled.
+const TraceEnabled = struct {
+    /// The entries that have been recorded so far.
+    entries: ArrayList(TraceContext.Entry),
+
+    fn init(allocator: Allocator) !TraceEnabled {
+        return TraceEnabled{
+            .entries = ArrayList(TraceContext.Entry).init(allocator),
+        };
+    }
+
+    fn deinit(self: *State) void {
+        const this = &self.enabled;
+        this.entries.deinit();
+    }
+
+    fn traceInstruction(self: *State, entry: TraceContext.Entry) !void {
+        const this = &self.enabled;
+        try this.entries.append(entry);
+    }
+};
+
+/// The state of the tracing system when it's disabled.
+const TraceDisabled = struct {
+    fn deinit(self: *State) void {
+        const this = &self.disabled;
+        _ = this;
+    }
+
+    fn traceInstruction(self: *State, entry: TraceContext.Entry) !void {
+        const this = &self.disabled;
+        _ = entry;
+        _ = this;
+    }
+};

--- a/src/vm/trace_context.zig
+++ b/src/vm/trace_context.zig
@@ -29,12 +29,6 @@ pub const TraceContext = struct {
         fp: *Relocatable,
     };
 
-    /// This boolean should generally not be used directly. Instead, function dispatch should
-    /// be used.
-    ///
-    /// This is mainly used for actors outside of the tracing system to know whether it is
-    /// enabled or not (e.g. tests).
-    enabled: bool,
     /// The current state of the tracing context.
     state: State,
 
@@ -79,7 +73,6 @@ pub const TraceContext = struct {
         }
 
         return TraceContext{
-            .enabled = enable,
             .state = state,
             .traceInstructionFn = traceInstructionFn,
             .deinitFn = deinitFn,
@@ -94,6 +87,11 @@ pub const TraceContext = struct {
     /// Records a new entry in the tracing context.
     pub fn traceInstruction(self: *TraceContext, entry: TraceContext.Entry) !void {
         try self.traceInstructionFn(&self.state, entry);
+    }
+
+    /// Returns whether tracing is enabled.
+    pub fn isEnabled(self: *const TraceContext) bool {
+        return self.traceInstructionFn == TraceEnabled.traceInstruction;
     }
 };
 

--- a/src/vm/trace_context.zig
+++ b/src/vm/trace_context.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
 
-const build_options = @import("../main.zig").build_options;
+const build_options = @import("../build_options.zig");
 const Relocatable = @import("./memory/relocatable.zig").Relocatable;
 
 /// The inner state of the `TraceContext`.


### PR DESCRIPTION
This PR introduces a dynamic dispatch mechanism to trace instructions within the VM.

This is related to #25.

# Performance Considerations

I'm not yet sure whether a function pointer call is that slower or faster than a regular if/else branch. The CPU might be able to optimze the latter better because of its knowledge of the content. With this PR, we might've just removed any optimization possibility entierly.

This should be benchmark to avoid regressions.