### PR TITLE
refac: various refactoring and safer behaviour for casting between integer types

### DIFF
--- a/src/math/fields/fields.zig
+++ b/src/math/fields/fields.zig
@@ -322,7 +322,7 @@ pub fn Field(
             // Check if the value is small enough to fit into a u64
             if (asU256 > @as(
                 u256,
-                std.math.maxInt(u64),
+                @intCast(std.math.maxInt(u64)),
             )) {
                 return error.ValueTooLarge;
             }

--- a/src/utils/time.zig
+++ b/src/utils/time.zig
@@ -290,15 +290,15 @@ pub const DateTime = struct {
         res += self.ms;
         res += @as(
             u64,
-            self.seconds,
+            @intCast(self.seconds),
         ) * std.time.ms_per_s;
         res += @as(
             u64,
-            self.minutes,
+            @intCast(self.minutes),
         ) * std.time.ms_per_min;
         res += @as(
             u64,
-            self.hours,
+            @intCast(self.hours),
         ) * std.time.ms_per_hour;
         res += self.daysSinceEpoch() * std.time.ms_per_day;
         return res;

--- a/src/vm/builtins/builtin_runner/keccak.zig
+++ b/src/vm/builtins/builtin_runner/keccak.zig
@@ -53,7 +53,10 @@ pub const KeccakBuiltinRunner = struct {
         return .{
             .ratio = instance_def.ratio,
             .base = 0,
-            .n_input_cells = @as(u32, instance_def._state_rep.items.len),
+            .n_input_cells = @as(
+                u32,
+                @intCast(instance_def._state_rep.items.len),
+            ),
             .cell_per_instance = instance_def.cells_per_builtin(),
             .stop_ptr = null,
             .included = included,

--- a/src/vm/builtins/builtin_runner/segment_arena.zig
+++ b/src/vm/builtins/builtin_runner/segment_arena.zig
@@ -5,7 +5,7 @@ const ARENA_BUILTIN_SIZE: u32 = 3;
 // The size of the builtin segment at the time of its creation.
 const INITIAL_SEGMENT_SIZE: usize = @as(
     usize,
-    ARENA_BUILTIN_SIZE,
+    @intCast(ARENA_BUILTIN_SIZE),
 );
 
 /// Segment Arena built-in runner

--- a/src/vm/builtins/builtin_runner/segment_arena.zig
+++ b/src/vm/builtins/builtin_runner/segment_arena.zig
@@ -52,7 +52,7 @@ pub const SegmentArenaBuiltinRunner = struct {
     pub fn get_base(self: *const Self) usize {
         return @as(
             usize,
-            self.base.segment_index,
+            @intCast(self.base.segment_index),
         );
     }
 };

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -396,7 +396,7 @@ pub const CairoVM = struct {
         for (self.builtin_runners.items) |builtin_item| {
             if (@as(
                 u64,
-                builtin_item.base(),
+                @intCast(builtin_item.base()),
             ) == address.segment_index) {
                 return builtin.deduce(
                     address,

--- a/src/vm/instructions.zig
+++ b/src/vm/instructions.zig
@@ -584,15 +584,15 @@ test "decode offset negative" {
     const decoded_instruction = try decode(encoded_instruction);
     try expectEqual(@as(
         i16,
-        -1,
+        @intCast(-1),
     ), decoded_instruction.off_0);
     try expectEqual(@as(
         i16,
-        0,
+        @intCast(0),
     ), decoded_instruction.off_1);
     try expectEqual(@as(
         i16,
-        1,
+        @intCast(1),
     ), decoded_instruction.off_2);
 }
 

--- a/src/vm/memory/relocatable.zig
+++ b/src/vm/memory/relocatable.zig
@@ -108,13 +108,19 @@ pub const Relocatable = struct {
         other: i64,
     ) !Self {
         if (other < 0) {
-            return self.subUint(@as(u64, @intCast(
-                -other,
-            )));
+            return self.subUint(@as(
+                u64,
+                @intCast(
+                    -other,
+                ),
+            ));
         }
-        return self.addUint(@as(u64, @intCast(
-            other,
-        )));
+        return self.addUint(@as(
+            u64,
+            @intCast(
+                other,
+            ),
+        ));
     }
 
     /// Add a felt to this Relocatable, modifying it in place.
@@ -125,12 +131,10 @@ pub const Relocatable = struct {
         self: *Self,
         other: Felt252,
     ) !void {
-        const new_offset_felt = Felt252.fromInteger(@as(
+        self.offset = try Felt252.fromInteger(@as(
             u256,
-            self.offset,
-        )).add(other);
-        const new_offset = try new_offset_felt.tryIntoU64();
-        self.offset = new_offset;
+            @intCast(self.offset),
+        )).add(other).tryIntoU64();
     }
 
     /// Performs additions if other contains a Felt value, fails otherwise.
@@ -140,8 +144,7 @@ pub const Relocatable = struct {
         self: *Self,
         other: MaybeRelocatable,
     ) !void {
-        const other_as_felt = try other.tryIntoFelt();
-        try self.addFeltInPlace(other_as_felt);
+        try self.addFeltInPlace(try other.tryIntoFelt());
     }
 };
 
@@ -282,7 +285,7 @@ pub fn fromU256(value: u256) MaybeRelocatable {
 pub fn fromU64(value: u64) MaybeRelocatable {
     return fromU256(@as(
         u256,
-        value,
+        @intCast(value),
     ));
 }
 

--- a/src/vm/memory/segments.zig
+++ b/src/vm/memory/segments.zig
@@ -1,8 +1,8 @@
 // Core imports.
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const expect = @import("std").testing.expect;
-const expectEqual = @import("std").testing.expectEqual;
+const expect = std.testing.expect;
+const expectEqual = std.testing.expectEqual;
 
 // Local imports.
 const Memory = @import("memory.zig").Memory;
@@ -58,7 +58,7 @@ pub const MemorySegmentManager = struct {
         // Create the pointer to the MemorySegmentManager.
         var segment_manager = try allocator.create(Self);
         // Initialize the values of the MemorySegmentManager struct.
-        segment_manager.* = Self{
+        segment_manager.* = .{
             .allocator = allocator,
             .segment_used_sizes = std.AutoHashMap(
                 u32,

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -41,7 +41,7 @@ pub const RunContext = struct {
     /// - If a memory allocation fails.
     pub fn init(allocator: Allocator) !*Self {
         var run_context = try allocator.create(Self);
-        run_context.* = Self{
+        run_context.* = .{
             .allocator = allocator,
             .pc = try allocator.create(Relocatable),
             .ap = try allocator.create(Relocatable),

--- a/src/vm/trace_context.zig
+++ b/src/vm/trace_context.zig
@@ -63,24 +63,18 @@ pub const TraceContext = struct {
     ///
     /// Fails in case of memory allocation errors.
     pub fn init(allocator: Allocator, enable: bool) !Self {
-        var state: State = undefined;
-        var traceInstructionFn: *const State.TraceInstructionFn = undefined;
-        var deinitFn: *const State.DeinitFn = undefined;
-
         if (enable) {
-            state = State{ .enabled = try TraceEnabled.init(allocator) };
-            traceInstructionFn = TraceEnabled.traceInstruction;
-            deinitFn = TraceEnabled.deinit;
-        } else {
-            state = State{ .disabled = TraceDisabled{} };
-            traceInstructionFn = TraceDisabled.traceInstruction;
-            deinitFn = TraceDisabled.deinit;
+            return .{
+                .state = .{ .enabled = try TraceEnabled.init(allocator) },
+                .traceInstructionFn = TraceEnabled.traceInstruction,
+                .deinitFn = TraceEnabled.deinit,
+            };
         }
 
         return .{
-            .state = state,
-            .traceInstructionFn = traceInstructionFn,
-            .deinitFn = deinitFn,
+            .state = .{ .disabled = .{} },
+            .traceInstructionFn = TraceDisabled.traceInstruction,
+            .deinitFn = TraceDisabled.deinit,
         };
     }
 

--- a/src/vm/types/keccak_instance_def.zig
+++ b/src/vm/types/keccak_instance_def.zig
@@ -17,6 +17,9 @@ pub const KeccakInstanceDef = struct {
 
     /// Number of cells per built in
     pub fn cells_per_builtin(self: *Self) u32 {
-        return 2 * @as(u32, self._state_rep.items.len);
+        return 2 * @as(
+            u32,
+            @intCast(self._state_rep.items.len),
+        );
     }
 };


### PR DESCRIPTION
This PR contains:
- Several small refactorings for less verbose code in certain small places.
- Safer behavior for integer casting by systematically using `@intCast`

Please let me know if there are any items that are not suitable or need improvement.