### PR TITLE
fix: memory leaks in case of error during initialization

### DIFF
--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -67,11 +67,14 @@ pub const CairoVM = struct {
         // Initialize the trace context.
         const trace_context = try TraceContext.init(allocator, config.enable_trace);
         errdefer trace_context.deinit();
+        // Initialize the built-in runners.
+        const builtin_runners = ArrayList(BuiltinRunner).init(allocator);
+        errdefer builtin_runners.deinit();
 
         return Self{
             .allocator = allocator,
             .run_context = run_context,
-            .builtin_runners = ArrayList(BuiltinRunner).init(allocator),
+            .builtin_runners = builtin_runners,
             .segments = memory_segment_manager,
             .is_run_finished = false,
             .trace_context = trace_context,

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -60,10 +60,13 @@ pub const CairoVM = struct {
     ) !Self {
         // Initialize the memory segment manager.
         const memory_segment_manager = try segments.MemorySegmentManager.init(allocator);
+        errdefer memory_segment_manager.deinit();
         // Initialize the run context.
         const run_context = try RunContext.init(allocator);
+        errdefer run_context.deinit();
         // Initialize the trace context.
         const trace_context = try TraceContext.init(allocator, config.enable_trace);
+        errdefer trace_context.deinit();
 
         return Self{
             .allocator = allocator,

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -1185,3 +1185,35 @@ test "compute res mul fails felt and reloc" {
     // ************************************************************
     try expectError(error.MulRelocForbidden, computeRes(&instruction, op0, op1));
 }
+
+test "memory is not leaked upon allocation failure during initialization" {
+    var i: usize = 0;
+    while (i < 20) {
+        // ************************************************************
+        // *                 SETUP TEST CONTEXT                       *
+        // ************************************************************
+        var allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = i });
+        i += 1;
+
+        // ************************************************************
+        // *                      TEST BODY                           *
+        // ************************************************************
+        // Nothing.
+
+        // ************************************************************
+        // *                      TEST CHECKS                         *
+        // ************************************************************
+        // Error must have occured!
+
+        // It's not given that the final error will be an OutOfMemory. It's likely though.
+        // Plus we're not certain that the error will be thrown at the same place as the
+        // VM is upgraded. For this reason, we should just ensure that no memory has
+        // been leaked.
+        // try expectError(error.OutOfMemory, CairoVM.init(allocator.allocator(), .{}));
+
+        // Note that `.deinit()` is not called in case of failure (obviously).
+        // If error handling is done correctly, no memory should be leaked.
+        var vm = CairoVM.init(allocator.allocator(), .{}) catch continue;
+        vm.deinit();
+    }
+}

--- a/src/vm/memory/segments.zig
+++ b/src/vm/memory/segments.zig
@@ -57,6 +57,11 @@ pub const MemorySegmentManager = struct {
     pub fn init(allocator: Allocator) !*Self {
         // Create the pointer to the MemorySegmentManager.
         var segment_manager = try allocator.create(Self);
+        errdefer segment_manager.deinit();
+
+        const memory = try Memory.init(allocator);
+        errdefer memory.deinit();
+
         // Initialize the values of the MemorySegmentManager struct.
         segment_manager.* = Self{
             .allocator = allocator,
@@ -69,7 +74,7 @@ pub const MemorySegmentManager = struct {
                 u32,
             ).init(allocator),
             // Initialize the memory pointer.
-            .memory = try Memory.init(allocator),
+            .memory = memory,
             .public_memory_offsets = std.AutoHashMap(u32, u32).init(allocator),
         };
         // Return the pointer to the MemorySegmentManager.

--- a/src/vm/memory/segments.zig
+++ b/src/vm/memory/segments.zig
@@ -57,7 +57,7 @@ pub const MemorySegmentManager = struct {
     pub fn init(allocator: Allocator) !*Self {
         // Create the pointer to the MemorySegmentManager.
         var segment_manager = try allocator.create(Self);
-        errdefer segment_manager.deinit();
+        errdefer allocator.destroy(segment_manager);
 
         const memory = try Memory.init(allocator);
         errdefer memory.deinit();

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -41,7 +41,7 @@ pub const RunContext = struct {
     /// - If a memory allocation fails.
     pub fn init(allocator: Allocator) !*Self {
         var run_context = try allocator.create(Self);
-        errdefer run_context.deinit();
+        errdefer allocator.destroy(run_context);
 
         const pc = try allocator.create(Relocatable);
         errdefer allocator.destroy(pc);

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -41,15 +41,25 @@ pub const RunContext = struct {
     /// - If a memory allocation fails.
     pub fn init(allocator: Allocator) !*Self {
         var run_context = try allocator.create(Self);
+        errdefer run_context.deinit();
+
+        const pc = try allocator.create(Relocatable);
+        errdefer allocator.destroy(pc);
+        const ap = try allocator.create(Relocatable);
+        errdefer allocator.destroy(ap);
+        const fp = try allocator.create(Relocatable);
+        errdefer allocator.destroy(fp);
+
         run_context.* = Self{
             .allocator = allocator,
-            .pc = try allocator.create(Relocatable),
-            .ap = try allocator.create(Relocatable),
-            .fp = try allocator.create(Relocatable),
+            .pc = pc,
+            .ap = ap,
+            .fp = fp,
         };
         run_context.pc.* = .{};
         run_context.ap.* = .{};
         run_context.fp.* = .{};
+
         return run_context;
     }
 


### PR DESCRIPTION
Functions like this one (initialization of `CairoVM`)

```zig
pub fn init(
    allocator: Allocator,
    config: Config,
) !Self {
    // Initialize the memory segment manager.
    const memory_segment_manager = try segments.MemorySegmentManager.init(allocator);
    // Initialize the run context.
    const run_context = try RunContext.init(allocator);
    // Initialize the trace context.
    const trace_context = try TraceContext.init(allocator, config.enable_trace);

    return Self{
        .allocator = allocator,
        .run_context = run_context,
        .builtin_runners = ArrayList(BuiltinRunner).init(allocator),
        .segments = memory_segment_manager,
        .is_run_finished = false,
        .trace_context = trace_context,
    };
}
```

... can leak memory if one of the allocations fail (specifically, the first two).

In order to properly cleanup when the one of those allocations fail, we need to add some `errdefer`s.


```zig
pub fn init(
    allocator: Allocator,
    config: Config,
) !Self {
    // Initialize the memory segment manager.
    const memory_segment_manager = try segments.MemorySegmentManager.init(allocator);
    errdefer memory_segment_manager.deinit();
    // Initialize the run context.
    const run_context = try RunContext.init(allocator);
    errdefer run_context.deinit();
    // Initialize the trace context.
    const trace_context = try TraceContext.init(allocator, config.enable_trace);
    errdefer trace_context.deinit(); // technically not needed, but probably cleaner with it

    return Self{
        .allocator = allocator,
        .run_context = run_context,
        .builtin_runners = ArrayList(BuiltinRunner).init(allocator),
        .segments = memory_segment_manager,
        .is_run_finished = false,
        .trace_context = trace_context,
    };
}
```

This PR adds those `errdefer`s.