### PR TITLE
feat: add some helpers functions to `CairoVM` structure

### DIFF
--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -196,6 +196,22 @@ pub const CairoVM = struct {
         return self.segments.getSegmentSize(index);
     }
 
+    /// Retrieves a `Felt252` value from the memory at the specified relocatable address in the Cairo VM.
+    ///
+    /// This function internally calls `getFelt` on the memory segments manager, attempting
+    /// to retrieve a `Felt252` value at the given address. It handles the possibility of an
+    /// out-of-bounds memory access and returns an error if needed.
+    ///
+    /// # Arguments
+    ///
+    /// - `address`: The relocatable address to retrieve the `Felt252` value from.
+    /// # Returns
+    ///
+    /// - The `Felt252` value at the specified address, or an error if not available.
+    pub fn getFelt(self: *Self, address: Relocatable) !Felt252 {
+        return self.segments.memory.getFelt(address);
+    }
+
     /// Do a single step of the VM.
     /// Process an instruction cycle using the typical fetch-decode-execute cycle.
     pub fn step(self: *Self) !void {

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -420,21 +420,21 @@ pub const CairoVM = struct {
     /// # Returns
     /// - `MaybeRelocatable`: The current ap.
     pub fn getAp(self: *const Self) Relocatable {
-        return self.run_context.getAp();
+        return self.run_context.ap.*;
     }
 
     /// Returns the current fp.
     /// # Returns
     /// - `MaybeRelocatable`: The current fp.
     pub fn getFp(self: *const Self) Relocatable {
-        return self.run_context.getFp();
+        return self.run_context.fp.*;
     }
 
     /// Returns the current pc.
     /// # Returns
     /// - `MaybeRelocatable`: The current pc.
     pub fn getPc(self: *const Self) Relocatable {
-        return self.run_context.getPc();
+        return self.run_context.pc.*;
     }
 
     /// Applies the corresponding builtin's deduction rules if addr's segment index corresponds to a builtin segment

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -164,6 +164,22 @@ pub const CairoVM = struct {
         // TODO: complete the implementation once set method is completed in Memory
     }
 
+    /// Retrieves the used size of a memory segment by its index, if available; otherwise, returns null.
+    ///
+    /// This function internally calls `getSegmentUsedSize` on the memory segments manager, returning
+    /// the used size of the segment at the specified index. It handles the possibility of the size not
+    /// being computed and returns null if not available.
+    ///
+    /// # Parameters
+    ///
+    /// - `index` (u32): The index of the memory segment.
+    /// # Returns
+    ///
+    /// - The used size of the segment at the specified index, or null if not computed.
+    pub fn getSegmentUsedSize(self: *Self, index: u32) ?u32 {
+        return self.segments.getSegmentUsedSize(index);
+    }
+
     /// Do a single step of the VM.
     /// Process an instruction cycle using the typical fetch-decode-execute cycle.
     pub fn step(self: *Self) !void {

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -420,21 +420,21 @@ pub const CairoVM = struct {
     /// # Returns
     /// - `MaybeRelocatable`: The current ap.
     pub fn getAp(self: *const Self) Relocatable {
-        return self.run_context.ap.*;
+        return self.run_context.getAp();
     }
 
     /// Returns the current fp.
     /// # Returns
     /// - `MaybeRelocatable`: The current fp.
     pub fn getFp(self: *const Self) Relocatable {
-        return self.run_context.fp.*;
+        return self.run_context.getFp();
     }
 
     /// Returns the current pc.
     /// # Returns
     /// - `MaybeRelocatable`: The current pc.
     pub fn getPc(self: *const Self) Relocatable {
-        return self.run_context.pc.*;
+        return self.run_context.getPc();
     }
 
     /// Applies the corresponding builtin's deduction rules if addr's segment index corresponds to a builtin segment

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -140,6 +140,18 @@ pub const CairoVM = struct {
         return self.segments.memory.get(address);
     }
 
+    /// Gets a reference to the list of built-in runners in the Cairo VM.
+    ///
+    /// This function returns a mutable reference to the list of built-in runners,
+    /// allowing access and modification of the Cairo VM's built-in runner instances.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the list of built-in runners.
+    pub fn getBuiltinRunners(self: *Self) *ArrayList(BuiltinRunner) {
+        return &self.builtin_runners;
+    }
+
     /// Do a single step of the VM.
     /// Process an instruction cycle using the typical fetch-decode-execute cycle.
     pub fn step(self: *Self) !void {

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -96,6 +96,19 @@ pub const CairoVM = struct {
     // *                        METHODS                           *
     // ************************************************************
 
+    /// Computes and returns the effective size of memory segments.
+    ///
+    /// This function iterates through the memory segments, calculates their effective sizes, and
+    /// updates the segment sizes map accordingly. It ensures that the map reflects the maximum
+    /// offset used in each segment.
+    ///
+    /// # Returns
+    ///
+    /// An AutoArrayHashMap representing the computed effective sizes of memory segments.
+    pub fn computeSegmentsEffectiveSizes(self: *Self) !std.AutoArrayHashMap(u32, u32) {
+        return self.segments.computeEffectiveSize();
+    }
+
     /// Do a single step of the VM.
     /// Process an instruction cycle using the typical fetch-decode-execute cycle.
     pub fn step(self: *Self) !void {

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -109,6 +109,18 @@ pub const CairoVM = struct {
         return self.segments.computeEffectiveSize();
     }
 
+    /// Adds a memory segment to the Cairo VM and returns the first address of the new segment.
+    ///
+    /// This function internally calls `addSegment` on the memory segments manager, creating a new
+    /// relocatable address for the new segment. It increments the number of segments in the VM.
+    ///
+    /// # Returns
+    ///
+    /// The relocatable address representing the first address of the new memory segment.
+    pub fn addMemorySegment(self: *Self) Relocatable {
+        return self.segments.addSegment();
+    }
+
     /// Do a single step of the VM.
     /// Process an instruction cycle using the typical fetch-decode-execute cycle.
     pub fn step(self: *Self) !void {

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -121,6 +121,25 @@ pub const CairoVM = struct {
         return self.segments.addSegment();
     }
 
+    /// Retrieves a value from the memory at the specified relocatable address.
+    ///
+    /// This function internally calls `get` on the memory segments manager, returning the value
+    /// at the given address. It handles the possibility of an out-of-bounds access and returns
+    /// an error of type `MemoryOutOfBounds` in such cases.
+    ///
+    /// # Arguments
+    ///
+    /// - `address`: The relocatable address to retrieve the value from.
+    /// # Returns
+    ///
+    /// - The value at the specified address, or an error of type `MemoryOutOfBounds`.
+    pub fn getRelocatable(
+        self: *Self,
+        address: Relocatable,
+    ) error{MemoryOutOfBounds}!MaybeRelocatable {
+        return self.segments.memory.get(address);
+    }
+
     /// Do a single step of the VM.
     /// Process an instruction cycle using the typical fetch-decode-execute cycle.
     pub fn step(self: *Self) !void {

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -180,6 +180,22 @@ pub const CairoVM = struct {
         return self.segments.getSegmentUsedSize(index);
     }
 
+    /// Retrieves the size of a memory segment by its index, if available; otherwise, computes it.
+    ///
+    /// This function internally calls `getSegmentSize` on the memory segments manager, attempting
+    /// to retrieve the size of the segment at the specified index. If the size is not available,
+    /// it computes the effective size using `getSegmentUsedSize` and returns it.
+    ///
+    /// # Parameters
+    ///
+    /// - `index` (u32): The index of the memory segment.
+    /// # Returns
+    ///
+    /// - The size of the segment at the specified index, or a computed effective size if not available.
+    pub fn getSegmentSize(self: *Self, index: u32) ?u32 {
+        return self.segments.getSegmentSize(index);
+    }
+
     /// Do a single step of the VM.
     /// Process an instruction cycle using the typical fetch-decode-execute cycle.
     pub fn step(self: *Self) !void {

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -152,6 +152,18 @@ pub const CairoVM = struct {
         return &self.builtin_runners;
     }
 
+    pub fn insertInMemory(
+        self: *Self,
+        address: Relocatable,
+        value: MaybeRelocatable,
+    ) error{ InvalidMemoryAddress, MemoryOutOfBounds }!void {
+        _ = value;
+        _ = address;
+        _ = self;
+
+        // TODO: complete the implementation once set method is completed in Memory
+    }
+
     /// Do a single step of the VM.
     /// Process an instruction cycle using the typical fetch-decode-execute cycle.
     pub fn step(self: *Self) !void {

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -1689,3 +1689,25 @@ test "CairoVM: getSegmentUsedSize should return the size of a memory segment by 
         vm.getSegmentUsedSize(10).?,
     );
 }
+
+test "MemorySegmentManager: getSegmentUsedSize should return the size of the segment if contained in segment_sizes" {
+    var vm = try CairoVM.init(
+        std.testing.allocator,
+        .{},
+    );
+    defer vm.deinit();
+
+    try vm.segments.segment_sizes.put(10, 105);
+    try expectEqual(@as(u32, 105), vm.getSegmentSize(10).?);
+}
+
+test "MemorySegmentManager: getSegmentSize should return the size of the segment via getSegmentUsedSize if not contained in segment_sizes" {
+    var vm = try CairoVM.init(
+        std.testing.allocator,
+        .{},
+    );
+    defer vm.deinit();
+
+    try vm.segments.segment_used_sizes.put(3, 6);
+    try expectEqual(@as(u32, 6), vm.getSegmentSize(3).?);
+}

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -90,8 +90,8 @@ test "update pc regular no imm" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.pc_update = instructions.PcUpdate.Regular;
-    instruction.op_1_addr = instructions.Op1Src.AP;
+    instruction.pc_update = .Regular;
+    instruction.op_1_addr = .AP;
     const operands = OperandsResult.default();
     // Create a new VM instance.
     var vm = try CairoVM.init(allocator, .{});
@@ -118,8 +118,8 @@ test "update pc regular with imm" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.pc_update = instructions.PcUpdate.Regular;
-    instruction.op_1_addr = instructions.Op1Src.Imm;
+    instruction.pc_update = .Regular;
+    instruction.op_1_addr = .Imm;
     const operands = OperandsResult.default();
     // Create a new VM instance.
     var vm = try CairoVM.init(allocator, .{});
@@ -146,7 +146,7 @@ test "update pc jump with operands res null" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.pc_update = instructions.PcUpdate.Jump;
+    instruction.pc_update = .Jump;
     var operands = OperandsResult.default();
     operands.res = null;
     // Create a new VM instance.
@@ -164,7 +164,7 @@ test "update pc jump with operands res not relocatable" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.pc_update = instructions.PcUpdate.Jump;
+    instruction.pc_update = .Jump;
     var operands = OperandsResult.default();
     operands.res = relocatable.fromU64(0);
     // Create a new VM instance.
@@ -182,7 +182,7 @@ test "update pc jump with operands res relocatable" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.pc_update = instructions.PcUpdate.Jump;
+    instruction.pc_update = .Jump;
     var operands = OperandsResult.default();
     operands.res = relocatable.newFromRelocatable(Relocatable.new(
         0,
@@ -213,7 +213,7 @@ test "update pc jump rel with operands res null" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.pc_update = instructions.PcUpdate.JumpRel;
+    instruction.pc_update = .JumpRel;
     var operands = OperandsResult.default();
     operands.res = null;
     // Create a new VM instance.
@@ -231,7 +231,7 @@ test "update pc jump rel with operands res not felt" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.pc_update = instructions.PcUpdate.JumpRel;
+    instruction.pc_update = .JumpRel;
     var operands = OperandsResult.default();
     operands.res = relocatable.newFromRelocatable(Relocatable.new(
         0,
@@ -252,7 +252,7 @@ test "update pc jump rel with operands res felt" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.pc_update = instructions.PcUpdate.JumpRel;
+    instruction.pc_update = .JumpRel;
     var operands = OperandsResult.default();
     operands.res = relocatable.fromU64(42);
     // Create a new VM instance.
@@ -280,7 +280,7 @@ test "update pc update jnz with operands dst zero" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.pc_update = instructions.PcUpdate.Jnz;
+    instruction.pc_update = .Jnz;
     var operands = OperandsResult.default();
     operands.dst = relocatable.fromU64(0);
     // Create a new VM instance.
@@ -308,7 +308,7 @@ test "update pc update jnz with operands dst not zero op1 not felt" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.pc_update = instructions.PcUpdate.Jnz;
+    instruction.pc_update = .Jnz;
     var operands = OperandsResult.default();
     operands.dst = relocatable.fromU64(1);
     operands.op_1 = relocatable.newFromRelocatable(Relocatable.new(
@@ -333,7 +333,7 @@ test "update pc update jnz with operands dst not zero op1 felt" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.pc_update = instructions.PcUpdate.Jnz;
+    instruction.pc_update = .Jnz;
     var operands = OperandsResult.default();
     operands.dst = relocatable.fromU64(1);
     operands.op_1 = relocatable.fromU64(42);
@@ -362,7 +362,7 @@ test "update ap add with operands res unconstrained" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.ap_update = instructions.ApUpdate.Add;
+    instruction.ap_update = .Add;
     var operands = OperandsResult.default();
     operands.res = null; // Simulate unconstrained res
     // Create a new VM instance.
@@ -380,7 +380,7 @@ test "update ap add1" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.ap_update = instructions.ApUpdate.Add1;
+    instruction.ap_update = .Add1;
     var operands = OperandsResult.default();
     // Create a new VM instance.
     var vm = try CairoVM.init(allocator, .{});
@@ -408,7 +408,7 @@ test "update ap add2" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.ap_update = instructions.ApUpdate.Add2;
+    instruction.ap_update = .Add2;
     var operands = OperandsResult.default();
     // Create a new VM instance.
     var vm = try CairoVM.init(allocator, .{});
@@ -436,7 +436,7 @@ test "update fp appplus2" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.fp_update = instructions.FpUpdate.APPlus2;
+    instruction.fp_update = .APPlus2;
     var operands = OperandsResult.default();
     // Create a new VM instance.
     var vm = try CairoVM.init(allocator, .{});
@@ -464,7 +464,7 @@ test "update fp dst relocatable" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.fp_update = instructions.FpUpdate.Dst;
+    instruction.fp_update = .Dst;
     var operands = OperandsResult.default();
     operands.dst = relocatable.newFromRelocatable(Relocatable.new(
         0,
@@ -496,7 +496,7 @@ test "update fp dst felt" {
     // Test setup
     var allocator = std.testing.allocator;
     var instruction = Instruction.default();
-    instruction.fp_update = instructions.FpUpdate.Dst;
+    instruction.fp_update = .Dst;
     var operands = OperandsResult.default();
     operands.dst = relocatable.fromU64(42);
     // Create a new VM instance.
@@ -941,14 +941,14 @@ test "compute res op1 works" {
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Op1,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.NOp,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Op1,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .NOp,
     };
 
     // Create a new VM instance.
@@ -978,14 +978,14 @@ test "compute res add felts works" {
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Add,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.NOp,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Add,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .NOp,
     };
 
     // Create a new VM instance.
@@ -1015,14 +1015,14 @@ test "compute res add felt to offset works" {
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Add,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.NOp,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Add,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .NOp,
     };
 
     // Create a new VM instance.
@@ -1055,14 +1055,14 @@ test "compute res add fails two relocs" {
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Add,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.NOp,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Add,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .NOp,
     };
 
     // Create a new VM instance.
@@ -1089,14 +1089,14 @@ test "compute res mul works" {
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Mul,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.NOp,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Mul,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .NOp,
     };
 
     // Create a new VM instance.
@@ -1126,14 +1126,14 @@ test "compute res mul fails two relocs" {
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Mul,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.NOp,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Mul,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .NOp,
     };
 
     // Create a new VM instance.
@@ -1160,14 +1160,14 @@ test "compute res mul fails felt and reloc" {
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Mul,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.NOp,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Mul,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .NOp,
     };
 
     // Create a new VM instance.
@@ -1192,14 +1192,14 @@ test "compute res Unconstrained should return null" {
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Unconstrained,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.NOp,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Unconstrained,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .NOp,
     };
 
     // Create a new VM instance.
@@ -1492,14 +1492,14 @@ test "CairoVM: deduceDst should return res if AssertEq opcode" {
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Add,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.AssertEq,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Add,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .AssertEq,
     };
 
     var res = MaybeRelocatable{ .felt = Felt252.fromInteger(7) };
@@ -1520,14 +1520,14 @@ test "CairoVM: deduceDst should return VM error No dst if AssertEq opcode withou
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Add,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.AssertEq,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Add,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .AssertEq,
     };
 
     // Test check
@@ -1547,14 +1547,14 @@ test "CairoVM: deduceDst should return fp Relocatable if Call opcode" {
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Add,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.Call,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Add,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .Call,
     };
 
     // Test check
@@ -1573,14 +1573,14 @@ test "CairoVM: deduceDst should return VM error No dst if not AssertEq or Call o
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
-        .dst_reg = instructions.Register.AP,
-        .op_0_reg = instructions.Register.AP,
-        .op_1_addr = instructions.Op1Src.AP,
-        .res_logic = instructions.ResLogic.Add,
-        .pc_update = instructions.PcUpdate.Regular,
-        .ap_update = instructions.ApUpdate.Regular,
-        .fp_update = instructions.FpUpdate.Regular,
-        .opcode = instructions.Opcode.Ret,
+        .dst_reg = .AP,
+        .op_0_reg = .AP,
+        .op_1_addr = .AP,
+        .res_logic = .Add,
+        .pc_update = .Regular,
+        .ap_update = .Regular,
+        .fp_update = .Regular,
+        .opcode = .Ret,
     };
 
     // Test check

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -1589,3 +1589,31 @@ test "CairoVM: deduceDst should return VM error No dst if not AssertEq or Call o
         vm.deduceDst(&instruction, null),
     );
 }
+
+test "CairoVM: addMemorySegment should return a proper relocatable address for the new segment." {
+    // Test setup
+    var vm = try CairoVM.init(std.testing.allocator, .{});
+    defer vm.deinit();
+
+    // Test check
+    try expectEqual(
+        Relocatable.new(0, 0),
+        vm.addMemorySegment(),
+    );
+}
+
+test "CairoVM: addMemorySegment should increase by one the number of segments in the VM" {
+    // Test setup
+    var vm = try CairoVM.init(std.testing.allocator, .{});
+    defer vm.deinit();
+
+    _ = vm.addMemorySegment();
+    _ = vm.addMemorySegment();
+    _ = vm.addMemorySegment();
+
+    // Test check
+    try expectEqual(
+        @as(u32, 3),
+        vm.segments.memory.num_segments,
+    );
+}

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -1467,3 +1467,18 @@ test "CairoVM: computeOp0Deductions should return VM error if deduceOp0 and dedu
         ),
     );
 }
+
+test "CairoVM: computeSegmentsEffectiveSizes should return the computed effective size for the VM segments" {
+    // Test setup
+    var vm = try CairoVM.init(std.testing.allocator, .{});
+    defer vm.deinit();
+
+    try vm.segments.memory.data.put(Relocatable.new(0, 0), .{ .felt = Felt252.fromInteger(1) });
+    try vm.segments.memory.data.put(Relocatable.new(0, 1), .{ .felt = Felt252.fromInteger(1) });
+    try vm.segments.memory.data.put(Relocatable.new(0, 2), .{ .felt = Felt252.fromInteger(1) });
+
+    var actual = try vm.computeSegmentsEffectiveSizes();
+
+    try expectEqual(@as(usize, 1), actual.count());
+    try expectEqual(@as(u32, 3), actual.get(0).?);
+}

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -1617,3 +1617,32 @@ test "CairoVM: addMemorySegment should increase by one the number of segments in
         vm.segments.memory.num_segments,
     );
 }
+
+test "CairoVM: getRelocatable without value raises error" {
+    // Test setup
+    var vm = try CairoVM.init(std.testing.allocator, .{});
+    defer vm.deinit();
+
+    // Test check
+    try expectError(
+        error.MemoryOutOfBounds,
+        vm.getRelocatable(Relocatable.new(0, 0)),
+    );
+}
+
+test "CairoVM: getRelocatable with value should return a MaybeRelocatable" {
+    // Test setup
+    var vm = try CairoVM.init(std.testing.allocator, .{});
+    defer vm.deinit();
+
+    try vm.segments.memory.data.put(
+        Relocatable.new(34, 12),
+        .{ .felt = Felt252.fromInteger(5) },
+    );
+
+    // Test check
+    try expectEqual(
+        MaybeRelocatable{ .felt = Felt252.fromInteger(5) },
+        try vm.getRelocatable(Relocatable.new(34, 12)),
+    );
+}

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -29,6 +29,7 @@ const deduceOp1 = @import("core.zig").deduceOp1;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const expectError = std.testing.expectError;
+const expectEqualSlices = std.testing.expectEqualSlices;
 
 test "CairoVM: deduceMemoryCell no builtin" {
     var vm = try CairoVM.init(
@@ -1644,5 +1645,33 @@ test "CairoVM: getRelocatable with value should return a MaybeRelocatable" {
     try expectEqual(
         MaybeRelocatable{ .felt = Felt252.fromInteger(5) },
         try vm.getRelocatable(Relocatable.new(34, 12)),
+    );
+}
+
+test "CairoVM: getBuiltinRunners should return a reference to the builtin runners ArrayList" {
+    var vm = try CairoVM.init(
+        std.testing.allocator,
+        .{},
+    );
+    defer vm.deinit();
+    var instance_def: BitwiseInstanceDef = .{ .ratio = null, .total_n_bits = 2 };
+    try vm.builtin_runners.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.new(
+        &instance_def,
+        true,
+    ) });
+
+    // Test check
+    try expectEqual(&vm.builtin_runners, vm.getBuiltinRunners());
+
+    var expected = ArrayList(BuiltinRunner).init(std.testing.allocator);
+    defer expected.deinit();
+    try expected.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.new(
+        &instance_def,
+        true,
+    ) });
+    try expectEqualSlices(
+        BuiltinRunner,
+        expected.items,
+        vm.getBuiltinRunners().*.items,
     );
 }

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -1675,3 +1675,17 @@ test "CairoVM: getBuiltinRunners should return a reference to the builtin runner
         vm.getBuiltinRunners().*.items,
     );
 }
+
+test "CairoVM: getSegmentUsedSize should return the size of a memory segment by its index if available" {
+    var vm = try CairoVM.init(
+        std.testing.allocator,
+        .{},
+    );
+    defer vm.deinit();
+
+    try vm.segments.segment_used_sizes.put(10, 4);
+    try expectEqual(
+        @as(u32, @intCast(4)),
+        vm.getSegmentUsedSize(10).?,
+    );
+}

--- a/src/vm/error.zig
+++ b/src/vm/error.zig
@@ -11,6 +11,7 @@ pub const CairoVMError = error{
     TypeMismatchNotRelocatable,
     ValueTooLarge,
     FailedToComputeOperands,
+    NoDst,
 };
 
 pub const MemoryError = error{

--- a/src/vm/memory/memory.zig
+++ b/src/vm/memory/memory.zig
@@ -185,14 +185,10 @@ test "memory get without value raises error" {
     // *                      TEST CHECKS                         *
     // ************************************************************
     // Get a value from the memory at an address that doesn't exist.
-    _ = memory.get(Relocatable.new(
-        0,
-        0,
-    )) catch |err| {
-        // Assert that the error is the expected error.
-        try expect(err == error.MemoryOutOfBounds);
-        return;
-    };
+    try expectError(
+        error.MemoryOutOfBounds,
+        memory.get(Relocatable.new(0, 0)),
+    );
 }
 
 test "memory set and get" {

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -167,36 +167,6 @@ pub const RunContext = struct {
             return try base_addr.addUint(@intCast(instruction.off_2));
         }
     }
-
-    /// Gets the current value of the program counter (pc).
-    ///
-    /// # Returns
-    ///
-    /// The current value of the program counter, representing the address in memory
-    /// of the current Cairo instruction to be executed.
-    pub fn getPc(self: *const Self) Relocatable {
-        return self.pc.*;
-    }
-
-    /// Gets the current value of the allocation pointer (ap).
-    ///
-    /// # Returns
-    ///
-    /// The current value of the allocation pointer, pointing to the first memory cell
-    /// that has not been used by the program so far.
-    pub fn getAp(self: *const Self) Relocatable {
-        return self.ap.*;
-    }
-
-    /// Gets the current value of the frame pointer (fp).
-    ///
-    /// # Returns
-    ///
-    /// The current value of the frame pointer, pointing to the beginning of the stack
-    /// frame of the current function.
-    pub fn getFp(self: *const Self) Relocatable {
-        return self.fp.*;
-    }
 };
 
 // ************************************************************
@@ -876,83 +846,5 @@ test "RunContext: compute_op1_addr for OP0 op1 addr and instruction off_2 > 0" {
                 32,
             ) },
         ),
-    );
-}
-
-test "RunContext: getPc should return Pc" {
-    const run_context = try RunContext.init_with_values(
-        std.testing.allocator,
-        Relocatable.new(
-            0,
-            4,
-        ),
-        Relocatable.new(
-            0,
-            5,
-        ),
-        Relocatable.new(
-            0,
-            6,
-        ),
-    );
-    defer run_context.deinit();
-    try expectEqual(
-        Relocatable.new(
-            0,
-            4,
-        ),
-        run_context.getPc(),
-    );
-}
-
-test "RunContext: getAp should return Ap" {
-    const run_context = try RunContext.init_with_values(
-        std.testing.allocator,
-        Relocatable.new(
-            0,
-            4,
-        ),
-        Relocatable.new(
-            0,
-            5,
-        ),
-        Relocatable.new(
-            0,
-            6,
-        ),
-    );
-    defer run_context.deinit();
-    try expectEqual(
-        Relocatable.new(
-            0,
-            5,
-        ),
-        run_context.getAp(),
-    );
-}
-
-test "RunContext: getFp should return Fp" {
-    const run_context = try RunContext.init_with_values(
-        std.testing.allocator,
-        Relocatable.new(
-            0,
-            4,
-        ),
-        Relocatable.new(
-            0,
-            5,
-        ),
-        Relocatable.new(
-            0,
-            6,
-        ),
-    );
-    defer run_context.deinit();
-    try expectEqual(
-        Relocatable.new(
-            0,
-            6,
-        ),
-        run_context.getFp(),
     );
 }

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -167,6 +167,36 @@ pub const RunContext = struct {
             return try base_addr.addUint(@intCast(instruction.off_2));
         }
     }
