### PR TITLE
felt: implement `getFeltRange` in `Memory`

### DIFF
--- a/src/vm/builtins/builtin_runner/range_check.zig
+++ b/src/vm/builtins/builtin_runner/range_check.zig
@@ -287,7 +287,7 @@ pub const RangeCheckBuiltinRunner = struct {
 /// verification fails.
 pub fn rangeCheckValidationRule(memory: *Memory, address: Relocatable) MemoryError![]const Relocatable {
     const num = memory.getFelt(address) catch |err| switch (err) {
-        error.MemoryOutOfBounds => return MemoryError.RangeCheckGetError,
+        error.UnknownMemoryCell => return MemoryError.RangeCheckGetError,
         error.ExpectedInteger => return MemoryError.RangecheckNonInt,
     };
 

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -1639,7 +1639,7 @@ test "CairoVM: getSegmentSize should return the size of the segment via getSegme
     try expectEqual(@as(u32, 6), vm.getSegmentSize(3).?);
 }
 
-test "CairoVM: getFelt should return MemoryOutOfBounds error if no value at the given address" {
+test "CairoVM: getFelt should return UnknownMemoryCell error if no value at the given address" {
     // Test setup
     var vm = try CairoVM.init(
         std.testing.allocator,
@@ -1649,7 +1649,7 @@ test "CairoVM: getFelt should return MemoryOutOfBounds error if no value at the 
 
     // Test checks
     try expectError(
-        error.MemoryOutOfBounds,
+        error.UnknownMemoryCell,
         vm.getFelt(Relocatable.new(10, 30)),
     );
 }

--- a/src/vm/error.zig
+++ b/src/vm/error.zig
@@ -59,6 +59,10 @@ pub const MemoryError = error{
     RangecheckNonInt,
     /// Range Check get error
     RangeCheckGetError,
+    /// Unknown memory cell
+    UnknownMemoryCell,
+    /// This memory cell doesn't contain an integer
+    ExpectedInteger,
 };
 
 /// Represents the error conditions that are related to the `CairoRunner`.

--- a/src/vm/memory/memory.zig
+++ b/src/vm/memory/memory.zig
@@ -407,6 +407,7 @@ pub const Memory = struct {
     ///
     /// This function internally calls `get` on the memory, attempting to retrieve a value at the given address.
     /// If the value is of type `Felt252`, it is returned; otherwise, an error of type `ExpectedInteger` is returned.
+    /// If there is no value, an error of type 'UnknownMemoryCell' is returned.
     ///
     /// Additionally, it handles the possibility of an out-of-bounds memory access and returns an error of type `MemoryOutOfBounds` if needed.
     ///
@@ -419,14 +420,14 @@ pub const Memory = struct {
     pub fn getFelt(
         self: *Self,
         address: Relocatable,
-    ) error{ ExpectedInteger, MemoryOutOfBounds }!Felt252 {
+    ) error{ ExpectedInteger, UnknownMemoryCell }!Felt252 {
         if (self.get(address)) |m| {
             return switch (m) {
                 .felt => |fe| fe,
-                else => error.ExpectedInteger,
+                else => MemoryError.ExpectedInteger,
             };
         } else {
-            return error.MemoryOutOfBounds;
+            return MemoryError.UnknownMemoryCell;
         }
     }
 
@@ -770,7 +771,7 @@ pub const Memory = struct {
     ///
     /// # Errors
     ///
-    /// Returns an error if there are any gaps encountered within the continuous memory range.
+    /// Returns an error if there are any unknown memory cell encountered within the continuous memory range.
     /// Returns an error if value inside the range is not a `Felt252`
     pub fn getFeltRange(
         self: *Self,
@@ -783,16 +784,7 @@ pub const Memory = struct {
         );
         errdefer values.deinit();
         for (0..size) |i| {
-            const elem = self.getFelt(try address.addUint(@intCast(i))) catch |err| {
-                // getFelt return ExpectedInteger
-                if (err == error.ExpectedInteger) {
-                    if (null == try (self.get(try address.addUint(@intCast(i))))) {
-                        return MemoryError.GetRangeMemoryGap;
-                    }
-                }
-                return err;
-            };
-            try values.append(elem);
+            try values.append(try self.getFelt(try address.addUint(@intCast(i))));
         }
         return values;
     }
@@ -1175,14 +1167,14 @@ test "validate existing memory for range check within bound" {
     try expect(maybe_value_1.?.eq(value_1));
 }
 
-test "Memory: getFelt should return MemoryOutOfBounds error if no value at the given address" {
+test "Memory: getFelt should return UnknownMemoryCell error if address is unknown" {
     // Test setup
     var memory = try Memory.init(std.testing.allocator);
     defer memory.deinit();
 
     // Test checks
     try expectError(
-        error.MemoryOutOfBounds,
+        MemoryError.UnknownMemoryCell,
         memory.getFelt(Relocatable.new(0, 0)),
     );
 }
@@ -1220,8 +1212,29 @@ test "Memory: getFelt should return ExpectedInteger error if Relocatable instead
 
     // Test checks
     try expectError(
-        error.ExpectedInteger,
+        MemoryError.ExpectedInteger,
         memory.getFelt(Relocatable.new(0, 0)),
+    );
+}
+
+test "Memory: getFelt should return UnknownMemoryCell error if no value at the given address" {
+    // Test setup
+    var memory = try Memory.init(std.testing.allocator);
+    defer memory.deinit();
+    try setUpMemory(
+        memory,
+        std.testing.allocator,
+        .{
+            .{ .{ 0, 0 }, .{3} },
+            .{ .{ 0, 2 }, .{4} },
+        },
+    );
+    defer memory.deinitData(std.testing.allocator);
+
+    // Test checks
+    try expectError(
+        MemoryError.UnknownMemoryCell,
+        memory.getFelt(Relocatable.new(0, 1)),
     );
 }
 
@@ -2041,7 +2054,7 @@ test "Memory: getFeltRange for Relocatable instead of Felt" {
 
     // Test checks
     try expectError(
-        error.ExpectedInteger,
+        MemoryError.ExpectedInteger,
         memory.getFeltRange(
             Relocatable.new(1, 0),
             2,
@@ -2066,7 +2079,7 @@ test "Memory: getFeltRange for out of bounds memory" {
 
     // Test checks
     try expectError(
-        error.MemoryOutOfBounds,
+        error.UnknownMemoryCell,
         memory.getFeltRange(
             Relocatable.new(1, 0),
             4,
@@ -2092,7 +2105,7 @@ test "Memory: getFeltRange for non continuous memory" {
 
     // Test checks
     try expectError(
-        MemoryError.GetRangeMemoryGap,
+        MemoryError.UnknownMemoryCell,
         memory.getFeltRange(
             Relocatable.new(1, 0),
             3,


### PR DESCRIPTION
This PR should close #193 

Please note I have to call `get` in case of `ExpectedInteger` to check for gap in range to avoid modification in `getFelt`.

