### PR TITLE
refactor `Memory` `get` function

### DIFF
--- a/src/vm/memory/memory.zig
+++ b/src/vm/memory/memory.zig
@@ -116,11 +116,7 @@ pub const Memory = struct {
         self: *Self,
         address: Relocatable,
     ) error{MemoryOutOfBounds}!MaybeRelocatable {
-        var maybe_value = self.data.get(address);
-        if (maybe_value == null) {
-            return CairoVMError.MemoryOutOfBounds;
-        }
-        return maybe_value.?;
+        return self.data.get(address) orelse CairoVMError.MemoryOutOfBounds;
     }
 };
 


### PR DESCRIPTION
Small refactoring of the `get` function of the `Memory` structure for a less verbose representation.