+
+    /// Gets the current value of the program counter (pc).
+    ///
+    /// # Returns
+    ///
+    /// The current value of the program counter, representing the address in memory
+    /// of the current Cairo instruction to be executed.
+    pub fn getPc(self: *const Self) Relocatable {
+        return self.pc.*;
+    }
+
+    /// Gets the current value of the allocation pointer (ap).
+    ///
+    /// # Returns
+    ///
+    /// The current value of the allocation pointer, pointing to the first memory cell
+    /// that has not been used by the program so far.
+    pub fn getAp(self: *const Self) Relocatable {
+        return self.ap.*;
+    }
+
+    /// Gets the current value of the frame pointer (fp).
+    ///
+    /// # Returns
+    ///
+    /// The current value of the frame pointer, pointing to the beginning of the stack
+    /// frame of the current function.
+    pub fn getFp(self: *const Self) Relocatable {
+        return self.fp.*;
+    }
 };
 
 // ************************************************************
@@ -846,5 +876,83 @@ test "RunContext: compute_op1_addr for OP0 op1 addr and instruction off_2 > 0" {
                 32,
             ) },
         ),
+    );
+}
+
+test "RunContext: getPc should return Pc" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            5,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            4,
+        ),
+        run_context.getPc(),
+    );
+}
+
+test "RunContext: getAp should return Ap" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            5,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            5,
+        ),
+        run_context.getAp(),
+    );
+}
+
+test "RunContext: getFp should return Fp" {
+    const run_context = try RunContext.init_with_values(
+        std.testing.allocator,
+        Relocatable.new(
+            0,
+            4,
+        ),
+        Relocatable.new(
+            0,
+            5,
+        ),
+        Relocatable.new(
+            0,
+            6,
+        ),
+    );
+    defer run_context.deinit();
+    try expectEqual(
+        Relocatable.new(
+            0,
+            6,
+        ),
+        run_context.getFp(),
     );
 }


