### PR TITLE
feat(`run_context`): add test coverage for methods of `RunContext` struct

### DIFF
--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -233,3 +233,155 @@ test "compute_op1_addr for fp op1 addr" {
         9,
     )));
 }
+
+test "RunContext: compute_dst_addr should return self.ap - instruction.off_0 if instruction.off_0 is negative" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            25,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            15,
+        ),
+        try run_context.compute_dst_addr(&.{
+            .off_0 = -10,
+            .off_1 = 2,
+            .off_2 = 3,
+            .dst_reg = .AP,
+            .op_0_reg = .AP,
+            .op_1_addr = .FP,
+            .res_logic = .Add,
+            .pc_update = .Regular,
+            .ap_update = .Regular,
+            .fp_update = .Regular,
+            .opcode = .NOp,
+        }),
+    );
+}
+
+test "RunContext: compute_dst_addr should return self.ap + instruction.off_0 if instruction.off_0 is positive" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            25,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            35,
+        ),
+        try run_context.compute_dst_addr(&.{
+            .off_0 = 10,
+            .off_1 = 2,
+            .off_2 = 3,
+            .dst_reg = .AP,
+            .op_0_reg = .AP,
+            .op_1_addr = .FP,
+            .res_logic = .Add,
+            .pc_update = .Regular,
+            .ap_update = .Regular,
+            .fp_update = .Regular,
+            .opcode = .NOp,
+        }),
+    );
+}
+
+test "RunContext: compute_dst_addr should return self.fp - instruction.off_0 if instruction.off_0 is negative" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            25,
+        ),
+        Relocatable.new(
+            0,
+            40,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            30,
+        ),
+        try run_context.compute_dst_addr(&.{
+            .off_0 = -10,
+            .off_1 = 2,
+            .off_2 = 3,
+            .dst_reg = .FP,
+            .op_0_reg = .AP,
+            .op_1_addr = .FP,
+            .res_logic = .Add,
+            .pc_update = .Regular,
+            .ap_update = .Regular,
+            .fp_update = .Regular,
+            .opcode = .NOp,
+        }),
+    );
+}
+
+test "RunContext: compute_dst_addr should return self.fp + instruction.off_0 if instruction.off_0 is positive" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            25,
+        ),
+        Relocatable.new(
+            0,
+            30,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            40,
+        ),
+        try run_context.compute_dst_addr(&.{
+            .off_0 = 10,
+            .off_1 = 2,
+            .off_2 = 3,
+            .dst_reg = .FP,
+            .op_0_reg = .AP,
+            .op_1_addr = .FP,
+            .res_logic = .Add,
+            .pc_update = .Regular,
+            .ap_update = .Regular,
+            .fp_update = .Regular,
+            .opcode = .NOp,
+        }),
+    );
+}

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -573,3 +573,85 @@ test "RunContext: compute_op1_addr for FP op1 addr and instruction off_2 > 0" {
         ),
     );
 }
+
+test "RunContext: compute_op1_addr for AP op1 addr and instruction off_2 < 0" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            5,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            2,
+        ),
+        try run_context.compute_op_1_addr(
+            &.{
+                .off_0 = 1,
+                .off_1 = 2,
+                .off_2 = -3,
+                .dst_reg = .FP,
+                .op_0_reg = .AP,
+                .op_1_addr = .AP,
+                .res_logic = .Add,
+                .pc_update = .Regular,
+                .ap_update = .Regular,
+                .fp_update = .Regular,
+                .opcode = .NOp,
+            },
+            null,
+        ),
+    );
+}
+
+test "RunContext: compute_op1_addr for AP op1 addr and instruction off_2 > 0" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            5,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            8,
+        ),
+        try run_context.compute_op_1_addr(
+            &.{
+                .off_0 = 1,
+                .off_1 = 2,
+                .off_2 = 3,
+                .dst_reg = .FP,
+                .op_0_reg = .AP,
+                .op_1_addr = .AP,
+                .res_logic = .Add,
+                .pc_update = .Regular,
+                .ap_update = .Regular,
+                .fp_update = .Regular,
+                .opcode = .NOp,
+            },
+            null,
+        ),
+    );
+}

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -385,3 +385,155 @@ test "RunContext: compute_dst_addr should return self.fp + instruction.off_0 if 
         }),
     );
 }
