### PR TITLE
refactor: rename `memoryInner` to `setUpMemory`

### DIFF
--- a/src/vm/memory/memory.zig
+++ b/src/vm/memory/memory.zig
@@ -519,7 +519,7 @@ test "Memory: markAsAccessed should mark memory cell" {
     defer memory.deinit();
 
     var relo = Relocatable.new(1, 3);
-    try memoryInner(memory, .{
+    try setUpMemory(memory, .{
         .{ .{ 1, 3 }, .{ 4, 5 } },
     });
 

--- a/src/vm/memory/memory.zig
+++ b/src/vm/memory/memory.zig
@@ -212,7 +212,7 @@ pub const Memory = struct {
 // # Arguments
 // - `memory` - memory to be set
 // - `vals` - complile time structure with heterogenous types
-fn memoryInner(memory: *Memory, comptime vals: anytype) !void {
+fn setUpMemory(memory: *Memory, comptime vals: anytype) !void {
     inline for (vals) |row| {
         const firstCol = row[0];
         const address = Relocatable.new(firstCol[0], firstCol[1]);
@@ -241,7 +241,7 @@ test "memory inner for testing test" {
     var memory = try Memory.init(allocator);
     defer memory.deinit();
 
-    try memoryInner(memory, .{
+    try setUpMemory(memory, .{
         .{ .{ 1, 3 }, .{ 4, 5 } },
         .{ .{ 2, 6 }, .{ 7, 8 } },
         .{ .{ 9, 10 }, .{23} },


### PR DESCRIPTION
When looking at Rust macros, the `memory` and `memory_inner` functionalities have exactly the same form and besides `memory` only calls `memory_inner`. The work done by @oxlime in #133 is already very good and fulfills exactly this functionality. For example, it is possible with the `memoryInner` function to create something like:

```rust
let memory = memory![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
```

with something like:
```zig
try memoryInner(memory, .{
         .{ .{ 0, 3 }, .{ 32 } },
         .{ .{ 0, 4 }, .{ 72 } },
         .{ .{ 0, 5 }, .{ 0 } },
     });
```

For me this is just a set of macros in Rust but we don't need that. So I simply suggest renaming `memoryInner` to `setUpMemory` and we can close #74.