### PR TITLE
feat: improve `Relocatable` operation type coercion and error handling

### DIFF
--- a/src/vm/builtins/bitwise/bitwise.zig
+++ b/src/vm/builtins/bitwise/bitwise.zig
@@ -60,7 +60,7 @@ fn getValue(address: Relocatable, memory: *Memory) BitwiseError!u256 {
 /// - memory: The cairo memory where addresses are looked up
 /// # Returns
 /// The deduced value as a `MaybeRelocatable`
-pub fn deduce(address: Relocatable, memory: *Memory) BitwiseError!MaybeRelocatable {
+pub fn deduce(address: Relocatable, memory: *Memory) !MaybeRelocatable {
     const index = address.offset % CELLS_PER_BITWISE;
 
     if (index < BITWISE_INPUT_CELLS_PER_INSTANCE) {

--- a/src/vm/builtins/builtin_runner/keccak.zig
+++ b/src/vm/builtins/builtin_runner/keccak.zig
@@ -342,9 +342,7 @@ pub const KeccakBuiltinRunner = struct {
         pointer: Relocatable,
     ) !Relocatable {
         if (self.included) {
-            const stop_pointer_addr = pointer.subUint(
-                @intCast(1),
-            ) catch return RunnerError.NoStopPointer;
+            const stop_pointer_addr = pointer.subUint(1) catch return RunnerError.NoStopPointer;
             const stop_pointer = try ((segments.memory.get(
                 stop_pointer_addr,
             ) catch return RunnerError.NoStopPointer) orelse return RunnerError.NoStopPointer).tryIntoRelocatable();
@@ -419,8 +417,8 @@ pub const KeccakBuiltinRunner = struct {
             return .{ .felt = felt.? };
         }
 
-        const first_input_addr = try address.subUint(@intCast(index));
-        const first_output_addr = try first_input_addr.addUint(@intCast(self.n_input_cells));
+        const first_input_addr = try address.subUint(index);
+        const first_output_addr = try first_input_addr.addUint(self.n_input_cells);
 
         var input_felts = ArrayList(Felt252).init(allocator);
         defer input_felts.deinit();
@@ -429,7 +427,7 @@ pub const KeccakBuiltinRunner = struct {
             usize,
             @intCast(self.n_input_cells),
         )) |i| {
-            const num = ((memory.get(try first_input_addr.addUint(@intCast(i))) catch {
+            const num = ((memory.get(try first_input_addr.addUint(i)) catch {
                 return null;
             }) orelse return null).tryIntoFelt() catch {
                 return RunnerError.BuiltinExpectedInteger;
@@ -476,7 +474,7 @@ pub const KeccakBuiltinRunner = struct {
             std.mem.copy(u8, &bytes, keccak_result.items[start_index..end_index]);
 
             try self.cache.put(
-                try first_output_addr.addUint(@intCast(i)),
+                try first_output_addr.addUint(i),
                 Felt252.fromBytes(bytes),
             );
             start_index = end_index;
@@ -844,7 +842,7 @@ test "KeccakBuiltinRunner: finalStack should return TypeMismatchNotRelocatable e
         try Relocatable.new(
             2,
             2,
-        ).subUint(@intCast(1)),
+        ).subUint(1),
         .{ .felt = Felt252.fromInteger(10) },
     );
     defer memory_segment_manager.memory.deinitData(std.testing.allocator);
@@ -875,7 +873,7 @@ test "KeccakBuiltinRunner: finalStack should return InvalidStopPointerIndex erro
         try Relocatable.new(
             2,
             2,
-        ).subUint(@intCast(1)),
+        ).subUint(1),
         .{ .relocatable = Relocatable.new(
             10,
             2,
@@ -908,7 +906,7 @@ test "KeccakBuiltinRunner: finalStack should return InvalidStopPointer error if 
         try Relocatable.new(
             2,
             2,
-        ).subUint(@intCast(1)),
+        ).subUint(1),
         .{ .relocatable = Relocatable.new(
             22,
             2,
@@ -943,7 +941,7 @@ test "KeccakBuiltinRunner: finalStack should return stop pointer address and upd
         try Relocatable.new(
             2,
             2,
-        ).subUint(@intCast(1)),
+        ).subUint(1),
         .{ .relocatable = Relocatable.new(
             22,
             22 * 16,

--- a/src/vm/builtins/builtin_runner/range_check.zig
+++ b/src/vm/builtins/builtin_runner/range_check.zig
@@ -187,9 +187,7 @@ pub const RangeCheckBuiltinRunner = struct {
         pointer: Relocatable,
     ) !Relocatable {
         if (self.included) {
-            const stop_pointer_addr = pointer.subUint(
-                @intCast(1),
-            ) catch return RunnerError.NoStopPointer;
+            const stop_pointer_addr = pointer.subUint(1) catch return RunnerError.NoStopPointer;
             const stop_pointer = try (segments.memory.get(
                 stop_pointer_addr,
             ) catch return RunnerError.NoStopPointer).tryIntoRelocatable();

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -757,7 +757,7 @@ pub const CairoVM = struct {
     /// - `operands`: The result of the operands computation.
     /// # Errors
     /// - Returns an error if an assertion fails.
-    pub fn opcodeAssertions(self: *Self, instruction: *const Instruction, operands: OperandsResult) CairoVMError!void {
+    pub fn opcodeAssertions(self: *Self, instruction: *const Instruction, operands: OperandsResult) !void {
         // Switch on the opcode to perform the appropriate assertion.
         switch (instruction.opcode) {
             // Assert that the result and destination operands are equal for AssertEq opcode.

--- a/src/vm/error.zig
+++ b/src/vm/error.zig
@@ -73,4 +73,6 @@ pub const MathError = error{
     RelocatableSubUsizeNegOffset,
     /// Value is too large to be coerced to a u64.
     ValueTooLarge,
+    /// Error indicating that the addition operation on the Relocatable offset exceeds the maximum limit.
+    RelocatableAdditionOffsetExceeded,
 };

--- a/src/vm/memory/relocatable.zig
+++ b/src/vm/memory/relocatable.zig
@@ -11,17 +11,17 @@ const MemoryError = @import("../error.zig").MemoryError;
 pub const Relocatable = struct {
     const Self = @This();
 
-    // The index of the memory segment.
+    /// The index of the memory segment.
     segment_index: i64 = 0,
-    // The offset in the memory segment.
+    /// The offset in the memory segment.
     offset: u64 = 0,
 
-    // Creates a new Relocatable.
-    // # Arguments
-    // - segment_index - The index of the memory segment.
-    // - offset - The offset in the memory segment.
-    // # Returns
-    // A new Relocatable.
+    /// Creates a new Relocatable.
+    /// # Arguments
+    /// - segment_index - The index of the memory segment.
+    /// - offset - The offset in the memory segment.
+    /// # Returns
+    /// A new Relocatable.
     pub fn new(
         segment_index: i64,
         offset: u64,
@@ -32,11 +32,11 @@ pub const Relocatable = struct {
         };
     }
 
-    // Determines if this Relocatable is equal to another.
-    // # Arguments
-    // - other: The other Relocatable to compare to.
-    // # Returns
-    // `true` if they are equal, `false` otherwise.
+    /// Determines if this Relocatable is equal to another.
+    /// # Arguments
+    /// - other: The other Relocatable to compare to.
+    /// # Returns
+    /// `true` if they are equal, `false` otherwise.
     pub fn eq(
         self: Self,
         other: Self,
@@ -44,11 +44,11 @@ pub const Relocatable = struct {
         return self.segment_index == other.segment_index and self.offset == other.offset;
     }
 
-    // Determines if this Relocatable is less than another.
-    // # Arguments
-    // - other: The other Relocatable to compare to.
-    // # Returns
-    // `true` if self is less than other, `false` otherwise.
+    /// Determines if this Relocatable is less than another.
+    /// # Arguments
+    /// - other: The other Relocatable to compare to.
+    /// # Returns
+    /// `true` if self is less than other, `false` otherwise.
     pub fn lt(
         self: Self,
         other: Self,
@@ -56,11 +56,11 @@ pub const Relocatable = struct {
         return self.segment_index < other.segment_index or (self.segment_index == other.segment_index and self.offset < other.offset);
     }
 
-    // Determines if this Relocatable is less than or equal to another.
-    // # Arguments
-    // - other: The other Relocatable to compare to.
-    // # Returns
-    // `true` if self is less than or equal to other, `false` otherwise.
+    /// Determines if this Relocatable is less than or equal to another.
+    /// # Arguments
+    /// - other: The other Relocatable to compare to.
+    /// # Returns
+    /// `true` if self is less than or equal to other, `false` otherwise.
     pub fn le(
         self: Self,
         other: Self,
@@ -68,11 +68,11 @@ pub const Relocatable = struct {
         return self.segment_index < other.segment_index or (self.segment_index == other.segment_index and self.offset <= other.offset);
     }
 
-    // Determines if this Relocatable is greater than another.
-    // # Arguments
-    // - other: The other Relocatable to compare to.
-    // # Returns
-    // `true` if self is greater than other, `false` otherwise.
+    /// Determines if this Relocatable is greater than another.
+    /// # Arguments
+    /// - other: The other Relocatable to compare to.
+    /// # Returns
+    /// `true` if self is greater than other, `false` otherwise.
     pub fn gt(
         self: Self,
         other: Self,
@@ -80,11 +80,11 @@ pub const Relocatable = struct {
         return self.segment_index > other.segment_index or (self.segment_index == other.segment_index and self.offset > other.offset);
     }
 
-    // Determines if this Relocatable is greater than or equal to another.
-    // # Arguments
-    // - other: The other Relocatable to compare to.
-    // # Returns
-    // `true` if self is greater than or equal to other, `false` otherwise.
+    /// Determines if this Relocatable is greater than or equal to another.
+    /// # Arguments
+    /// - other: The other Relocatable to compare to.
+    /// # Returns
+    /// `true` if self is greater than or equal to other, `false` otherwise.
     pub fn ge(
         self: Self,
         other: Self,
@@ -117,36 +117,37 @@ pub const Relocatable = struct {
         return try self.subUint(try other.tryIntoU64());
     }
 
-    // Substract a u64 from a Relocatable and return a new Relocatable.
-    // # Arguments
-    // - other: The u64 to substract.
-    // # Returns
-    // A new Relocatable.
+    /// Substract a u64 from a Relocatable and return a new Relocatable.
+    /// # Arguments
+    /// - other: The u64 to substract.
+    /// # Returns
+    /// A new Relocatable.
     pub fn subUint(
         self: Self,
         other: u64,
     ) MathError!Self {
-        if (self.offset < other) {
-            return MathError.RelocatableSubUsizeNegOffset;
-        }
+        if (self.offset < other) return MathError.RelocatableSubUsizeNegOffset;
+
         return .{
             .segment_index = self.segment_index,
             .offset = self.offset - other,
         };
     }
 
-    // Add a u64 to a Relocatable and return a new Relocatable.
-    // # Arguments
-    // - other: The u64 to add.
-    // # Returns
-    // A new Relocatable.
+    /// Add a u64 to a Relocatable and return a new Relocatable.
+    /// # Arguments
+    /// - other: The u64 to add.
+    /// # Returns
+    /// A new Relocatable.
     pub fn addUint(
         self: Self,
         other: u64,
     ) !Self {
+        const offset = @addWithOverflow(self.offset, other);
+        if (offset[1] != 0) return MathError.RelocatableAdditionOffsetExceeded;
         return .{
             .segment_index = self.segment_index,
-            .offset = self.offset + other,
+            .offset = offset[0],
         };
     }
 
@@ -162,29 +163,16 @@ pub const Relocatable = struct {
         self.offset += other;
     }
 
-    // Add a i64 to a Relocatable and return a new Relocatable.
-    // # Arguments
-    // - other: The i64 to add.
-    // # Returns
-    // A new Relocatable.
+    /// Add a i64 to a Relocatable and return a new Relocatable.
+    /// # Arguments
+    /// - other: The i64 to add.
+    /// # Returns
+    /// A new Relocatable.
     pub fn addInt(
         self: Self,
         other: i64,
     ) !Self {
-        if (other < 0) {
-            return self.subUint(@as(
-                u64,
-                @intCast(
-                    -other,
-                ),
-            ));
-        }
-        return self.addUint(@as(
-            u64,
-            @intCast(
-                other,
-            ),
-        ));
+        return if (other < 0) self.subUint(@intCast(-other)) else self.addUint(@intCast(other));
     }
 
     /// Adds a Felt252 value to this Relocatable.
@@ -643,6 +631,18 @@ test "Relocatable: addUint should add a u64 to a Relocatable and return a new Re
     try expectEqual(
         expected,
         result,
+    );
+}
+
+test "Relocatable: addUint should return a math error if overflow occurs." {
+    const relocatable = Relocatable.new(
+        2,
+        4,
+    );
+
+    try expectError(
+        MathError.RelocatableAdditionOffsetExceeded,
+        relocatable.addUint(std.math.maxInt(u64)),
     );
 }
 


### PR DESCRIPTION
This PR should close #200.

Finally, there is no need to implement an `addUsize` method because it is implicitly taken into account by the coercion type during a call function described here: https://ziglang.org/documentation/master/#toc-Type-Coercion

Thus, this be satisfied with a call `addUint(x)` with `x` of type `usize` and the coercion of the type `usize` to `u64` is done implicitly without any problem because it is completely unambiguous how to get from one type to another.

This PR therefore focuses on the following points:
- Call the `addUint` function of the `Relocatable` structure without needing verbose `intCast` for unambiguous types like usize.
- Better error handling is also done for adding `u64` to an instance of `Relocatable` in the case of an overflow.
- A bit of refactoring for to transform comment to comment doc in `Relocatable` structure.