### PR DESCRIPTION
This PR focuses on:
- The addition of several helper functions to the main `CairoVM` structure in order to facilitate implementations and access in the structure tree.
- Unit tests corresponding to these new implementations.
- Adding a `getFelt` method to the `Memory` structure in order to retrieve a `Felt252` at a given address or an error.
- A little refactoring on the unit tests of `CairoVM` where the declaration of a type instruction:
```
var instruction = Instruction{
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
         .dst_reg = instructions.Register.AP,
         .op_0_reg = instructions.Register.AP,
         .op_1_addr = instructions.Op1Src.AP,
         .res_logic = instructions.ResLogic.Add,
         .pc_update = instructions.PcUpdate.Regular,
         .ap_update = instructions.ApUpdate.Regular,
         .fp_update = instructions.FpUpdate.Regular,
         .opcode = instructions.Opcode.NOp,
     };
```
can be simplified to:
```
var instruction = Instruction{
         .off_0 = 0,
         .off_1 = 1,
         .off_2 = 2,
         .dst_reg = .AP,
         .op_0_reg = .AP,
         .op_1_addr = .AP,
         .res_logic = .Add,
         .pc_update = .Regular,
         .ap_update = .Regular,
         .fp_update = .Regular,
         .opcode = .NOp,
     };
```
in order to have less verbose tests.