### PR TITLE
add `cmp` utils for `Felt252`

### DIFF
--- a/src/math/fields/fields.zig
+++ b/src/math/fields/fields.zig
@@ -351,5 +351,87 @@ pub fn Field(
             }
             return 1;
         }
+
+        /// Compare two field elements and return the ordering result.
+        ///
+        /// # Parameters
+        /// - `self` - The first field element to compare.
+        /// - `other` - The second field element to compare.
+        ///
+        /// # Returns
+        /// A `std.math.Order` enum indicating the ordering relationship.
+        pub fn cmp(self: Self, other: Self) std.math.Order {
+            var a = self.fe;
+            var b = other.fe;
+            _ = std.mem.reverse(u64, a[0..]);
+            _ = std.mem.reverse(u64, b[0..]);
+            return std.mem.order(
+                u64,
+                &a,
+                &b,
+            );
+        }
+
+        /// Check if this field element is less than the other.
+        ///
+        /// # Parameters
+        /// - `self` - The field element to check.
+        /// - `other` - The field element to compare against.
+        ///
+        /// # Returns
+        /// `true` if `self` is less than `other`, `false` otherwise.
+        pub fn lt(self: Self, other: Self) bool {
+            return switch (self.cmp(other)) {
+                .lt => true,
+                else => false,
+            };
+        }
+
+        /// Check if this field element is less than or equal to the other.
+        ///
+        /// # Parameters
+        /// - `self` - The field element to check.
+        /// - `other` - The field element to compare against.
+        ///
+        /// # Returns
+        /// `true` if `self` is less than or equal to `other`, `false` otherwise.
+        pub fn le(self: Self, other: Self) bool {
+            return switch (self.cmp(other)) {
+                .lt => true,
+                .eq => true,
+                else => false,
+            };
+        }
+
+        /// Check if this field element is greater than the other.
+        ///
+        /// # Parameters
+        /// - `self` - The field element to check.
+        /// - `other` - The field element to compare against.
+        ///
+        /// # Returns
+        /// `true` if `self` is greater than `other`, `false` otherwise.
+        pub fn gt(self: Self, other: Self) bool {
+            return switch (self.cmp(other)) {
+                .gt => true,
+                else => false,
+            };
+        }
+
+        /// Check if this field element is greater than or equal to the other.
+        ///
+        /// # Parameters
+        /// - `self` - The field element to check.
+        /// - `other` - The field element to compare against.
+        ///
+        /// # Returns
+        /// `true` if `self` is greater than or equal to `other`, `false` otherwise.
+        pub fn ge(self: Self, other: Self) bool {
+            return switch (self.cmp(other)) {
+                .gt => true,
+                .eq => true,
+                else => false,
+            };
+        }
     };
 }

--- a/src/math/fields/starknet.zig
+++ b/src/math/fields/starknet.zig
@@ -436,3 +436,82 @@ test "Felt252 legendre" {
         Felt252.fromInteger(135).legendre(),
     );
 }
+
+test "Felt252 cmp" {
+    try expect(Felt252.fromInteger(10).cmp(
+        Felt252.fromInteger(343535),
+    ) == .gt);
+    try expect(Felt252.fromInteger(433).cmp(
+        Felt252.fromInteger(343535),
+    ) == .gt);
+    try expect(Felt252.fromInteger(543636535).cmp(
+        Felt252.fromInteger(434),
+    ) == .lt);
+    try expect(Felt252.fromInteger(std.math.maxInt(u256)).cmp(
+        Felt252.fromInteger(21313),
+    ) == .lt);
+    try expect(Felt252.fromInteger(10).cmp(
+        Felt252.fromInteger(10),
+    ) == .eq);
+    try expect(Felt252.one().cmp(
+        Felt252.one(),
+    ) == .eq);
+    try expect(Felt252.zero().cmp(
+        Felt252.zero(),
+    ) == .eq);
+    try expect(Felt252.fromInteger(10).cmp(
+        Felt252.fromInteger(10 + 0x800000000000011000000000000000000000000000000000000000000000001),
+    ) == .eq);
+}
+
+test "Felt252 lt" {
+    try expect(!Felt252.fromInteger(10).lt(Felt252.fromInteger(343535)));
+    try expect(!Felt252.fromInteger(433).lt(Felt252.fromInteger(343535)));
+    try expect(Felt252.fromInteger(543636535).lt(Felt252.fromInteger(434)));
+    try expect(Felt252.fromInteger(std.math.maxInt(u256)).lt(Felt252.fromInteger(21313)));
+    try expect(!Felt252.fromInteger(10).lt(Felt252.fromInteger(10)));
+    try expect(!Felt252.one().lt(Felt252.one()));
+    try expect(!Felt252.zero().lt(Felt252.zero()));
+    try expect(!Felt252.fromInteger(10).lt(
+        Felt252.fromInteger(10 + 0x800000000000011000000000000000000000000000000000000000000000001),
+    ));
+}
+
+test "Felt252 le" {
+    try expect(!Felt252.fromInteger(10).le(Felt252.fromInteger(343535)));
+    try expect(!Felt252.fromInteger(433).le(Felt252.fromInteger(343535)));
+    try expect(Felt252.fromInteger(543636535).le(Felt252.fromInteger(434)));
+    try expect(Felt252.fromInteger(std.math.maxInt(u256)).le(Felt252.fromInteger(21313)));
+    try expect(Felt252.fromInteger(10).le(Felt252.fromInteger(10)));
+    try expect(Felt252.one().le(Felt252.one()));
+    try expect(Felt252.zero().le(Felt252.zero()));
+    try expect(Felt252.fromInteger(10).le(
+        Felt252.fromInteger(10 + 0x800000000000011000000000000000000000000000000000000000000000001),
+    ));
+}
+
+test "Felt252 gt" {
+    try expect(Felt252.fromInteger(10).gt(Felt252.fromInteger(343535)));
+    try expect(Felt252.fromInteger(433).gt(Felt252.fromInteger(343535)));
+    try expect(!Felt252.fromInteger(543636535).gt(Felt252.fromInteger(434)));
+    try expect(!Felt252.fromInteger(std.math.maxInt(u256)).gt(Felt252.fromInteger(21313)));
+    try expect(!Felt252.fromInteger(10).gt(Felt252.fromInteger(10)));
+    try expect(!Felt252.one().gt(Felt252.one()));
+    try expect(!Felt252.zero().gt(Felt252.zero()));
+    try expect(!Felt252.fromInteger(10).gt(
+        Felt252.fromInteger(10 + 0x800000000000011000000000000000000000000000000000000000000000001),
+    ));
+}
+
+test "Felt252 ge" {
+    try expect(Felt252.fromInteger(10).ge(Felt252.fromInteger(343535)));
+    try expect(Felt252.fromInteger(433).ge(Felt252.fromInteger(343535)));
+    try expect(!Felt252.fromInteger(543636535).ge(Felt252.fromInteger(434)));
+    try expect(!Felt252.fromInteger(std.math.maxInt(u256)).ge(Felt252.fromInteger(21313)));
+    try expect(Felt252.fromInteger(10).ge(Felt252.fromInteger(10)));
+    try expect(Felt252.one().ge(Felt252.one()));
+    try expect(Felt252.zero().ge(Felt252.zero()));
+    try expect(Felt252.fromInteger(10).ge(
+        Felt252.fromInteger(10 + 0x800000000000011000000000000000000000000000000000000000000000001),
+    ));
+}


### PR DESCRIPTION
This PRs adds some util primitives for field element comparisons with unit tests.