### PR TITLE
feat(tests): fix argument order in `expectEqual` tests

### DIFF
--- a/src/math/fields/starknet.zig
+++ b/src/math/fields/starknet.zig
@@ -10,80 +10,89 @@ pub const Felt252 = fields.Field(
     0x800000000000011000000000000000000000000000000000000000000000001,
 );
 
+const expect = std.testing.expect;
+const expectEqual = std.testing.expectEqual;
+
 test "Felt252 fromInteger" {
-    try std.testing.expectEqual(
-        Felt252.fromInteger(10),
+    try expectEqual(
         Felt252{ .fe = .{
             0xfffffffffffffec1,
             0xffffffffffffffff,
             0xffffffffffffffff,
             0x7ffffffffffead0,
         } },
+        Felt252.fromInteger(10),
     );
 
-    try std.testing.expectEqual(
-        Felt252.fromInteger(std.math.maxInt(u256)),
+    try expectEqual(
         Felt252{ .fe = .{
             0xfffffd737e000421,
             0x1330fffff,
             0xffffffffff6f8000,
             0x7ffd4ab5e008a30,
         } },
+        Felt252.fromInteger(std.math.maxInt(u256)),
     );
 }
 
 test "Felt252 toInteger" {
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            10,
+        ),
         Felt252.fromInteger(10).toInteger(),
-        10,
     );
 
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x7fffffffffffdf0ffffffffffffffffffffffffffffffffffffffffffffffe0,
+        ),
         Felt252.fromInteger(std.math.maxInt(u256)).toInteger(),
