### PR TITLE
feat: add `markAddressRangeAsAccessed` method in `CairoVM` structure

### DIFF
--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -556,13 +556,9 @@ pub const CairoVM = struct {
                 }
             },
             // AP update Add1
-            .Add1 => {
-                self.run_context.ap.*.addUintInPlace(1);
-            },
+            .Add1 => self.run_context.ap.*.addUintInPlace(1),
             // AP update Add2
-            .Add2 => {
-                self.run_context.ap.*.addUintInPlace(2);
-            },
+            .Add2 => self.run_context.ap.*.addUintInPlace(2),
             // AP update regular
             .Regular => {},
         }
@@ -579,12 +575,12 @@ pub const CairoVM = struct {
     ) !void {
         switch (instruction.fp_update) {
             // FP update Add + 2
-            instructions.FpUpdate.APPlus2 => { // Update the FP.
+            .APPlus2 => { // Update the FP.
                 // FP = AP + 2.
                 self.run_context.fp.*.offset = self.run_context.ap.*.offset + 2;
             },
             // FP update Dst
-            instructions.FpUpdate.Dst => {
+            .Dst => {
                 switch (operands.dst) {
                     .relocatable => |rel| {
                         // Update the FP.
@@ -643,27 +639,10 @@ pub const CairoVM = struct {
         res: ?MaybeRelocatable,
     ) !MaybeRelocatable {
         return switch (instruction.opcode) {
-            .AssertEq => {
-                if (res != null) {
-                    return res.?;
-                } else {
-                    return CairoVMError.NoDst;
-                }
-            },
+            .AssertEq => if (res) |r| r else CairoVMError.NoDst,
             .Call => relocatable.newFromRelocatable(self.run_context.fp.*),
             else => CairoVMError.NoDst,
         };
-    }
-
-    // ************************************************************
-    // *                    ACCESSORS                             *
-    // ************************************************************
-
-    /// Returns whether the run is finished or not.
-    /// # Returns
-    /// - `bool`: Whether the run is finished or not.
-    pub fn isRunFinished(self: *const Self) bool {
-        return self.is_run_finished;
     }
 
     /// Applies the corresponding builtin's deduction rules if addr's segment index corresponds to a builtin segment
@@ -693,6 +672,28 @@ pub const CairoVM = struct {
         }
         return null;
     }
+
+    /// Marks a range of memory addresses as accessed within the Cairo VM's memory segment.
+    ///
+    /// # Arguments
+    ///
+    /// - `base`: The base relocatable address of the memory range to mark as accessed.
+    /// - `len`: The length of the memory range to mark as accessed.
+    ///
+    /// # Safety
+    ///
+    /// - This function assumes correct usage and does not perform bounds checking. It's the responsibility of the caller
+    ///   to ensure that the provided range defined by `base` and `len` is within the valid bounds of the memory segment.
+    ///
+    /// # Errors
+    ///
+    /// - Returns `CairoVMError.RunNotFinished` if the VM's run is not yet finished.
+    pub fn markAddressRangeAsAccessed(self: *Self, base: Relocatable, len: usize) !void {
+        if (!self.is_run_finished) return CairoVMError.RunNotFinished;
+        for (0..len) |i| {
+            self.segments.memory.markAsAccessed(try base.addUint(@intCast(i)));
+        }
+    }
 };
 
 /// Compute the result operand for a given instruction on op 0 and op 1.
@@ -709,8 +710,8 @@ pub fn computeRes(
 ) !?MaybeRelocatable {
     return switch (instruction.res_logic) {
         .Op1 => op_1,
-        .Add => return try addOperands(op_0, op_1),
-        .Mul => return try mulOperands(op_0, op_1),
+        .Add => try addOperands(op_0, op_1),
+        .Mul => try mulOperands(op_0, op_1),
         .Unconstrained => null,
     };
 }
@@ -780,20 +781,20 @@ pub fn mulOperands(
 /// Only values of the same type may be subtracted. Specifically, attempting to
 /// subtract a `.felt` with a `.relocatable` will result in an error.
 pub fn subOperands(self: MaybeRelocatable, other: MaybeRelocatable) !MaybeRelocatable {
-    switch (self) {
+    return switch (self) {
         .felt => |self_value| switch (other) {
-            .felt => |other_value| return relocatable.fromFelt(
+            .felt => |other_value| relocatable.fromFelt(
                 self_value.sub(other_value),
             ),
-            .relocatable => return error.TypeMismatchNotFelt,
+            .relocatable => error.TypeMismatchNotFelt,
         },
         .relocatable => |self_value| switch (other) {
-            .felt => return error.TypeMismatchNotFelt,
-            .relocatable => |other_value| return relocatable.newFromRelocatable(
+            .felt => error.TypeMismatchNotFelt,
+            .relocatable => |other_value| relocatable.newFromRelocatable(
                 try self_value.sub(other_value),
             ),
         },
-    }
+    };
 }
 
 /// Attempts to deduce `op1` and `res` for an instruction, given `dst` and `op0`.

--- a/src/vm/error.zig
+++ b/src/vm/error.zig
@@ -29,6 +29,8 @@ pub const CairoVMError = error{
     FailedToComputeOp1,
     /// Occurs when both built-in deductions and fallback deductions fail to deduce Op0.
     FailedToComputeOp0,
+    /// Signifies that the execution run has not finished.
+    RunNotFinished,
 };
 
 /// Represent different error conditions that are memory-related.

--- a/src/vm/memory/memory.zig
+++ b/src/vm/memory/memory.zig
@@ -328,12 +328,28 @@ pub const Memory = struct {
         try self.validation_rules.put(@intCast(segment_index), rule);
     }
 
-    /// Marks a `MemoryCell` as accessed at the specified relocatable address.
+    /// Marks a `MemoryCell` as accessed at the specified relocatable address within the memory segment.
+    ///
+    /// # Description
+    /// This function marks a memory cell as accessed at the provided relocatable address within the memory segment.
+    /// It enables tracking and management of memory access for effective memory handling within the Cairo VM.
+    ///
     /// # Arguments
-    /// - `address` - The relocatable address to mark.
+    /// - `address` - The relocatable address to mark as accessed within the memory segment.
+    ///
+    /// # Safety
+    /// This function assumes correct usage and does not perform bounds checking. It's the responsibility of the caller
+    /// to ensure that the provided `address` is within the valid bounds of the memory segment.
     pub fn markAsAccessed(self: *Self, address: Relocatable) void {
         const segment_index: usize = @intCast(if (address.segment_index < 0) -(address.segment_index + 1) else address.segment_index);
-        (if (address.segment_index < 0) &self.temp_data else &self.data).items[segment_index].items[address.offset].?.markAccessed();
+        var data = if (address.segment_index < 0) &self.temp_data else &self.data;
+
+        if (segment_index < data.items.len) {
+            if (address.offset < data.items[segment_index].items.len) {
+                if (data.items[segment_index].items[address.offset] != null)
+                    data.items[segment_index].items[address.offset].?.is_accessed = true;
+            }
+        }
     }
 
     /// Adds a relocation rule to the VM memory, allowing redirection of temporary data to a specified destination.
@@ -870,6 +886,29 @@ test "Memory: markAsAccessed should mark memory cell" {
         true,
         memory.data.items[1].items[3].?.is_accessed,
     );
+}
+
+test "Memory: markAsAccessed should not panic if non existing segment" {
+    // Test setup
+    var memory = try Memory.init(std.testing.allocator);
+    defer memory.deinit();
+
+    memory.markAsAccessed(Relocatable.new(10, 0));
+}
+
+test "Memory: markAsAccessed should not panic if non existing offset" {
+    // Test setup
+    var memory = try Memory.init(std.testing.allocator);
+    defer memory.deinit();
+
+    try setUpMemory(
+        memory,
+        std.testing.allocator,
+        .{.{ .{ 1, 3 }, .{ 4, 5 } }},
+    );
+    defer memory.deinitData(std.testing.allocator);
+
+    memory.markAsAccessed(Relocatable.new(1, 17));
 }
 
 test "Memory: addRelocationRule should return an error if source segment index >= 0" {

--- a/src/vm/memory/memory.zig
+++ b/src/vm/memory/memory.zig
@@ -46,14 +46,6 @@ pub const MemoryCell = struct {
         };
     }
 
-    /// Marks the MemoryCell as accessed.
-    ///
-    /// # Safety
-    /// This function marks the MemoryCell as accessed, indicating it has been used or read.
-    pub fn markAccessed(self: *Self) void {
-        self.is_accessed = true;
-    }
-
     /// Checks equality between two MemoryCell instances.
     ///
     /// Checks whether two MemoryCell instances are equal based on their relocation information


### PR DESCRIPTION
Should close #196 plus a bit of refactoring.