### PR TITLE
Omit the struct type of a literal when the result is coerced

### DIFF
--- a/src/math/fields/fields.zig
+++ b/src/math/fields/fields.zig
@@ -19,7 +19,7 @@ pub fn Field(
                 &bz,
                 [_]u8{0} ** BytesSize,
             );
-            break :val Self{ .fe = bz };
+            break :val .{ .fe = bz };
         };
 
         fe: F.MontgomeryDomainFieldElement,
@@ -44,7 +44,7 @@ pub fn Field(
                 nonMont,
             );
 
-            return Self{ .fe = mont };
+            return .{ .fe = mont };
         }
 
         pub fn zero() Self {
@@ -55,7 +55,7 @@ pub fn Field(
             const oneValue = comptime blk: {
                 var baseOne: F.MontgomeryDomainFieldElement = undefined;
                 F.setOne(&baseOne);
-                break :blk Self{ .fe = baseOne };
+                break :blk .{ .fe = baseOne };
             };
             return oneValue;
         }
@@ -120,7 +120,7 @@ pub fn Field(
                 self.fe,
                 other.fe,
             );
-            return Self{ .fe = ret };
+            return .{ .fe = ret };
         }
 
         pub fn sub(
@@ -133,7 +133,7 @@ pub fn Field(
                 self.fe,
                 other.fe,
             );
-            return Self{ .fe = ret };
+            return .{ .fe = ret };
         }
 
         pub fn mul(
@@ -146,7 +146,7 @@ pub fn Field(
                 self.fe,
                 other.fe,
             );
-            return Self{ .fe = ret };
+            return .{ .fe = ret };
         }
 
         pub fn mulBy5(self: Self) Self {
@@ -166,7 +166,7 @@ pub fn Field(
                 ret,
                 self.fe,
             );
-            return Self{ .fe = ret };
+            return .{ .fe = ret };
         }
 
         pub fn neg(self: Self) Self {
@@ -176,7 +176,7 @@ pub fn Field(
                 base_zero.fe,
                 self.fe,
             );
-            return Self{ .fe = ret };
+            return .{ .fe = ret };
         }
 
         pub fn isZero(self: Self) bool {

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -162,7 +162,7 @@ pub const CairoVM = struct {
         const op_1_op = try self.segments.memory.get(op_1_addr);
         _ = op_1_op;
 
-        return OperandsResult{
+        return .{
             .dst = relocatable.fromU64(0),
             .res = relocatable.fromU64(0),
             .op_0 = relocatable.fromU64(0),
@@ -399,7 +399,7 @@ const OperandsResult = struct {
 
     /// Returns a default instance of the OperandsResult struct.
     pub fn default() OperandsResult {
-        return OperandsResult{
+        return .{
             .dst = relocatable.fromU64(0),
             .res = relocatable.fromU64(0),
             .op_0 = relocatable.fromU64(0),

--- a/src/vm/instructions.zig
+++ b/src/vm/instructions.zig
@@ -179,7 +179,7 @@ pub fn decode(encoded_instruction: u64) Error!Instruction {
         ),
     );
 
-    return Instruction{
+    return .{
         .off_0 = fromBiasedRepresentation(
             @as(
                 u16,
@@ -233,10 +233,10 @@ pub fn decode(encoded_instruction: u64) Error!Instruction {
 /// Parsed Opcode value, or an error if invalid
 fn parseOpcode(opcode_num: u8) Error!Opcode {
     return switch (opcode_num) {
-        0 => Opcode.NOp,
-        1 => Opcode.Call,
-        2 => Opcode.Ret,
-        4 => Opcode.AssertEq,
+        0 => .NOp,
+        1 => .Call,
+        2 => .Ret,
+        4 => .AssertEq,
         else => Error.InvalidOpcode,
     };
 }
@@ -248,10 +248,10 @@ fn parseOpcode(opcode_num: u8) Error!Opcode {
 /// Parsed Op1Src value, or an error if invalid
 fn parseOp1Src(op1_src_num: u8) Error!Op1Src {
     return switch (op1_src_num) {
-        0 => Op1Src.Op0,
-        1 => Op1Src.Imm,
-        2 => Op1Src.FP,
-        4 => Op1Src.AP,
+        0 => .Op0,
+        1 => .Imm,
+        2 => .FP,
+        4 => .AP,
         else => Error.InvalidOp1Reg,
     };
 }
@@ -268,14 +268,14 @@ fn parseResLogic(
 ) Error!ResLogic {
     return switch (res_logic_num) {
         0 => {
-            if (pc_update == PcUpdate.Jnz) {
-                return ResLogic.Unconstrained;
+            if (pc_update == .Jnz) {
+                return .Unconstrained;
             } else {
-                return ResLogic.Op1;
+                return .Op1;
             }
         },
-        1 => ResLogic.Add,
-        2 => ResLogic.Mul,
+        1 => .Add,
+        2 => .Mul,
         else => Error.Invalidres_logic,
     };
 }
@@ -287,10 +287,10 @@ fn parseResLogic(
 /// Parsed pc_update value, or an error if invalid
 fn parsePcUpdate(pc_update_num: u8) Error!PcUpdate {
     return switch (pc_update_num) {
-        0 => PcUpdate.Regular,
-        1 => PcUpdate.Jump,
-        2 => PcUpdate.JumpRel,
-        4 => PcUpdate.Jnz,
+        0 => .Regular,
+        1 => .Jump,
+        2 => .JumpRel,
+        4 => .Jnz,
         else => Error.Invalidpc_update,
     };
 }
@@ -306,13 +306,13 @@ fn parseApUpdate(
     opcode: Opcode,
 ) Error!ApUpdate {
     return switch (ap_update_num) {
-        0 => if (opcode == Opcode.Call) {
-            return ApUpdate.Add2;
+        0 => if (opcode == .Call) {
+            return .Add2;
         } else {
-            return ApUpdate.Regular;
+            return .Regular;
         },
-        1 => ApUpdate.Add,
-        2 => ApUpdate.Add1,
+        1 => .Add,
+        2 => .Add1,
         else => Error.Invalidap_update,
     };
 }
@@ -324,9 +324,9 @@ fn parseApUpdate(
 /// Appropriate fp_update value
 fn parseFpUpdate(opcode: Opcode) FpUpdate {
     return switch (opcode) {
-        Opcode.Call => FpUpdate.APPlus2,
-        Opcode.Ret => FpUpdate.Dst,
-        else => FpUpdate.Regular,
+        .Call => .APPlus2,
+        .Ret => .Dst,
+        else => .Regular,
     };
 }
 

--- a/src/vm/memory/relocatable.zig
+++ b/src/vm/memory/relocatable.zig
@@ -16,7 +16,7 @@ pub const Relocatable = struct {
     // # Returns
     // A new Relocatable with the default values.
     pub fn default() Relocatable {
-        return Relocatable{
+        return .{
             .segment_index = 0,
             .offset = 0,
         };
@@ -32,7 +32,7 @@ pub const Relocatable = struct {
         segment_index: u64,
         offset: u64,
     ) Relocatable {
-        return Relocatable{
+        return .{
             .segment_index = segment_index,
             .offset = offset,
         };
@@ -62,7 +62,7 @@ pub const Relocatable = struct {
         if (self.offset < other) {
             return error.RelocatableSubUsizeNegOffset;
         }
-        return Relocatable{
+        return .{
             .segment_index = self.segment_index,
             .offset = self.offset - other,
         };
@@ -77,7 +77,7 @@ pub const Relocatable = struct {
         self: Relocatable,
         other: u64,
     ) !Relocatable {
-        return Relocatable{
+        return .{
             .segment_index = self.segment_index,
             .offset = self.offset + other,
         };
@@ -232,7 +232,7 @@ pub const MaybeRelocatable = union(enum) {
 // # Returns
 // A new MaybeRelocatable.
 pub fn newFromRelocatable(relocatable: Relocatable) MaybeRelocatable {
-    return MaybeRelocatable{ .relocatable = relocatable };
+    return .{ .relocatable = relocatable };
 }
 
 // Creates a new MaybeRelocatable from a field element.
@@ -241,7 +241,7 @@ pub fn newFromRelocatable(relocatable: Relocatable) MaybeRelocatable {
 // # Returns
 // A new MaybeRelocatable.
 pub fn fromFelt(felt: Felt252) MaybeRelocatable {
-    return MaybeRelocatable{ .felt = felt };
+    return .{ .felt = felt };
 }
 
 // Creates a new MaybeRelocatable from a u256.
@@ -250,7 +250,7 @@ pub fn fromFelt(felt: Felt252) MaybeRelocatable {
 // # Returns
 // A new MaybeRelocatable.
 pub fn fromU256(value: u256) MaybeRelocatable {
-    return MaybeRelocatable{ .felt = Felt252.fromInteger(value) };
+    return .{ .felt = Felt252.fromInteger(value) };
 }
 
 // Creates a new MaybeRelocatable from a u64.

--- a/src/vm/trace_context.zig
+++ b/src/vm/trace_context.zig
@@ -73,7 +73,7 @@ pub const TraceContext = struct {
             deinitFn = TraceDisabled.deinit;
         }
 
-        return TraceContext{
+        return .{
             .state = state,
             .traceInstructionFn = traceInstructionFn,
             .deinitFn = deinitFn,
@@ -102,8 +102,11 @@ const TraceEnabled = struct {
     entries: ArrayList(TraceContext.Entry),
 
     fn init(allocator: Allocator) !TraceEnabled {
-        return TraceEnabled{
-            .entries = try ArrayList(TraceContext.Entry).initCapacity(allocator, build_options.trace_initial_capacity),
+        return .{
+            .entries = try ArrayList(TraceContext.Entry).initCapacity(
+                allocator,
+                build_options.trace_initial_capacity,
+            ),
         };
     }
 


### PR DESCRIPTION
Should close #36.