-        0x7fffffffffffdf0ffffffffffffffffffffffffffffffffffffffffffffffe0,
     );
 }
 
 test "Felt252 one" {
-    try std.testing.expectEqual(
-        Felt252.one(),
+    try expectEqual(
         Felt252{ .fe = .{
             0xffffffffffffffe1,
             0xffffffffffffffff,
             0xffffffffffffffff,
             0x7fffffffffffdf0,
         } },
+        Felt252.one(),
     );
 }
 
 test "Felt252 zero" {
-    try std.testing.expectEqual(
-        Felt252.zero(),
+    try expectEqual(
         Felt252{ .fe = .{
             0,
             0,
             0,
             0,
         } },
+        Felt252.zero(),
     );
 }
 
 test "Felt252 equal" {
-    try std.testing.expect(Felt252.zero().equal(Felt252.zero()));
-    try std.testing.expect(Felt252.fromInteger(10).equal(Felt252.fromInteger(10)));
-    try std.testing.expect(!Felt252.fromInteger(10).equal(Felt252.fromInteger(100)));
+    try expect(Felt252.zero().equal(Felt252.zero()));
+    try expect(Felt252.fromInteger(10).equal(Felt252.fromInteger(10)));
+    try expect(!Felt252.fromInteger(100).equal(Felt252.fromInteger(10)));
 }
 
 test "Felt252 isZero" {
-    try std.testing.expect(Felt252.zero().isZero());
-    try std.testing.expect(!Felt252.one().isZero());
-    try std.testing.expect(!Felt252.fromInteger(10).isZero());
+    try expect(Felt252.zero().isZero());
+    try expect(!Felt252.one().isZero());
+    try expect(!Felt252.fromInteger(10).isZero());
 }
 
 test "Felt252 isOne" {
-    try std.testing.expect(Felt252.one().isOne());
-    try std.testing.expect(!Felt252.zero().isOne());
-    try std.testing.expect(!Felt252.fromInteger(10).isOne());
+    try expect(Felt252.one().isOne());
+    try expect(!Felt252.zero().isOne());
+    try expect(!Felt252.fromInteger(10).isOne());
 }
 
 test "Felt252 fromBytes" {
@@ -121,66 +130,75 @@ test "Felt252 fromBytes" {
         0x96,
         0x00,
     };
-
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x96f8e63ba9b2bcea770f6a07c669ba51ce76df2f67195f5f5f5f5f5f5f5f4e,
+        ),
         Felt252.fromBytes(a).toInteger(),
-        0x96f8e63ba9b2bcea770f6a07c669ba51ce76df2f67195f5f5f5f5f5f5f5f4e,
     );
 
-    try std.testing.expectEqual(
-        Felt252.fromBytes(a),
+    try expectEqual(
         Felt252.fromInteger(0x96f8e63ba9b2bcea770f6a07c669ba51ce76df2f67195f5f5f5f5f5f5f5f4e),
+        Felt252.fromBytes(a),
     );
 }
 
 test "Felt252 toBytes" {
-    try std.testing.expectEqual(
+    const expected = [_]u8{
+        0x4E,
+        0x5F,
+        0x5F,
+        0x5F,
+        0x5F,
+        0x5F,
+        0x5F,
+        0x5F,
+        0x5F,
+        0x19,
+        0x67,
+        0x2F,
+        0xDF,
+        0x76,
+        0xCE,
+        0x51,
+        0xBA,
+        0x69,
+        0xC6,
+        0x07,
+        0x6A,
+        0x0F,
+        0x77,
+        0xEA,
+        0xBC,
+        0xB2,
+        0xA9,
+        0x3B,
+        0xE6,
+        0xF8,
+        0x96,
+        0x00,
+    };
+    try expectEqual(
+        expected,
         Felt252.fromInteger(0x96f8e63ba9b2bcea770f6a07c669ba51ce76df2f67195f5f5f5f5f5f5f5f4e).toBytes(),
-        .{
-            0x4E,
-            0x5F,
-            0x5F,
-            0x5F,
-            0x5F,
-            0x5F,
-            0x5F,
-            0x5F,
-            0x5F,
-            0x19,
-            0x67,
-            0x2F,
-            0xDF,
-            0x76,
-            0xCE,
-            0x51,
-            0xBA,
-            0x69,
-            0xC6,
-            0x07,
-            0x6A,
-            0x0F,
-            0x77,
-            0xEA,
-            0xBC,
-            0xB2,
-            0xA9,
-            0x3B,
-            0xE6,
-            0xF8,
-            0x96,
-            0x00,
-        },
     );
 }
 
 test "Felt252 tryIntoU64" {
-    try std.testing.expectEqual(
-        Felt252.fromInteger(10).tryIntoU64(),
-        10,
+    try expectEqual(
+        @as(
+            u64,
+            10,
+        ),
+        try Felt252.fromInteger(10).tryIntoU64(),
     );
-    try std.testing.expectEqual(
-        Felt252.fromInteger(std.math.maxInt(u64)).tryIntoU64(),
-        std.math.maxInt(u64),
+    try expectEqual(
+        @as(
+            u64,
+            std.math.maxInt(u64),
+        ),
+        try Felt252.fromInteger(std.math.maxInt(u64)).tryIntoU64(),
     );
     try std.testing.expectError(
         error.ValueTooLarge,
@@ -192,112 +210,166 @@ test "Felt252 arithmetic operations" {
     const a = Felt252.one();
     const b = Felt252.fromInteger(2);
     const c = a.add(b);
-    try std.testing.expect(c.equal(Felt252.fromInteger(3)));
+    try expect(c.equal(Felt252.fromInteger(3)));
 }
 
 test "Felt252 add" {
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0xf,
+        ),
         Felt252.fromInteger(10).add(Felt252.fromInteger(5)).toInteger(),
-        0xf,
     );
-    try std.testing.expect(Felt252.fromInteger(1).add(Felt252.zero()).isOne());
-    try std.testing.expect(Felt252.zero().add(Felt252.zero()).isZero());
-    try std.testing.expectEqual(
+    try expect(Felt252.one().add(Felt252.zero()).isOne());
+    try expect(Felt252.zero().add(Felt252.zero()).isZero());
+    try expectEqual(
+        @as(
+            u256,
+            0x7fffffffffffbd0ffffffffffffffffffffffffffffffffffffffffffffffbf,
+        ),
         Felt252.fromInteger(std.math.maxInt(u256)).add(Felt252.fromInteger(std.math.maxInt(u256))).toInteger(),
-        0x7fffffffffffbd0ffffffffffffffffffffffffffffffffffffffffffffffbf,
     );
 }
 
 test "Felt252 sub" {
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x5,
+        ),
         Felt252.fromInteger(10).sub(Felt252.fromInteger(5)).toInteger(),
-        0x5,
     );
-    try std.testing.expect(Felt252.fromInteger(std.math.maxInt(u256)).sub(Felt252.fromInteger(std.math.maxInt(u256))).isZero());
-    try std.testing.expect(Felt252.zero().sub(Felt252.zero()).isZero());
+    try expect(Felt252.fromInteger(std.math.maxInt(u256)).sub(Felt252.fromInteger(std.math.maxInt(u256))).isZero());
+    try expect(Felt252.zero().sub(Felt252.zero()).isZero());
 }
 
 test "Felt252 mul" {
-    try std.testing.expect(Felt252.zero().mul(Felt252.zero()).isZero());
-    try std.testing.expect(Felt252.one().mul(Felt252.one()).isOne());
-    try std.testing.expectEqual(
+    try expect(Felt252.zero().mul(Felt252.zero()).isZero());
+    try expect(Felt252.one().mul(Felt252.one()).isOne());
+    try expectEqual(
+        @as(
+            u256,
+            0x32,
+        ),
         Felt252.fromInteger(10).mul(Felt252.fromInteger(5)).toInteger(),
-        0x32,
     );
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x7fffffffffffbd0ffffffffffffffffffffffffffffffffffffffffffffffbf,
+        ),
         Felt252.fromInteger(std.math.maxInt(u256)).mul(Felt252.fromInteger(2)).toInteger(),
-        0x7fffffffffffbd0ffffffffffffffffffffffffffffffffffffffffffffffbf,
     );
 }
 
 test "Felt252 mulBy5" {
-    try std.testing.expect(Felt252.zero().mulBy5().isZero());
-    try std.testing.expectEqual(
+    try expect(Felt252.zero().mulBy5().isZero());
+    try expectEqual(
+        @as(
+            u256,
+            5,
+        ),
         Felt252.one().mulBy5().toInteger(),
-        5,
     );
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x7fffffffffff570ffffffffffffffffffffffffffffffffffffffffffffff5c,
+        ),
         Felt252.fromInteger(std.math.maxInt(u256)).mulBy5().toInteger(),
-        0x7fffffffffff570ffffffffffffffffffffffffffffffffffffffffffffff5c,
     );
 }
 
 test "Felt252 neg" {
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff7,
+        ),
         Felt252.fromInteger(10).neg().toInteger(),
-        0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff7,
     );
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x220000000000000000000000000000000000000000000000021,
+        ),
         Felt252.fromInteger(std.math.maxInt(u256)).neg().toInteger(),
