### PR TITLE
refactor: replace tuples by structures in `deduceOp0` and `deduceOp1`

### DIFF
--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -569,38 +569,30 @@ pub fn deduceOp1(
     inst: *const instructions.Instruction,
     dst: ?*const MaybeRelocatable,
     op0: ?*const MaybeRelocatable,
-) !std.meta.Tuple(&[_]type{ ?relocatable.MaybeRelocatable, ?relocatable.MaybeRelocatable }) {
+) !Op1Result {
     if (inst.opcode != .AssertEq) {
-        return .{ null, null };
+        return .{ .op_1 = null, .res = null };
     }
 
     switch (inst.res_logic) {
         .Op1 => if (dst) |dst_val| {
-            return .{ dst_val.*, dst_val.* };
+            return .{ .op_1 = dst_val.*, .res = dst_val.* };
         },
         .Add => if (dst != null and op0 != null) {
-            return .{ try subOperands(
-                dst.?.*,
-                op0.?.*,
-            ), dst.?.* };
+            return .{ .op_1 = try subOperands(dst.?.*, op0.?.*), .res = dst.?.* };
         },
         .Mul => {
-            if (dst != null and op0 != null and
-                dst.?.isFelt() and op0.?.isFelt() and
-                !op0.?.felt.isZero())
-            {
+            if (dst != null and op0 != null and dst.?.isFelt() and op0.?.isFelt() and !op0.?.felt.isZero()) {
                 return .{
-                    relocatable.fromFelt(
-                        try dst.?.felt.div(op0.?.felt),
-                    ),
-                    dst.?.*,
+                    .op_1 = relocatable.fromFelt(try dst.?.felt.div(op0.?.felt)),
+                    .res = dst.?.*,
                 };
             }
         },
         else => {},
     }
 
-    return .{ null, null };
+    return .{ .op_1 = null, .res = null };
 }
 
 // *****************************************************************************
@@ -639,5 +631,14 @@ const Op0Result = struct {
     /// The computed operand Op0.
     op_0: ?MaybeRelocatable,
     /// The result of the operation involving Op0.
+    res: ?MaybeRelocatable,
+};
+
+/// Represents the result of deduce Op1 operation.
+const Op1Result = struct {
+    const Self = @This();
+    /// The computed operand Op1.
+    op_1: ?MaybeRelocatable,
+    /// The result of the operation involving Op1.
     res: ?MaybeRelocatable,
 };

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -587,15 +587,13 @@ test "deduceOp0 when opcode == .Call" {
     var instr = deduceOpTestInstr;
     instr.opcode = .Call;
 
-    const tuple = try vm.deduceOp0(&instr, null, null);
-    const op0 = tuple[0];
-    const res = tuple[1];
+    const deduceOp0 = try vm.deduceOp0(&instr, null, null);
 
     // Test checks
     const expected_op_0: ?MaybeRelocatable = relocatable.newFromRelocatable(Relocatable.new(0, 1)); // temp var needed for type inference
     const expected_res: ?MaybeRelocatable = null;
-    try expectEqual(expected_op_0, op0);
-    try expectEqual(expected_res, res);
+    try expectEqual(expected_op_0, deduceOp0.op_0);
+    try expectEqual(expected_res, deduceOp0.res);
 }
 
 test "deduceOp0 when opcode == .AssertEq, res_logic == .Add, input is felt" {
@@ -611,13 +609,11 @@ test "deduceOp0 when opcode == .AssertEq, res_logic == .Add, input is felt" {
     const dst = relocatable.fromU64(3);
     const op1 = relocatable.fromU64(2);
 
-    const tuple = try vm.deduceOp0(&instr, &dst, &op1);
-    const op0 = tuple[0];
-    const res = tuple[1];
+    const deduceOp0 = try vm.deduceOp0(&instr, &dst, &op1);
 
     // Test checks
-    try expect(op0.?.eq(relocatable.fromU64(1)));
-    try expect(res.?.eq(relocatable.fromU64(3)));
+    try expect(deduceOp0.op_0.?.eq(relocatable.fromU64(1)));
+    try expect(deduceOp0.res.?.eq(relocatable.fromU64(3)));
 }
 
 test "deduceOp0 when opcode == .AssertEq, res_logic == .Add, with no input" {
@@ -630,15 +626,13 @@ test "deduceOp0 when opcode == .AssertEq, res_logic == .Add, with no input" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Add;
 
-    const tuple = try vm.deduceOp0(&instr, null, null);
-    const op0 = tuple[0];
-    const res = tuple[1];
+    const deduceOp0 = try vm.deduceOp0(&instr, null, null);
 
     // Test checks
     const expected_op_0: ?MaybeRelocatable = null; // temp var needed for type inference
     const expected_res: ?MaybeRelocatable = null;
-    try expectEqual(expected_op_0, op0);
-    try expectEqual(expected_res, res);
+    try expectEqual(expected_op_0, deduceOp0.op_0);
+    try expectEqual(expected_res, deduceOp0.res);
 }
 
 test "deduceOp0 when opcode == .AssertEq, res_logic == .Mul, input is felt 1" {
@@ -654,15 +648,13 @@ test "deduceOp0 when opcode == .AssertEq, res_logic == .Mul, input is felt 1" {
     const dst = relocatable.fromU64(4);
     const op1 = relocatable.fromU64(2);
 
-    const tuple = try vm.deduceOp0(&instr, &dst, &op1);
-    const op0 = tuple[0];
-    const res = tuple[1];
+    const deduceOp0 = try vm.deduceOp0(&instr, &dst, &op1);
 
     // Test checks
     const expected_op_0: ?MaybeRelocatable = relocatable.fromU64(2); // temp var needed for type inference
     const expected_res: ?MaybeRelocatable = relocatable.fromU64(4);
-    try expectEqual(expected_op_0, op0);
-    try expectEqual(expected_res, res);
+    try expectEqual(expected_op_0, deduceOp0.op_0);
+    try expectEqual(expected_res, deduceOp0.res);
 }
 
 test "deduceOp0 when opcode == .AssertEq, res_logic == .Op1, input is felt" {
@@ -678,15 +670,13 @@ test "deduceOp0 when opcode == .AssertEq, res_logic == .Op1, input is felt" {
     const dst = relocatable.fromU64(4);
     const op1 = relocatable.fromU64(0);
 
-    const tuple = try vm.deduceOp0(&instr, &dst, &op1);
-    const op0 = tuple[0];
-    const res = tuple[1];
+    const deduceOp0 = try vm.deduceOp0(&instr, &dst, &op1);
 
     // Test checks
     const expected_op_0: ?MaybeRelocatable = null; // temp var needed for type inference
     const expected_res: ?MaybeRelocatable = null;
-    try expectEqual(expected_op_0, op0);
-    try expectEqual(expected_res, res);
+    try expectEqual(expected_op_0, deduceOp0.op_0);
+    try expectEqual(expected_res, deduceOp0.res);
 }
 
 test "deduceOp0 when opcode == .AssertEq, res_logic == .Mul, input is felt 2" {
@@ -702,15 +692,13 @@ test "deduceOp0 when opcode == .AssertEq, res_logic == .Mul, input is felt 2" {
     const dst = relocatable.fromU64(4);
     const op1 = relocatable.fromU64(0);
 
-    const tuple = try vm.deduceOp0(&instr, &dst, &op1);
-    const op0 = tuple[0];
-    const res = tuple[1];
+    const deduceOp0 = try vm.deduceOp0(&instr, &dst, &op1);
 
     // Test checks
     const expected_op_0: ?MaybeRelocatable = null; // temp var needed for type inference
     const expected_res: ?MaybeRelocatable = null;
-    try expectEqual(expected_op_0, op0);
-    try expectEqual(expected_res, res);
+    try expectEqual(expected_op_0, deduceOp0.op_0);
+    try expectEqual(expected_res, deduceOp0.res);
 }
 
 test "deduceOp0 when opcode == .Ret, res_logic == .Mul, input is felt" {
@@ -726,15 +714,13 @@ test "deduceOp0 when opcode == .Ret, res_logic == .Mul, input is felt" {
     const dst = relocatable.fromU64(4);
     const op1 = relocatable.fromU64(0);
 
-    const tuple = try vm.deduceOp0(&instr, &dst, &op1);
-    const op0 = tuple[0];
-    const res = tuple[1];
+    const deduceOp0 = try vm.deduceOp0(&instr, &dst, &op1);
 
     // Test checks
     const expected_op_0: ?MaybeRelocatable = null; // temp var needed for type inference
     const expected_res: ?MaybeRelocatable = null;
-    try expectEqual(expected_op_0, op0);
-    try expectEqual(expected_res, res);
+    try expectEqual(expected_op_0, deduceOp0.op_0);
+    try expectEqual(expected_res, deduceOp0.res);
 }
 
 test "deduceOp1 when opcode == .Call" {

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -731,21 +731,13 @@ test "deduceOp1 when opcode == .Call" {
     var instr = deduceOpTestInstr;
     instr.opcode = .Call;
 
-    const tuple = try deduceOp1(&instr, null, null);
-    const op1 = tuple[0];
-    const res = tuple[1];
+    const op1Deduction = try deduceOp1(&instr, null, null);
 
     // Test checks
     const expected_op_1: ?MaybeRelocatable = null; // temp var needed for type inference
     const expected_res: ?MaybeRelocatable = null;
-    try expectEqual(
-        expected_op_1,
-        op1,
-    );
-    try expectEqual(
-        expected_res,
-        res,
-    );
+    try expectEqual(expected_op_1, op1Deduction.op_1);
+    try expectEqual(expected_res, op1Deduction.res);
 }
 
 test "deduceOp1 when opcode == .AssertEq, res_logic == .Add, input is felt" {
@@ -760,13 +752,11 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Add, input is felt" {
     const dst = relocatable.fromU64(3);
     const op0 = relocatable.fromU64(2);
 
-    const tuple = try deduceOp1(&instr, &dst, &op0);
-    const op1 = tuple[0];
-    const res = tuple[1];
+    const op1Deduction = try deduceOp1(&instr, &dst, &op0);
 
     // Test checks
-    try expect(op1.?.eq(relocatable.fromU64(1)));
-    try expect(res.?.eq(relocatable.fromU64(3)));
+    try expect(op1Deduction.op_1.?.eq(relocatable.fromU64(1)));
+    try expect(op1Deduction.res.?.eq(relocatable.fromU64(3)));
 }
 
 test "deduceOp1 when opcode == .AssertEq, res_logic == .Mul, non-zero op0" {
@@ -781,13 +771,11 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Mul, non-zero op0" {
     const dst = relocatable.fromU64(4);
     const op0 = relocatable.fromU64(2);
 
-    const op1_and_result = try deduceOp1(&instr, &dst, &op0);
-    const op1 = op1_and_result[0];
-    const res = op1_and_result[1];
+    const op1Deduction = try deduceOp1(&instr, &dst, &op0);
 
     // Test checks
-    try expect(op1.?.eq(relocatable.fromU64(2)));
-    try expect(res.?.eq(relocatable.fromU64(4)));
+    try expect(op1Deduction.op_1.?.eq(relocatable.fromU64(2)));
+    try expect(op1Deduction.res.?.eq(relocatable.fromU64(4)));
 }
 
 test "deduceOp1 when opcode == .AssertEq, res_logic == .Mul, zero op0" {
@@ -802,21 +790,13 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Mul, zero op0" {
     const dst = relocatable.fromU64(4);
     const op0 = relocatable.fromU64(0);
 
-    const tuple = try deduceOp1(&instr, &dst, &op0);
-    const op1 = tuple[0];
-    const res = tuple[1];
+    const op1Deduction = try deduceOp1(&instr, &dst, &op0);
 
     // Test checks
     const expected_op_1: ?MaybeRelocatable = null; // temp var needed for type inference
     const expected_res: ?MaybeRelocatable = null;
-    try expectEqual(
-        expected_op_1,
-        op1,
-    );
-    try expectEqual(
-        expected_res,
-        res,
-    );
+    try expectEqual(expected_op_1, op1Deduction.op_1);
+    try expectEqual(expected_res, op1Deduction.res);
 }
 
 test "deduceOp1 when opcode == .AssertEq, res_logic = .Mul, no input" {
@@ -828,21 +808,13 @@ test "deduceOp1 when opcode == .AssertEq, res_logic = .Mul, no input" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Mul;
 
-    const tuple = try deduceOp1(&instr, null, null);
-    const op1 = tuple[0];
-    const res = tuple[1];
+    const op1Deduction = try deduceOp1(&instr, null, null);
 
     // Test checks
     const expected_op_1: ?MaybeRelocatable = null; // temp var needed for type inference
     const expected_res: ?MaybeRelocatable = null;
-    try expectEqual(
-        expected_op_1,
-        op1,
-    );
-    try expectEqual(
-        expected_res,
-        res,
-    );
+    try expectEqual(expected_op_1, op1Deduction.op_1);
+    try expectEqual(expected_res, op1Deduction.res);
 }
 
 test "deduceOp1 when opcode == .AssertEq, res_logic == .Op1, no dst" {
@@ -856,21 +828,13 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Op1, no dst" {
 
     const op0 = relocatable.fromU64(0);
 
-    const tuple = try deduceOp1(&instr, null, &op0);
-    const op1 = tuple[0];
-    const res = tuple[1];
+    const op1Deduction = try deduceOp1(&instr, null, &op0);
 
     // Test checks
     const expected_op_1: ?MaybeRelocatable = null; // temp var needed for type inference
     const expected_res: ?MaybeRelocatable = null;
-    try expectEqual(
-        expected_op_1,
-        op1,
-    );
-    try expectEqual(
-        expected_res,
-        res,
-    );
+    try expectEqual(expected_op_1, op1Deduction.op_1);
+    try expectEqual(expected_res, op1Deduction.res);
 }
 
 test "deduceOp1 when opcode == .AssertEq, res_logic == .Op1, no op0" {
@@ -884,13 +848,11 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Op1, no op0" {
 
     const dst = relocatable.fromU64(7);
 
-    const tuple = try deduceOp1(&instr, &dst, null);
-    const op1 = tuple[0];
-    const res = tuple[1];
+    const op1Deduction = try deduceOp1(&instr, &dst, null);
 
     // Test checks
-    try expect(op1.?.eq(relocatable.fromU64(7)));
-    try expect(res.?.eq(relocatable.fromU64(7)));
+    try expect(op1Deduction.op_1.?.eq(relocatable.fromU64(7)));
+    try expect(op1Deduction.res.?.eq(relocatable.fromU64(7)));
 }
 
 test "set get value in vm memory" {


### PR DESCRIPTION
Should close #121.