### PR TITLE
Update zig-cli url

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,7 +10,7 @@
     },
     .dependencies = .{
         .@"zig-cli" = .{
-            .url = "https://github.com/sam701/zig-cli/archive/refs/heads/main.tar.gz",
+            .url = "https://github.com/sam701/zig-cli/archive/f9e099bacee46b4776afbe7d6326656b33150b3b.tar.gz",
             .hash = "1220837b956355c73ccd18f1cce2fc829d7de04a71434e796f9ff913642ac908a1e5",
         },
     },


### PR DESCRIPTION
This PR update zig-cli url to use [this PR from @tcoratger](https://github.com/sam701/zig-cli/pull/27)