-        0x220000000000000000000000000000000000000000000000021,
     );
 }
 
 test "Felt252 square" {
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x64,
+        ),
         Felt252.fromInteger(10).square().toInteger(),
-        0x64,
     );
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x7ffd4ab5e008c50ffffffffff6f800000000001330ffffffffffd737e000442,
+        ),
         Felt252.fromInteger(std.math.maxInt(u256)).square().toInteger(),
-        0x7ffd4ab5e008c50ffffffffff6f800000000001330ffffffffffd737e000442,
     );
 }
 
 test "Felt252 pow2" {
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x4cdffe7c7b3f76a6ce28dde767fa09b60e963927bbd16d8b0d3a0fc13c6fa0,
+        ),
         Felt252.fromInteger(10).pow2(10).toInteger(),
-        0x4cdffe7c7b3f76a6ce28dde767fa09b60e963927bbd16d8b0d3a0fc13c6fa0,
     );
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x25f7dc4108a227e91fb20740a4866274f449e9d427775a58bb7cb4eaff1e653,
+        ),
         Felt252.fromInteger(std.math.maxInt(u256)).pow2(3).toInteger(),
-        0x25f7dc4108a227e91fb20740a4866274f449e9d427775a58bb7cb4eaff1e653,
     );
 }
 
 test "Felt252 pow" {
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x2540be400,
+        ),
         Felt252.fromInteger(10).pow(10).toInteger(),
-        0x2540be400,
     );
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x48ea9fffffffffffffff5ffffffffffffffe5000000000000449f,
+        ),
         Felt252.fromInteger(std.math.maxInt(u64)).pow(5).toInteger(),
-        0x48ea9fffffffffffffff5ffffffffffffffe5000000000000449f,
     );
 }
 
 test "Felt252 inv" {
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x733333333333342800000000000000000000000000000000000000000000001,
+        ),
         Felt252.fromInteger(10).inv().?.toInteger(),
-        0x733333333333342800000000000000000000000000000000000000000000001,
     );
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x538bf4edb6bf78474ef0f1979a0db0bdd364ce7aeda9f3c6c04bea822682ba,
+        ),
         Felt252.fromInteger(std.math.maxInt(u256)).inv().?.toInteger(),
