### PR TITLE
feat: modify return type to `?MaybeRelocatable` in `get` function of `Memory`

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,7 +11,7 @@
     .dependencies = .{
         .@"zig-cli" = .{
             .url = "https://github.com/sam701/zig-cli/archive/refs/heads/main.tar.gz",
-            .hash = "1220fc45b619eb891f7ebfb77d7591b03a50e341394ffe8ae8330a52b76cd8d608d4",
+            .hash = "1220837b956355c73ccd18f1cce2fc829d7de04a71434e796f9ff913642ac908a1e5",
         },
     },
 }

--- a/src/vm/builtins/bitwise/bitwise.zig
+++ b/src/vm/builtins/bitwise/bitwise.zig
@@ -42,15 +42,19 @@ fn getValue(address: Relocatable, memory: *Memory) BitwiseError!u256 {
         return BitwiseError.InvalidAddressForBitwise;
     };
 
-    var felt = value.tryIntoFelt() catch {
-        return BitwiseError.InvalidAddressForBitwise;
-    };
+    if (value) |v| {
+        var felt = v.tryIntoFelt() catch {
+            return BitwiseError.InvalidAddressForBitwise;
+        };
 
-    if (felt.toInteger() > std.math.pow(u256, 2, BITWISE_TOTAL_N_BITS)) {
-        return BitwiseError.UnsupportedNumberOfBits;
+        if (felt.toInteger() > std.math.pow(u256, 2, BITWISE_TOTAL_N_BITS)) {
+            return BitwiseError.UnsupportedNumberOfBits;
+        }
+
+        return felt.toInteger();
     }
 
-    return felt.toInteger();
+    return BitwiseError.InvalidAddressForBitwise;
 }
 
 /// Compute the auto-deduction rule for Bitwise

