### PR TITLE
refactor: deprecate default fn from Relocatable

### DIFF
--- a/src/vm/memory/relocatable.zig
+++ b/src/vm/memory/relocatable.zig
@@ -8,19 +8,9 @@ const CairoVMError = @import("../error.zig").CairoVMError;
 // represented by a field element.
 pub const Relocatable = struct {
     // The index of the memory segment.
-    segment_index: u64,
+    segment_index: u64 = 0,
     // The offset in the memory segment.
-    offset: u64,
-
-    // Creates a new Relocatable with the default values.
-    // # Returns
-    // A new Relocatable with the default values.
-    pub fn default() Relocatable {
-        return .{
-            .segment_index = 0,
-            .offset = 0,
-        };
-    }
+    offset: u64 = 0,
 
     // Creates a new Relocatable.
     // # Arguments

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -45,9 +45,9 @@ pub const RunContext = struct {
             .ap = try allocator.create(Relocatable),
             .fp = try allocator.create(Relocatable),
         };
-        run_context.pc.* = Relocatable.default();
-        run_context.ap.* = Relocatable.default();
-        run_context.fp.* = Relocatable.default();
+        run_context.pc.* = .{};
+        run_context.ap.* = .{};
+        run_context.fp.* = .{};
         return run_context;
     }
 


### PR DESCRIPTION
We make use of Zig's default struct initialization to get rid of the default() fn.