-        0x538bf4edb6bf78474ef0f1979a0db0bdd364ce7aeda9f3c6c04bea822682ba,
     );
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            ?Felt252,
+            null,
+        ),
         Felt252.zero().inv(),
-        null,
     );
 }
 
@@ -305,13 +377,19 @@ test "Felt252 batchInv" {
     var out: [2]Felt252 = undefined;
     const in: [2]Felt252 = .{ Felt252.fromInteger(10), Felt252.fromInteger(5) };
     try Felt252.batchInv(&out, &in);
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x733333333333342800000000000000000000000000000000000000000000001,
+        ),
         out[0].toInteger(),
-        0x733333333333342800000000000000000000000000000000000000000000001,
     );
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            u256,
+            0x666666666666674000000000000000000000000000000000000000000000001,
+        ),
         out[1].toInteger(),
-        0x666666666666674000000000000000000000000000000000000000000000001,
     );
 }
 
@@ -326,7 +404,7 @@ test "Felt252 batchInv with zero" {
 
 test "Felt252 div" {
     const div_10_by_10 = try Felt252.fromInteger(10).div(Felt252.fromInteger(10));
-    try std.testing.expect(
+    try expect(
         div_10_by_10.isOne(),
     );
     try std.testing.expectError(
@@ -336,16 +414,25 @@ test "Felt252 div" {
 }
 
 test "Felt252 legendre" {
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            i2,
+            0,
+        ),
         Felt252.fromInteger(0x1000000000000022000000000000000000000000000000000000000000000002).legendre(),
-        0,
     );
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            i2,
+            1,
+        ),
         Felt252.fromInteger(10).legendre(),
-        1,
     );
-    try std.testing.expectEqual(
+    try expectEqual(
+        @as(
+            i2,
+            -1,
+        ),
         Felt252.fromInteger(135).legendre(),
-        -1,
     );
 }

--- a/src/vm/builtins/bitwise/bitwise.zig
+++ b/src/vm/builtins/bitwise/bitwise.zig
@@ -171,8 +171,11 @@ test "valid bitwise and" {
     var expected = MaybeRelocatable{ .felt = Felt252.fromInteger(8) };
 
     // then
-    var result = deduce(address, mem);
-    try expectEqual(result, expected);
+    var result = try deduce(address, mem);
+    try expectEqual(
+        expected,
+        result,
+    );
 }
 
 test "valid bitwise xor" {
@@ -191,8 +194,11 @@ test "valid bitwise xor" {
     var expected = MaybeRelocatable{ .felt = Felt252.fromInteger(6) };
 
     // then
-    var result = deduce(address, mem);
-    try expectEqual(result, expected);
+    var result = try deduce(address, mem);
+    try expectEqual(
+        expected,
+        result,
+    );
 }
 
 test "valid bitwise or" {
@@ -211,6 +217,9 @@ test "valid bitwise or" {
     var expected = MaybeRelocatable{ .felt = Felt252.fromInteger(14) };
 
     // then
-    var result = deduce(address, mem);
-    try expectEqual(result, expected);
+    var result = try deduce(address, mem);
+    try expectEqual(
+        expected,
+        result,
+    );
 }

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -116,8 +116,11 @@ test "update pc regular no imm" {
     // ************************************************************
     const pc = vm.getPc();
     try expectEqual(
+        @as(
+            u64,
+            1,
+        ),
         pc.offset,
-        1,
     );
 }
 
@@ -149,8 +152,11 @@ test "update pc regular with imm" {
     // ************************************************************
     const pc = vm.getPc();
     try expectEqual(
+        @as(
+            u64,
+            2,
+        ),
         pc.offset,
-        2,
     );
 }
 
@@ -233,8 +239,11 @@ test "update pc jump with operands res relocatable" {
     // ************************************************************
     const pc = vm.getPc();
     try expectEqual(
+        @as(
+            u64,
+            42,
+        ),
         pc.offset,
-        42,
     );
 }
 
@@ -317,8 +326,11 @@ test "update pc jump rel with operands res felt" {
     // ************************************************************
     const pc = vm.getPc();
     try expectEqual(
+        @as(
+            u64,
+            42,
+        ),
         pc.offset,
-        42,
     );
 }
 
@@ -350,8 +362,11 @@ test "update pc update jnz with operands dst zero" {
     // ************************************************************
     const pc = vm.getPc();
     try expectEqual(
+        @as(
+            u64,
+            2,
+        ),
         pc.offset,
-        2,
     );
 }
 
@@ -415,8 +430,11 @@ test "update pc update jnz with operands dst not zero op1 felt" {
     // ************************************************************
     const pc = vm.getPc();
     try expectEqual(
+        @as(
+            u64,
+            42,
+        ),
         pc.offset,
-        42,
     );
 }
 
@@ -470,8 +488,11 @@ test "update ap add1" {
     // Verify the AP offset was incremented by 1.
     const ap = vm.getAp();
     try expectEqual(
+        @as(
+            u64,
+            1,
+        ),
         ap.offset,
-        1,
     );
 }
 
@@ -502,8 +523,11 @@ test "update ap add2" {
     // Verify the AP offset was incremented by 2.
     const ap = vm.getAp();
     try expectEqual(
+        @as(
+            u64,
+            2,
+        ),
         ap.offset,
-        2,
     );
 }
 
@@ -534,8 +558,11 @@ test "update fp appplus2" {
     // Verify the FP offset was incremented by 2.
     const fp = vm.getFp();
     try expectEqual(
+        @as(
+            u64,
+            2,
+        ),
         fp.offset,
-        2,
     );
 }
 
@@ -570,8 +597,11 @@ test "update fp dst relocatable" {
     // Verify the FP offset was incremented by 2.
     const fp = vm.getFp();
     try expectEqual(
+        @as(
+            u64,
+            42,
+        ),
         fp.offset,
-        42,
     );
 }
 
@@ -603,8 +633,11 @@ test "update fp dst felt" {
     // Verify the FP offset was incremented by 2.
     const fp = vm.getFp();
     try expectEqual(
+        @as(
+            u64,
+            42,
+        ),
         fp.offset,
-        42,
     );
 }
 
@@ -700,8 +733,14 @@ test "deduceOp1 when opcode == .Call" {
     // ************************************************************
     const expectedOp1: ?MaybeRelocatable = null; // temp var needed for type inference
     const expectedRes: ?MaybeRelocatable = null;
-    try expectEqual(expectedOp1, op1);
-    try expectEqual(expectedRes, res);
+    try expectEqual(
+        expectedOp1,
+        op1,
+    );
+    try expectEqual(
+        expectedRes,
+        res,
+    );
 }
 
 test "deduceOp1 when opcode == .AssertEq, res_logic == .Add, input is felt" {
@@ -783,8 +822,14 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Mul, zero op0" {
     // ************************************************************
     const expectedOp1: ?MaybeRelocatable = null; // temp var needed for type inference
     const expectedRes: ?MaybeRelocatable = null;
-    try expectEqual(expectedOp1, op1);
-    try expectEqual(expectedRes, res);
+    try expectEqual(
+        expectedOp1,
+        op1,
+    );
+    try expectEqual(
+        expectedRes,
+        res,
+    );
 }
 
 test "deduceOp1 when opcode == .AssertEq, res_logic = .Mul, no input" {
@@ -809,8 +854,14 @@ test "deduceOp1 when opcode == .AssertEq, res_logic = .Mul, no input" {
     // ************************************************************
     const expectedOp1: ?MaybeRelocatable = null; // temp var needed for type inference
     const expectedRes: ?MaybeRelocatable = null;
-    try expectEqual(expectedOp1, op1);
-    try expectEqual(expectedRes, res);
+    try expectEqual(
+        expectedOp1,
+        op1,
+    );
+    try expectEqual(
+        expectedRes,
+        res,
+    );
 }
 
 test "deduceOp1 when opcode == .AssertEq, res_logic == .Op1, no dst" {
@@ -837,8 +888,14 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Op1, no dst" {
     // ************************************************************
     const expectedOp1: ?MaybeRelocatable = null; // temp var needed for type inference
     const expectedRes: ?MaybeRelocatable = null;
-    try expectEqual(expectedOp1, op1);
-    try expectEqual(expectedRes, res);
+    try expectEqual(
+        expectedOp1,
+        op1,
+    );
+    try expectEqual(
+        expectedRes,
+        res,
+    );
 }
 
 test "deduceOp1 when opcode == .AssertEq, res_logic == .Op1, no op0" {
@@ -895,7 +952,10 @@ test "set get value in vm memory" {
     // Verify the value is correctly set to 42.
     const actual_value = try vm.segments.memory.get(address);
     const expected_value = value;
-    try expectEqual(expected_value, actual_value);
+    try expectEqual(
+        expected_value,
+        actual_value,
+    );
 }
 
 test "compute res op1 works" {
@@ -936,7 +996,10 @@ test "compute res op1 works" {
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
-    try expectEqual(expected_res, actual_res);
+    try expectEqual(
+        expected_res,
+        actual_res,
+    );
 }
 
 test "compute res add felts works" {
@@ -977,7 +1040,10 @@ test "compute res add felts works" {
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
-    try expectEqual(expected_res, actual_res);
+    try expectEqual(
+        expected_res,
+        actual_res,
+    );
 }
 
 test "compute res add felt to offset works" {
@@ -1021,7 +1087,10 @@ test "compute res add felt to offset works" {
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
-    try expectEqual(expected_res, actual_res);
+    try expectEqual(
+        expected_res,
+        actual_res,
+    );
 }
 
 test "compute res add fails two relocs" {
@@ -1103,7 +1172,10 @@ test "compute res mul works" {
     // ************************************************************
     // *                      TEST CHECKS                         *
     // ************************************************************
-    try expectEqual(expected_res, actual_res);
+    try expectEqual(
+        expected_res,
+        actual_res,
+    );
 }
 
 test "compute res mul fails two relocs" {

--- a/src/vm/instructions.zig
+++ b/src/vm/instructions.zig
@@ -582,18 +582,27 @@ test "decode flags nop regular regular op1 op0 ap ap" {
 test "decode offset negative" {
     const encoded_instruction: u64 = 0x0000800180007FFF;
     const decoded_instruction = try decode(encoded_instruction);
-    try expectEqual(@as(
-        i16,
-        -1,
-    ), decoded_instruction.off_0);
-    try expectEqual(@as(
-        i16,
-        0,
-    ), decoded_instruction.off_1);
-    try expectEqual(@as(
-        i16,
-        1,
-    ), decoded_instruction.off_2);
+    try expectEqual(
+        @as(
+            i16,
+            -1,
+        ),
+        decoded_instruction.off_0,
+    );
+    try expectEqual(
+        @as(
+            i16,
+            0,
+        ),
+        decoded_instruction.off_1,
+    );
+    try expectEqual(
+        @as(
+            i16,
+            1,
+        ),
+        decoded_instruction.off_2,
+    );
 }
 
 test "non zero high bit" {

--- a/src/vm/instructions.zig
+++ b/src/vm/instructions.zig
@@ -585,21 +585,21 @@ test "decode offset negative" {
     try expectEqual(
         @as(
             i16,
-        @intCast(-1),
+            @intCast(-1),
         ),
         decoded_instruction.off_0,
     );
     try expectEqual(
         @as(
             i16,
-        @intCast(0),
+            @intCast(0),
         ),
         decoded_instruction.off_1,
     );
     try expectEqual(
         @as(
             i16,
-        @intCast(1),
+            @intCast(1),
         ),
         decoded_instruction.off_2,
     );

--- a/src/vm/memory/relocatable.zig
+++ b/src/vm/memory/relocatable.zig
@@ -298,14 +298,14 @@ test "add uint" {
         2,
         4,
     );
-    const result = relocatable.addUint(24);
+    const result = try relocatable.addUint(24);
     const expected = Relocatable.new(
         2,
         28,
     );
     try expectEqual(
-        result,
         expected,
+        result,
     );
 }
 
@@ -314,14 +314,14 @@ test "add int" {
         2,
         4,
     );
-    const result = relocatable.addInt(24);
+    const result = try relocatable.addInt(24);
     const expected = Relocatable.new(
         2,
         28,
     );
     try expectEqual(
-        result,
         expected,
+        result,
     );
 }
 
@@ -330,14 +330,14 @@ test "add int negative" {
         2,
         4,
     );
-    const result = relocatable.addInt(-4);
+    const result = try relocatable.addInt(-4);
     const expected = Relocatable.new(
         2,
         0,
     );
     try expectEqual(
-        result,
         expected,
+        result,
     );
 }
 
@@ -346,14 +346,14 @@ test "sub uint" {
         2,
         4,
     );
-    const result = relocatable.subUint(2);
+    const result = try relocatable.subUint(2);
     const expected = Relocatable.new(
         2,
         2,
     );
     try expectEqual(
-        result,
         expected,
+        result,
     );
 }
 


### PR DESCRIPTION
Should close #78.