### PR TITLE
feat: integrate all builtin runners in `deduceMemoryCell` VM function

### DIFF
--- a/src/vm/builtins/builtin_runner/bitwise.zig
+++ b/src/vm/builtins/builtin_runner/bitwise.zig
@@ -1,4 +1,7 @@
 const bitwise_instance_def = @import("../../types/bitwise_instance_def.zig");
+const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
+const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
+const Memory = @import("../../memory/memory.zig").Memory;
 
 /// Bitwise built-in runner
 pub const BitwiseBuiltinRunner = struct {
@@ -41,9 +44,9 @@ pub const BitwiseBuiltinRunner = struct {
         return .{
             .ratio = instance_def.ratio,
             .base = 0,
-            .cell_per_instance = bitwise_instance_def.CELLS_PER_BITWISE,
+            .cells_per_instance = bitwise_instance_def.CELLS_PER_BITWISE,
             .n_input_cells = bitwise_instance_def.INPUT_CELLS_PER_BITWISE,
-            .bitwise_builtin = instance_def,
+            .bitwise_builtin = instance_def.*,
             .stop_ptr = null,
             .included = included,
             .instances_per_component = 1,
@@ -57,5 +60,16 @@ pub const BitwiseBuiltinRunner = struct {
     /// The base value as a `usize`.
     pub fn getBase(self: *const Self) usize {
         return self.base;
+    }
+
+    pub fn deduceMemoryCell(
+        self: *const Self,
+        address: Relocatable,
+        memory: *Memory,
+    ) ?MaybeRelocatable {
+        _ = memory;
+        _ = address;
+        _ = self;
+        return null;
     }
 };

--- a/src/vm/builtins/builtin_runner/builtin_runner.zig
+++ b/src/vm/builtins/builtin_runner/builtin_runner.zig
@@ -76,6 +76,7 @@ pub const BuiltinRunner = union(enum) {
         memory: *Memory,
     ) !?MaybeRelocatable {
         return switch (self.*) {
+            // TODO: switch to `BitwiseBuiltinRunner` `deduceMemoryCell` function after migration of `deduce` to `BitwiseBuiltinRunner`
             .Bitwise => try BitwiseBuiltinRunnerTmp.deduce(address, memory),
             .EcOp => |ec| ec.deduceMemoryCell(address, memory),
             .Hash => |hash| hash.deduceMemoryCell(address, memory),

--- a/src/vm/builtins/builtin_runner/builtin_runner.zig
+++ b/src/vm/builtins/builtin_runner/builtin_runner.zig
@@ -8,6 +8,12 @@ const RangeCheckBuiltinRunner = @import("./range_check.zig").RangeCheckBuiltinRu
 const SegmentArenaBuiltinRunner = @import("./segment_arena.zig").SegmentArenaBuiltinRunner;
 const SignatureBuiltinRunner = @import("./signature.zig").SignatureBuiltinRunner;
 
+const BitwiseBuiltinRunnerTmp = @import("../bitwise/bitwise.zig");
+
+const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
+const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
+const Memory = @import("../../memory/memory.zig").Memory;
+
 /// Built-in runner
 pub const BuiltinRunner = union(enum) {
     const Self = @This();
@@ -49,6 +55,36 @@ pub const BuiltinRunner = union(enum) {
             .Signature => |*signature| signature.getBase(),
             .Poseidon => |*poseidon| poseidon.getBase(),
             .SegmentArena => |*segment_arena| segment_arena.getBase(),
+        };
+    }
+
+    /// Deduces memory cell information for the built-in runner.
+    ///
+    /// This function deduces memory cell information for the specific type of built-in runner.
+    ///
+    /// # Arguments
+    ///
+    /// - `address`: The address of the memory cell.
+    /// - `memory`: The memory manager for the current context.
+    ///
+    /// # Returns
+    ///
+    /// A `MaybeRelocatable` representing the deduced memory cell information, or an error if deduction fails.
+    pub fn deduceMemoryCell(
+        self: *const Self,
+        address: Relocatable,
+        memory: *Memory,
+    ) !?MaybeRelocatable {
+        return switch (self.*) {
+            .Bitwise => try BitwiseBuiltinRunnerTmp.deduce(address, memory),
+            .EcOp => |ec| ec.deduceMemoryCell(address, memory),
+            .Hash => |hash| hash.deduceMemoryCell(address, memory),
+            .Output => |output| output.deduceMemoryCell(address, memory),
+            .RangeCheck => |range_check| range_check.deduceMemoryCell(address, memory),
+            .Keccak => |keccak| keccak.deduceMemoryCell(address, memory),
+            .Signature => |signature| signature.deduceMemoryCell(address, memory),
+            .Poseidon => |poseidon| poseidon.deduceMemoryCell(address, memory),
+            .SegmentArena => |segment_arena| segment_arena.deduceMemoryCell(address, memory),
         };
     }
 };

--- a/src/vm/builtins/builtin_runner/ec_op.zig
+++ b/src/vm/builtins/builtin_runner/ec_op.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const ec_op_instance_def = @import("../../types/ec_op_instance_def.zig");
 const relocatable = @import("../../memory/relocatable.zig");
 const Felt252 = @import("../../../math/fields/starknet.zig").Felt252;
+const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
+const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
+const Memory = @import("../../memory/memory.zig").Memory;
 
 const AutoHashMap = std.AutoHashMap;
 const Allocator = std.mem.Allocator;
@@ -68,5 +71,16 @@ pub const EcOpBuiltinRunner = struct {
     /// The base value as a `usize`.
     pub fn getBase(self: *const Self) usize {
         return self.base;
+    }
+
+    pub fn deduceMemoryCell(
+        self: *const Self,
+        address: Relocatable,
+        memory: *Memory,
+    ) ?MaybeRelocatable {
+        _ = memory;
+        _ = address;
+        _ = self;
+        return null;
     }
 };

--- a/src/vm/builtins/builtin_runner/hash.zig
+++ b/src/vm/builtins/builtin_runner/hash.zig
@@ -1,5 +1,8 @@
 const std = @import("std");
 const pedersen_instance_def = @import("../../types/pedersen_instance_def.zig");
+const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
+const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
+const Memory = @import("../../memory/memory.zig").Memory;
 
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
@@ -63,5 +66,16 @@ pub const HashBuiltinRunner = struct {
     /// The base value as a `usize`.
     pub fn getBase(self: *const Self) usize {
         return self.base;
+    }
+
+    pub fn deduceMemoryCell(
+        self: *const Self,
+        address: Relocatable,
+        memory: *Memory,
+    ) ?MaybeRelocatable {
+        _ = memory;
+        _ = address;
+        _ = self;
+        return null;
     }
 };

--- a/src/vm/builtins/builtin_runner/keccak.zig
+++ b/src/vm/builtins/builtin_runner/keccak.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const Felt252 = @import("../../../math/fields/starknet.zig").Felt252;
 const relocatable = @import("../../memory/relocatable.zig");
 const keccak_instance_def = @import("../../types/keccak_instance_def.zig");
+const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
+const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
+const Memory = @import("../../memory/memory.zig").Memory;
 
 const ArrayList = std.ArrayList;
 const AutoHashMap = std.AutoHashMap;
@@ -73,5 +76,16 @@ pub const KeccakBuiltinRunner = struct {
     /// The base value as a `usize`.
     pub fn getBase(self: *const Self) usize {
         return self.base;
+    }
+
+    pub fn deduceMemoryCell(
+        self: *const Self,
+        address: Relocatable,
+        memory: *Memory,
+    ) ?MaybeRelocatable {
+        _ = memory;
+        _ = address;
+        _ = self;
+        return null;
     }
 };

--- a/src/vm/builtins/builtin_runner/output.zig
+++ b/src/vm/builtins/builtin_runner/output.zig
@@ -1,3 +1,7 @@
+const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
+const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
+const Memory = @import("../../memory/memory.zig").Memory;
+
 /// Output built-in runner
 pub const OutputBuiltinRunner = struct {
     const Self = @This();
@@ -35,5 +39,16 @@ pub const OutputBuiltinRunner = struct {
     /// The base value as a `usize`.
     pub fn getBase(self: *const Self) usize {
         return self.base;
+    }
+
+    pub fn deduceMemoryCell(
+        self: *const Self,
+        address: Relocatable,
+        memory: *Memory,
+    ) ?MaybeRelocatable {
+        _ = memory;
+        _ = address;
+        _ = self;
+        return null;
     }
 };

--- a/src/vm/builtins/builtin_runner/poseidon.zig
+++ b/src/vm/builtins/builtin_runner/poseidon.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const relocatable = @import("../../memory/relocatable.zig");
 const Felt252 = @import("../../../math/fields/starknet.zig").Felt252;
 const poseidon_instance_def = @import("../../types/poseidon_instance_def.zig");
+const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
+const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
+const Memory = @import("../../memory/memory.zig").Memory;
 
 const AutoHashMap = std.AutoHashMap;
 const Allocator = std.mem.Allocator;
@@ -67,5 +70,16 @@ pub const PoseidonBuiltinRunner = struct {
     /// The base value as a `usize`.
     pub fn getBase(self: *const Self) usize {
         return self.base;
+    }
+
+    pub fn deduceMemoryCell(
+        self: *const Self,
+        address: Relocatable,
+        memory: *Memory,
+    ) ?MaybeRelocatable {
+        _ = memory;
+        _ = address;
+        _ = self;
+        return null;
     }
 };

--- a/src/vm/builtins/builtin_runner/range_check.zig
+++ b/src/vm/builtins/builtin_runner/range_check.zig
@@ -273,6 +273,17 @@ pub const RangeCheckBuiltinRunner = struct {
     pub fn addValidationRule(self: *const Self, memory: *Memory) void {
         memory.addValidationRule(self.base.segment_index, rangeCheckValidationRule);
     }
+
+    pub fn deduceMemoryCell(
+        self: *const Self,
+        address: Relocatable,
+        memory: *Memory,
+    ) ?MaybeRelocatable {
+        _ = memory;
+        _ = address;
+        _ = self;
+        return null;
+    }
 };
 
 test "initialize segments for range check" {

--- a/src/vm/builtins/builtin_runner/segment_arena.zig
+++ b/src/vm/builtins/builtin_runner/segment_arena.zig
@@ -1,4 +1,6 @@
-const relocatable = @import("../../memory/relocatable.zig");
+const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
+const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
+const Memory = @import("../../memory/memory.zig").Memory;
 
 /// Arena builtin size
 const ARENA_BUILTIN_SIZE: u32 = 3;
@@ -13,7 +15,7 @@ pub const SegmentArenaBuiltinRunner = struct {
     const Self = @This();
 
     /// Base
-    base: relocatable.Relocatable,
+    base: Relocatable,
     /// Included boolean flag
     included: bool,
     /// Number of cells per instance
@@ -36,7 +38,7 @@ pub const SegmentArenaBuiltinRunner = struct {
     /// A new `SegmentArenaBuiltinRunner` instance.
     pub fn new(included: bool) Self {
         return .{
-            .base = relocatable.Relocatable.default(),
+            .base = Relocatable.default(),
             .included = included,
             .cell_per_instance = ARENA_BUILTIN_SIZE,
             .n_input_cells_per_instance = ARENA_BUILTIN_SIZE,
@@ -54,5 +56,16 @@ pub const SegmentArenaBuiltinRunner = struct {
             usize,
             @intCast(self.base.segment_index),
         );
+    }
+
+    pub fn deduceMemoryCell(
+        self: *const Self,
+        address: Relocatable,
+        memory: *Memory,
+    ) ?MaybeRelocatable {
+        _ = memory;
+        _ = address;
+        _ = self;
+        return null;
     }
 };

--- a/src/vm/builtins/builtin_runner/signature.zig
+++ b/src/vm/builtins/builtin_runner/signature.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const Signature = @import("../../../math/crypto/signatures.zig").Signature;
-const relocatable = @import("../../memory/relocatable.zig");
+const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
+const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
+const Memory = @import("../../memory/memory.zig").Memory;
 const Felt252 = @import("../../../math/fields/starknet.zig").Felt252;
 const ecdsa_instance_def = @import("../../types/ecdsa_instance_def.zig");
 
@@ -28,7 +30,7 @@ pub const SignatureBuiltinRunner = struct {
     /// Number of instances per component
     instances_per_component: u32,
     /// Signatures HashMap
-    signatures: AutoHashMap(relocatable.Relocatable, Signature),
+    signatures: AutoHashMap(Relocatable, Signature),
 
     /// Create a new SignatureBuiltinRunner instance.
     ///
@@ -54,7 +56,7 @@ pub const SignatureBuiltinRunner = struct {
             ._total_n_bits = 251,
             .stop_ptr = null,
             .instances_per_component = 1,
-            .signatures = AutoHashMap(relocatable.Relocatable, Signature).init(allocator),
+            .signatures = AutoHashMap(Relocatable, Signature).init(allocator),
         };
     }
 
@@ -65,5 +67,16 @@ pub const SignatureBuiltinRunner = struct {
     /// The base value as a `usize`.
     pub fn getBase(self: *const Self) usize {
         return self.base;
+    }
+
+    pub fn deduceMemoryCell(
+        self: *const Self,
+        address: Relocatable,
+        memory: *Memory,
+    ) ?MaybeRelocatable {
+        _ = memory;
+        _ = address;
+        _ = self;
+        return null;
     }
 };

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -16,7 +16,6 @@ const Config = @import("config.zig").Config;
 const TraceContext = @import("trace_context.zig").TraceContext;
 const build_options = @import("../build_options.zig");
 const BuiltinRunner = @import("./builtins/builtin_runner/builtin_runner.zig").BuiltinRunner;
-const builtin = @import("./builtins/bitwise/bitwise.zig");
 const Felt252 = @import("../math/fields/starknet.zig").Felt252;
 const HashBuiltinRunner = @import("./builtins/builtin_runner/hash.zig").HashBuiltinRunner;
 const Instruction = @import("instructions.zig").Instruction;
@@ -434,7 +433,7 @@ pub const CairoVM = struct {
                 u64,
                 @intCast(builtin_item.base()),
             ) == address.segment_index) {
-                return builtin.deduce(
+                return builtin_item.deduceMemoryCell(
                     address,
                     self.segments.memory,
                 ) catch {

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -16,7 +16,8 @@ const Config = @import("config.zig").Config;
 const TraceContext = @import("trace_context.zig").TraceContext;
 const build_options = @import("../build_options.zig");
 const BuiltinRunner = @import("./builtins/builtin_runner/builtin_runner.zig").BuiltinRunner;
-const builtin = @import("./builtins/bitwise/bitwise.zig");
+const BitwiseBuiltinRunner = @import("./builtins/builtin_runner/bitwise.zig").BitwiseBuiltinRunner;
+const BitwiseInstanceDef = @import("./types/bitwise_instance_def.zig").BitwiseInstanceDef;
 const Felt252 = @import("../math/fields/starknet.zig").Felt252;
 const HashBuiltinRunner = @import("./builtins/builtin_runner/hash.zig").HashBuiltinRunner;
 const Instruction = @import("instructions.zig").Instruction;
@@ -50,9 +51,9 @@ test "CairoVM: deduceMemoryCell builtin valid" {
         .{},
     );
     defer vm.deinit();
-    try vm.builtin_runners.append(BuiltinRunner{ .Hash = HashBuiltinRunner.new(
-        std.testing.allocator,
-        8,
+    var instance_def: BitwiseInstanceDef = .{ .ratio = null, .total_n_bits = 2 };
+    try vm.builtin_runners.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.new(
+        &instance_def,
         true,
     ) });
     try vm.segments.memory.set(


### PR DESCRIPTION
This PR integrates all builtin runners within the `deduceMemoryCell` function of the `CairoVM` structure.
- A `deduceMemoryCell` function is integrated into the `BuiltinRunner` enum union which gives a switch between the different builtins.
- For now, as no builtin is implemented, all `deduceMemoryCell` functions return a `null`.
- The only existing implementation is the bitwise builtin but the implementation is currently in a separate file `/builtins/bitwise/bitwise.zig` awaiting migration to the `BitwiseBuiltinRunner` structure of the `builtins/builtin_runner.zig` file. So, at the moment a `BitwiseBuiltinRunnerTmp` type is imported and will have to be replaced by `BitwiseBuiltinRunner` once the implementation is migrated.

Should close #106.