### PR TITLE
feat: implement `computeOp1Deductions` method in `CairoVM` structure

### DIFF
--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -344,6 +344,39 @@ pub const CairoVM = struct {
         return op0_op orelse CairoVMError.FailedToComputeOperands;
     }
 
+    /// Compute Op1 deductions based on the provided instruction, destination, and Op0.
+    ///
+    /// This function attempts to deduce Op1 using built-in deductions. If that returns a null,
+    /// it falls back to deducing Op1 based on the provided destination, Op0, and the result.
+    ///
+    /// ## Arguments
+    /// - `op1_addr`: The address of the operand to deduce.
+    /// - `res`: The result of the computation.
+    /// - `instruction`: The instruction to deduce the operand for.
+    /// - `dst_op`: The destination operand.
+    /// - `op0`: The Op0 operand.
+    ///
+    /// ## Returns
+    /// - `MaybeRelocatable`: The deduced Op1 operand or an error if deducing Op1 fails.
+    pub fn computeOp1Deductions(
+        self: *Self,
+        op1_addr: Relocatable,
+        res: *?MaybeRelocatable,
+        instruction: *const instructions.Instruction,
+        dst_op: ?*const MaybeRelocatable,
+        op0: ?*const MaybeRelocatable,
+    ) !MaybeRelocatable {
+        if (try self.deduceMemoryCell(op1_addr)) |op1| {
+            return op1;
+        } else {
+            const op1_deductions = try deduceOp1(instruction, dst_op, op0);
+            if (res.* == null) {
+                res.* = op1_deductions.res;
+            }
+            return op1_deductions.op_1 orelse return CairoVMError.FailedToComputeOp1;
+        }
+    }
+
     /// Attempts to deduce `op0` and `res` for an instruction, given `dst` and `op1`.
     ///
     /// # Arguments

--- a/src/vm/error.zig
+++ b/src/vm/error.zig
@@ -12,6 +12,7 @@ pub const CairoVMError = error{
     ValueTooLarge,
     FailedToComputeOperands,
     NoDst,
+    FailedToComputeOp1,
 };
 
 pub const MemoryError = error{


### PR DESCRIPTION
Should close #68.