--- a/src/vm/builtins/bitwise/bitwise.zig
+++ b/src/vm/builtins/bitwise/bitwise.zig
@@ -38,7 +38,7 @@ const BITWISE_INPUT_CELLS_PER_INSTANCE = 2;
 /// # Returns
 /// The felt as an integer.
 fn getValue(address: Relocatable, memory: *Memory) BitwiseError!u256 {
-    var value = memory.get(address) catch {
+    const value = memory.get(address) catch {
         return BitwiseError.InvalidAddressForBitwise;
     };
 

--- a/src/vm/builtins/builtin_runner/keccak.zig
+++ b/src/vm/builtins/builtin_runner/keccak.zig
@@ -343,9 +343,9 @@ pub const KeccakBuiltinRunner = struct {
             const stop_pointer_addr = pointer.subUint(
                 @intCast(1),
             ) catch return RunnerError.NoStopPointer;
-            const stop_pointer = try (segments.memory.get(
+            const stop_pointer = try ((segments.memory.get(
                 stop_pointer_addr,
-            ) catch return RunnerError.NoStopPointer).tryIntoRelocatable();
+            ) catch return RunnerError.NoStopPointer) orelse return RunnerError.NoStopPointer).tryIntoRelocatable();
             if (@as(
                 isize,
                 @intCast(self.base),
@@ -427,9 +427,9 @@ pub const KeccakBuiltinRunner = struct {
             usize,
             @intCast(self.n_input_cells),
         )) |i| {
-            const num = (memory.get(try first_input_addr.addUint(@intCast(i))) catch {
+            const num = ((memory.get(try first_input_addr.addUint(@intCast(i))) catch {
                 return null;
-            }).tryIntoFelt() catch {
+            }) orelse return null).tryIntoFelt() catch {
                 return RunnerError.BuiltinExpectedInteger;
             };
 

--- a/src/vm/builtins/builtin_runner/range_check.zig
+++ b/src/vm/builtins/builtin_runner/range_check.zig
@@ -227,7 +227,9 @@ pub const RangeCheckBuiltinRunner = struct {
     /// An `ArrayList(Relocatable)` containing the rules address
     /// verification fails.
     pub fn rangeCheckValidationRule(memory: *Memory, address: Relocatable) ?[]const Relocatable {
-        const num = (memory.get(address) catch {
+        const num = ((memory.get(address) catch {
+            return null;
+        }) orelse {
             return null;
         }).tryIntoFelt() catch {
             return null;

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -317,7 +317,7 @@ pub const CairoVM = struct {
             instruction,
             op_res.op_0,
         );
-        const op_1_op = self.segments.memory.get(op_res.op_1_addr) catch null;
+        const op_1_op = try self.segments.memory.get(op_res.op_1_addr);
 
         // Deduce the operands if they haven't been successfully retrieved from memory.
         if (self.segments.memory.get(op_res.op_0_addr) catch null) |op_0| {

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -243,7 +243,7 @@ pub const CairoVM = struct {
         // First, we convert the encoded instruction to a u64.
         // If the MaybeRelocatable is not a felt, this operation will fail.
         // If the MaybeRelocatable is a felt but the value does not fit into a u64, this operation will fail.
-        const encoded_instruction_u64 = encoded_instruction.tryIntoU64() catch {
+        const encoded_instruction_u64 = encoded_instruction.?.tryIntoU64() catch {
             return CairoVMError.InstructionEncodingError;
         };
 

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -582,7 +582,7 @@ test "deduceOp0 when opcode == .Call" {
     var instr = deduceOpTestInstr;
     instr.opcode = .Call;
 
-    const deduceOp0 = try vm.deduceOp0(&instr, null, null);
+    const deduceOp0 = try vm.deduceOp0(&instr, &null, &null);
 
     // Test checks
     const expected_op_0: ?MaybeRelocatable = relocatable.newFromRelocatable(Relocatable.new(0, 1)); // temp var needed for type inference
@@ -601,8 +601,8 @@ test "deduceOp0 when opcode == .AssertEq, res_logic == .Add, input is felt" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Add;
 
-    const dst = relocatable.fromU64(3);
-    const op1 = relocatable.fromU64(2);
+    const dst: ?MaybeRelocatable = relocatable.fromU64(3);
+    const op1: ?MaybeRelocatable = relocatable.fromU64(2);
 
     const deduceOp0 = try vm.deduceOp0(&instr, &dst, &op1);
 
@@ -621,7 +621,7 @@ test "deduceOp0 when opcode == .AssertEq, res_logic == .Add, with no input" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Add;
 
-    const deduceOp0 = try vm.deduceOp0(&instr, null, null);
+    const deduceOp0 = try vm.deduceOp0(&instr, &null, &null);
 
     // Test checks
     const expected_op_0: ?MaybeRelocatable = null; // temp var needed for type inference
@@ -640,8 +640,8 @@ test "deduceOp0 when opcode == .AssertEq, res_logic == .Mul, input is felt 1" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Mul;
 
-    const dst = relocatable.fromU64(4);
-    const op1 = relocatable.fromU64(2);
+    const dst: ?MaybeRelocatable = relocatable.fromU64(4);
+    const op1: ?MaybeRelocatable = relocatable.fromU64(2);
 
     const deduceOp0 = try vm.deduceOp0(&instr, &dst, &op1);
 
@@ -662,8 +662,8 @@ test "deduceOp0 when opcode == .AssertEq, res_logic == .Op1, input is felt" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Op1;
 
-    const dst = relocatable.fromU64(4);
-    const op1 = relocatable.fromU64(0);
+    const dst: ?MaybeRelocatable = relocatable.fromU64(4);
+    const op1: ?MaybeRelocatable = relocatable.fromU64(0);
 
     const deduceOp0 = try vm.deduceOp0(&instr, &dst, &op1);
 
@@ -684,8 +684,8 @@ test "deduceOp0 when opcode == .AssertEq, res_logic == .Mul, input is felt 2" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Mul;
 
-    const dst = relocatable.fromU64(4);
-    const op1 = relocatable.fromU64(0);
+    const dst: ?MaybeRelocatable = relocatable.fromU64(4);
+    const op1: ?MaybeRelocatable = relocatable.fromU64(0);
 
     const deduceOp0 = try vm.deduceOp0(&instr, &dst, &op1);
 
@@ -706,8 +706,8 @@ test "deduceOp0 when opcode == .Ret, res_logic == .Mul, input is felt" {
     instr.opcode = .Ret;
     instr.res_logic = .Mul;
 
-    const dst = relocatable.fromU64(4);
-    const op1 = relocatable.fromU64(0);
+    const dst: ?MaybeRelocatable = relocatable.fromU64(4);
+    const op1: ?MaybeRelocatable = relocatable.fromU64(0);
 
     const deduceOp0 = try vm.deduceOp0(&instr, &dst, &op1);
 
@@ -726,7 +726,7 @@ test "deduceOp1 when opcode == .Call" {
     var instr = deduceOpTestInstr;
     instr.opcode = .Call;
 
-    const op1Deduction = try deduceOp1(&instr, null, null);
+    const op1Deduction = try deduceOp1(&instr, &null, &null);
 
     // Test checks
     const expected_op_1: ?MaybeRelocatable = null; // temp var needed for type inference
@@ -744,8 +744,8 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Add, input is felt" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Add;
 
-    const dst = relocatable.fromU64(3);
-    const op0 = relocatable.fromU64(2);
+    const dst: ?MaybeRelocatable = relocatable.fromU64(3);
+    const op0: ?MaybeRelocatable = relocatable.fromU64(2);
 
     const op1Deduction = try deduceOp1(&instr, &dst, &op0);
 
@@ -763,8 +763,8 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Mul, non-zero op0" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Mul;
 
-    const dst = relocatable.fromU64(4);
-    const op0 = relocatable.fromU64(2);
+    const dst: ?MaybeRelocatable = relocatable.fromU64(4);
+    const op0: ?MaybeRelocatable = relocatable.fromU64(2);
 
     const op1Deduction = try deduceOp1(&instr, &dst, &op0);
 
@@ -782,8 +782,8 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Mul, zero op0" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Mul;
 
-    const dst = relocatable.fromU64(4);
-    const op0 = relocatable.fromU64(0);
+    const dst: ?MaybeRelocatable = relocatable.fromU64(4);
+    const op0: ?MaybeRelocatable = relocatable.fromU64(0);
 
     const op1Deduction = try deduceOp1(&instr, &dst, &op0);
 
@@ -803,7 +803,7 @@ test "deduceOp1 when opcode == .AssertEq, res_logic = .Mul, no input" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Mul;
 
-    const op1Deduction = try deduceOp1(&instr, null, null);
+    const op1Deduction = try deduceOp1(&instr, &null, &null);
 
     // Test checks
     const expected_op_1: ?MaybeRelocatable = null; // temp var needed for type inference
@@ -821,9 +821,9 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Op1, no dst" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Op1;
 
-    const op0 = relocatable.fromU64(0);
+    const op0: ?MaybeRelocatable = relocatable.fromU64(0);
 
-    const op1Deduction = try deduceOp1(&instr, null, &op0);
+    const op1Deduction = try deduceOp1(&instr, &null, &op0);
 
     // Test checks
     const expected_op_1: ?MaybeRelocatable = null; // temp var needed for type inference
@@ -841,9 +841,9 @@ test "deduceOp1 when opcode == .AssertEq, res_logic == .Op1, no op0" {
     instr.opcode = .AssertEq;
     instr.res_logic = .Op1;
 
-    const dst = relocatable.fromU64(7);
+    const dst: ?MaybeRelocatable = relocatable.fromU64(7);
 
-    const op1Deduction = try deduceOp1(&instr, &dst, null);
+    const op1Deduction = try deduceOp1(&instr, &dst, &null);
 
     // Test checks
     try expect(op1Deduction.op_1.?.eq(relocatable.fromU64(7)));
@@ -880,7 +880,7 @@ test "set get value in vm memory" {
     const expected_value = value;
     try expectEqual(
         expected_value,
-        actual_value,
+        actual_value.?,
     );
 }
 
@@ -1220,14 +1220,15 @@ test "compute operands add AP" {
     );
     defer vm.segments.memory.deinitData(std.testing.allocator);
 
-    var expected_operands = OperandsResult.default();
-    expected_operands.dst_addr = dst_addr;
-    expected_operands.op_0_addr = op0_addr;
-    expected_operands.op_1_addr = op1_addr;
-    expected_operands.dst = dst_val;
-    expected_operands.op_0 = op0_val;
-    expected_operands.op_1 = op1_val;
-    expected_operands.res = dst_val;
+    var expected_operands: OperandsResult = .{
+        .dst_addr = dst_addr,
+        .op_0_addr = op0_addr,
+        .op_1_addr = op1_addr,
+        .dst = dst_val,
+        .op_0 = op0_val,
+        .op_1 = op1_val,
+        .res = dst_val,
+    };
 
     const actual_operands = try vm.computeOperands(
         std.testing.allocator,
@@ -1288,14 +1289,15 @@ test "compute operands mul FP" {
     );
     defer vm.segments.memory.deinitData(std.testing.allocator);
 
-    var expected_operands = OperandsResult.default();
-    expected_operands.dst_addr = dst_addr;
-    expected_operands.op_0_addr = op0_addr;
-    expected_operands.op_1_addr = op1_addr;
-    expected_operands.dst = dst_val;
-    expected_operands.op_0 = op0_val;
-    expected_operands.op_1 = op1_val;
-    expected_operands.res = dst_val;
+    var expected_operands: OperandsResult = .{
+        .dst_addr = dst_addr,
+        .op_0_addr = op0_addr,
+        .op_1_addr = op1_addr,
+        .dst = dst_val,
+        .op_0 = op0_val,
+        .op_1 = op1_val,
+        .res = dst_val,
+    };
 
     const actual_operands = try vm.computeOperands(
         std.testing.allocator,
@@ -1483,8 +1485,8 @@ test "CairoVM: computeOp0Deductions should return op0 from deduceOp0 if deduceMe
             std.testing.allocator,
             Relocatable.new(0, 7),
             &instr,
-            null,
-            null,
+            &null,
+            &null,
         ),
     );
 }
@@ -1733,7 +1735,7 @@ test "CairoVM: getRelocatable with value should return a MaybeRelocatable" {
     // Test check
     try expectEqual(
         fromU256(5),
-        try vm.getRelocatable(Relocatable.new(34, 12)),
+        (try vm.getRelocatable(Relocatable.new(34, 12))).?,
     );
 }
 
@@ -1896,8 +1898,8 @@ test "CairoVM: computeOp1Deductions should return op1 from deduceMemoryCell if n
             Relocatable.new(0, 7),
             &res,
             &instr,
-            null,
-            null,
+            &null,
+            &null,
         ),
     );
 }
@@ -1911,7 +1913,7 @@ test "CairoVM: computeOp1Deductions should return op1 from deduceOp1 if deduceMe
     instr.opcode = .AssertEq;
     instr.res_logic = .Op1;
 
-    const dst = relocatable.fromU64(7);
+    const dst: ?MaybeRelocatable = relocatable.fromU64(7);
     var res: ?MaybeRelocatable = relocatable.fromU64(7);
 
     // Test check
@@ -1923,7 +1925,7 @@ test "CairoVM: computeOp1Deductions should return op1 from deduceOp1 if deduceMe
             &res,
             &instr,
             &dst,
-            null,
+            &null,
         ),
     );
 }
@@ -1937,7 +1939,7 @@ test "CairoVM: computeOp1Deductions should modify res (if null) using res from d
     instr.opcode = .AssertEq;
     instr.res_logic = .Op1;
 
-    const dst = relocatable.fromU64(7);
+    const dst: ?MaybeRelocatable = relocatable.fromU64(7);
     var res: ?MaybeRelocatable = null;
 
     _ = try vm.computeOp1Deductions(
@@ -1946,7 +1948,7 @@ test "CairoVM: computeOp1Deductions should modify res (if null) using res from d
         &res,
         &instr,
         &dst,
-        null,
+        &null,
     );
 
     // Test check
@@ -1965,7 +1967,7 @@ test "CairoVM: computeOp1Deductions should return CairoVMError error if deduceMe
     instr.opcode = .AssertEq;
     instr.res_logic = .Op1;
 
-    const op0 = relocatable.fromU64(0);
+    const op0: ?MaybeRelocatable = relocatable.fromU64(0);
     var res: ?MaybeRelocatable = null;
 
     // Test check
@@ -1976,7 +1978,7 @@ test "CairoVM: computeOp1Deductions should return CairoVMError error if deduceMe
             Relocatable.new(0, 7),
             &res,
             &instr,
-            null,
+            &null,
             &op0,
         ),
     );

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -1220,7 +1220,7 @@ test "compute operands add AP" {
     );
     defer vm.segments.memory.deinitData(std.testing.allocator);
 
-    var expected_operands: OperandsResult = .{
+    const expected_operands: OperandsResult = .{
         .dst_addr = dst_addr,
         .op_0_addr = op0_addr,
         .op_1_addr = op1_addr,
@@ -1289,7 +1289,7 @@ test "compute operands mul FP" {
     );
     defer vm.segments.memory.deinitData(std.testing.allocator);
 
-    var expected_operands: OperandsResult = .{
+    const expected_operands: OperandsResult = .{
         .dst_addr = dst_addr,
         .op_0_addr = op0_addr,
         .op_1_addr = op1_addr,

--- a/src/vm/memory/memory.zig
+++ b/src/vm/memory/memory.zig
@@ -682,7 +682,7 @@ test "memory set and get" {
 test "Memory: get inside a segment without value but inbout should return null" {
     // Test setup
     // Initialize an allocator.
-    var allocator = std.testing.allocator;
+    const allocator = std.testing.allocator;
 
     // Initialize a memory instance.
     var memory = try Memory.init(allocator);

--- a/src/vm/memory/segments.zig
+++ b/src/vm/memory/segments.zig
@@ -337,8 +337,8 @@ test "set get integer value in segment memory" {
     const actual_value_2 = try memory_segment_manager.memory.get(address_2);
     const expected_value_2 = value_2;
 
-    try expect(expected_value_1.eq(actual_value_1));
-    try expect(expected_value_2.eq(actual_value_2));
+    try expect(expected_value_1.eq(actual_value_1.?));
+    try expect(expected_value_2.eq(actual_value_2.?));
 }
 
 test "MemorySegmentManager: getSegmentUsedSize should return the size of a memory segment by its index if available" {


### PR DESCRIPTION
## Description
The `get` function within the `Memory` structure now accommodates returning `null` in scenarios where it previously did not. Specifically, when searching for a particular `Relocatable` address within an inbound existing segment lacking a corresponding `MemoryCell`, the get function can now appropriately return `null`.

This pull request introduces an alteration to the return type of the `get` function, enabling it to handle and return `null` as a valid result. Furthermore, a unit test has been included to rigorously validate this new functionality.

## Changes Made
- Modified the `get` function in the `Memory` structure to support returning `null`.
- Added a unit test to verify the correct functionality of the updated `get` function.

## Reasoning
The enhancement allows for more comprehensive handling of scenarios where the `MemoryCell` is absent within an existing inbound segment. By enabling get to return `null`, the function becomes more robust in its behavior, ensuring accurate handling of diverse scenarios within the codebase.