+
+test "RunContext: compute_op_0_addr should return self.ap - instruction.off_1 if instruction.off_1 is negative" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            25,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            23,
+        ),
+        try run_context.compute_op_0_addr(&.{
+            .off_0 = 10,
+            .off_1 = -2,
+            .off_2 = 3,
+            .dst_reg = .AP,
+            .op_0_reg = .AP,
+            .op_1_addr = .FP,
+            .res_logic = .Add,
+            .pc_update = .Regular,
+            .ap_update = .Regular,
+            .fp_update = .Regular,
+            .opcode = .NOp,
+        }),
+    );
+}
+
+test "RunContext: compute_op_0_addr should return self.ap + instruction.off_1 if instruction.off_1 is positive" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            25,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            27,
+        ),
+        try run_context.compute_op_0_addr(&.{
+            .off_0 = 10,
+            .off_1 = 2,
+            .off_2 = 3,
+            .dst_reg = .AP,
+            .op_0_reg = .AP,
+            .op_1_addr = .FP,
+            .res_logic = .Add,
+            .pc_update = .Regular,
+            .ap_update = .Regular,
+            .fp_update = .Regular,
+            .opcode = .NOp,
+        }),
+    );
+}
+
+test "RunContext: compute_op_0_addr should return self.fp - instruction.off_1 if instruction.off_1 is negative" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            25,
+        ),
+        Relocatable.new(
+            0,
+            40,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            38,
+        ),
+        try run_context.compute_op_0_addr(&.{
+            .off_0 = 10,
+            .off_1 = -2,
+            .off_2 = 3,
+            .dst_reg = .FP,
+            .op_0_reg = .FP,
+            .op_1_addr = .FP,
+            .res_logic = .Add,
+            .pc_update = .Regular,
+            .ap_update = .Regular,
+            .fp_update = .Regular,
+            .opcode = .NOp,
+        }),
+    );
+}
+
+test "RunContext: compute_op_0_addr should return self.fp + instruction.off_1 if instruction.off_1 is positive" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            25,
+        ),
+        Relocatable.new(
+            0,
+            30,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            32,
+        ),
+        try run_context.compute_op_0_addr(&.{
+            .off_0 = 10,
+            .off_1 = 2,
+            .off_2 = 3,
+            .dst_reg = .FP,
+            .op_0_reg = .FP,
+            .op_1_addr = .FP,
+            .res_logic = .Add,
+            .pc_update = .Regular,
+            .ap_update = .Regular,
+            .fp_update = .Regular,
+            .opcode = .NOp,
+        }),
+    );
+}

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -156,18 +156,7 @@ pub const RunContext = struct {
             .FP => self.fp.*,
             .AP => self.ap.*,
             .Imm => if (instruction.off_2 == 1) self.pc.* else return error.ImmShouldBe1,
-            // .Op0 => {
-            //     if (op_0) |val| {
-            //         return val.tryIntoRelocatable();
-            //     } else {
-            //         return error.UnknownOp0;
-            //     }
-            // },
-
-            .Op0 => if (op_0) |val|
-                try val.tryIntoRelocatable()
-            else
-                return error.UnknownOp0,
+            .Op0 => if (op_0) |val| try val.tryIntoRelocatable() else return error.UnknownOp0,
         };
 
         if (instruction.off_2 < 0) {
@@ -730,6 +719,132 @@ test "RunContext: compute_op1_addr for IMM op1 addr and instruction off_2 == 1" 
                 .opcode = .NOp,
             },
             null,
+        ),
+    );
+}
+
+test "RunContext: compute_op1_addr for OP0 op1 addr and instruction op_0 is null" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            5,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectError(
+        error.UnknownOp0,
+        run_context.compute_op_1_addr(
+            &.{
+                .off_0 = 1,
+                .off_1 = 2,
+                .off_2 = -3,
+                .dst_reg = .FP,
+                .op_0_reg = .AP,
+                .op_1_addr = .Op0,
+                .res_logic = .Add,
+                .pc_update = .Regular,
+                .ap_update = .Regular,
+                .fp_update = .Regular,
+                .opcode = .NOp,
+            },
+            null,
+        ),
+    );
+}
+
+test "RunContext: compute_op1_addr for OP0 op1 addr and instruction off_2 < 0" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            5,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            28,
+        ),
+        try run_context.compute_op_1_addr(
+            &.{
+                .off_0 = 1,
+                .off_1 = 2,
+                .off_2 = -4,
+                .dst_reg = .FP,
+                .op_0_reg = .AP,
+                .op_1_addr = .Op0,
+                .res_logic = .Add,
+                .pc_update = .Regular,
+                .ap_update = .Regular,
+                .fp_update = .Regular,
+                .opcode = .NOp,
+            },
+            .{ .relocatable = Relocatable.new(
+                0,
+                32,
+            ) },
+        ),
+    );
+}
+
+test "RunContext: compute_op1_addr for OP0 op1 addr and instruction off_2 > 0" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            5,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            36,
+        ),
+        try run_context.compute_op_1_addr(
+            &.{
+                .off_0 = 1,
+                .off_1 = 2,
+                .off_2 = 4,
+                .dst_reg = .FP,
+                .op_0_reg = .AP,
+                .op_1_addr = .Op0,
+                .res_logic = .Add,
+                .pc_update = .Regular,
+                .ap_update = .Regular,
+                .fp_update = .Regular,
+                .opcode = .NOp,
+            },
+            .{ .relocatable = Relocatable.new(
+                0,
+                32,
+            ) },
         ),
     );
 }

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -732,21 +732,4 @@ test "RunContext: compute_op1_addr for IMM op1 addr and instruction off_2 == 1" 
             null,
         ),
     );
-
-    _ = try run_context.compute_op_1_addr(
-        &.{
-            .off_0 = 1,
-            .off_1 = 2,
-            .off_2 = 1,
-            .dst_reg = .FP,
-            .op_0_reg = .AP,
-            .op_1_addr = .Imm,
-            .res_logic = .Add,
-            .pc_update = .Regular,
-            .ap_update = .Regular,
-            .fp_update = .Regular,
-            .opcode = .NOp,
-        },
-        null,
-    );
 }


### PR DESCRIPTION
This PR focuses on:
- Adding test coverage for methods of `RunContext` structure.
- A small refactoring of the `compute_op_1_addr` method.