### PR TITLE
refactor: replace 'new' with 'init' for initializations

### DIFF
--- a/src/vm/builtins/bitwise/bitwise.zig
+++ b/src/vm/builtins/bitwise/bitwise.zig
@@ -98,7 +98,7 @@ test "deduce when address.offset less than BITWISE_INPUT_CELLS_PER_INSTANCE" {
     defer mem.deinit();
 
     // when
-    const address = Relocatable.new(0, 5);
+    const address = Relocatable.init(0, 5);
 
     // then
     try expectError(BitwiseError.InvalidBitwiseIndex, deduce(address, mem));
@@ -112,7 +112,7 @@ test "deduce when address points to nothing in memory" {
     defer mem.deinit();
 
     // when
-    const address = Relocatable.new(0, 3);
+    const address = Relocatable.init(0, 3);
 
     // then
     try expectError(BitwiseError.InvalidAddressForBitwise, deduce(address, mem));
@@ -126,7 +126,7 @@ test "deduce when address points to relocatable variant of MaybeRelocatable " {
     defer mem.deinit();
 
     // when
-    const address = Relocatable.new(0, 3);
+    const address = Relocatable.init(0, 3);
 
     try memoryFile.setUpMemory(
         mem,
@@ -147,7 +147,7 @@ test "deduce when address points to felt greater than BITWISE_TOTAL_N_BITS" {
     defer mem.deinit();
 
     // when
-    const address = Relocatable.new(0, 3);
+    const address = Relocatable.init(0, 3);
 
     try memoryFile.setUpMemory(
         mem,
@@ -180,7 +180,7 @@ test "valid bitwise and" {
     );
     defer mem.deinitData(std.testing.allocator);
 
-    const address = Relocatable.new(0, 7);
+    const address = Relocatable.init(0, 7);
     const expected = MaybeRelocatable.fromU256(8);
 
     // then
@@ -210,7 +210,7 @@ test "valid bitwise xor" {
     );
     defer mem.deinitData(std.testing.allocator);
 
-    const address = Relocatable.new(0, 8);
+    const address = Relocatable.init(0, 8);
     const expected = MaybeRelocatable.fromU256(6);
 
     // then
@@ -240,7 +240,7 @@ test "valid bitwise or" {
     );
     defer mem.deinitData(std.testing.allocator);
 
-    const address = Relocatable.new(0, 9);
+    const address = Relocatable.init(0, 9);
     const expected = MaybeRelocatable.fromU256(14);
 
     // then

--- a/src/vm/builtins/builtin_runner/bitwise.zig
+++ b/src/vm/builtins/builtin_runner/bitwise.zig
@@ -37,7 +37,7 @@ pub const BitwiseBuiltinRunner = struct {
     /// # Returns
     ///
     /// A new `BitwiseBuiltinRunner` instance.
-    pub fn new(
+    pub fn init(
         instance_def: *bitwise_instance_def.BitwiseInstanceDef,
         included: bool,
     ) Self {

--- a/src/vm/builtins/builtin_runner/ec_op.zig
+++ b/src/vm/builtins/builtin_runner/ec_op.zig
@@ -46,7 +46,7 @@ pub const EcOpBuiltinRunner = struct {
     /// # Returns
     ///
     /// A new `EcOpBuiltinRunner` instance.
-    pub fn new(
+    pub fn init(
         allocator: Allocator,
         instance_def: *ec_op_instance_def.EcOpInstanceDef,
         included: bool,

--- a/src/vm/builtins/builtin_runner/hash.zig
+++ b/src/vm/builtins/builtin_runner/hash.zig
@@ -41,7 +41,7 @@ pub const HashBuiltinRunner = struct {
     /// # Returns
     ///
     /// A new `HashBuiltinRunner` instance.
-    pub fn new(
+    pub fn init(
         allocator: Allocator,
         ratio: ?u32,
         included: bool,

--- a/src/vm/builtins/builtin_runner/keccak.zig
+++ b/src/vm/builtins/builtin_runner/keccak.zig
@@ -68,7 +68,7 @@ pub const KeccakBuiltinRunner = struct {
     /// # Returns
     ///
     /// A new `KeccakBuiltinRunner` instance.
-    pub fn new(
+    pub fn init(
         allocator: Allocator,
         instance_def: *KeccakInstanceDef,
         included: bool,
@@ -122,7 +122,7 @@ pub const KeccakBuiltinRunner = struct {
         var result = ArrayList(MaybeRelocatable).init(allocator);
         if (self.included) {
             try result.append(.{
-                .relocatable = Relocatable.new(
+                .relocatable = Relocatable.init(
                     @intCast(self.base),
                     0,
                 ),
@@ -491,7 +491,7 @@ pub const KeccakBuiltinRunner = struct {
 
 test "KeccakBuiltinRunner: initialStack should return an empty array list if included is false" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         false,
@@ -509,7 +509,7 @@ test "KeccakBuiltinRunner: initialStack should return an empty array list if inc
 
 test "KeccakBuiltinRunner: initialStack should return an a proper array list if included is true" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -533,7 +533,7 @@ test "KeccakBuiltinRunner: initialStack should return an a proper array list if 
 
 test "KeccakBuiltinRunner: initializeSegments should modify base field of Keccak built in" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -551,7 +551,7 @@ test "KeccakBuiltinRunner: initializeSegments should modify base field of Keccak
 
 test "KeccakBuiltinRunner: getUsedCells should return memory error if segment used size is null" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -567,7 +567,7 @@ test "KeccakBuiltinRunner: getUsedCells should return memory error if segment us
 
 test "KeccakBuiltinRunner: getUsedCells should return the number of used cells" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -587,7 +587,7 @@ test "KeccakBuiltinRunner: getUsedCells should return the number of used cells" 
 
 test "KeccakBuiltinRunner: getMemorySegmentAddresses should return base and stop pointer" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -605,7 +605,7 @@ test "KeccakBuiltinRunner: getMemorySegmentAddresses should return base and stop
 
 test "KeccakBuiltinRunner: getUsedInstances should return memory error if segment used size is null" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -621,7 +621,7 @@ test "KeccakBuiltinRunner: getUsedInstances should return memory error if segmen
 
 test "KeccakBuiltinRunner: getUsedInstances should return the number of used instances" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -638,7 +638,7 @@ test "KeccakBuiltinRunner: getUsedInstances should return the number of used ins
 
 test "KeccakBuiltinRunner: getMemoryAccesses should return memory error if segment used size is null" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -662,7 +662,7 @@ test "KeccakBuiltinRunner: getMemoryAccesses should return memory error if segme
 
 test "KeccakBuiltinRunner: getMemoryAccesses should return the memory accesses" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -766,7 +766,7 @@ test "KeccakBuiltinRunner: keccakF" {
 
 test "KeccakBuiltinRunner: finalStack should return relocatable pointer if not included" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         false,
@@ -776,20 +776,20 @@ test "KeccakBuiltinRunner: finalStack should return relocatable pointer if not i
     defer memory_segment_manager.deinit();
 
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             2,
             2,
         ),
         try keccak_builtin.finalStack(
             memory_segment_manager,
-            Relocatable.new(2, 2),
+            Relocatable.init(2, 2),
         ),
     );
 }
 
 test "KeccakBuiltinRunner: finalStack should return NoStopPointer error if pointer offset is 0" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -801,14 +801,14 @@ test "KeccakBuiltinRunner: finalStack should return NoStopPointer error if point
         RunnerError.NoStopPointer,
         keccak_builtin.finalStack(
             memory_segment_manager,
-            Relocatable.new(2, 0),
+            Relocatable.init(2, 0),
         ),
     );
 }
 
 test "KeccakBuiltinRunner: finalStack should return NoStopPointer error if no data in memory at the given stop pointer address" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -820,14 +820,14 @@ test "KeccakBuiltinRunner: finalStack should return NoStopPointer error if no da
         RunnerError.NoStopPointer,
         keccak_builtin.finalStack(
             memory_segment_manager,
-            Relocatable.new(2, 2),
+            Relocatable.init(2, 2),
         ),
     );
 }
 
 test "KeccakBuiltinRunner: finalStack should return TypeMismatchNotRelocatable error if data in memory at the given stop pointer address is not Relocatable" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -841,7 +841,7 @@ test "KeccakBuiltinRunner: finalStack should return TypeMismatchNotRelocatable e
     _ = try memory_segment_manager.addSegment();
     try memory_segment_manager.memory.set(
         std.testing.allocator,
-        try Relocatable.new(
+        try Relocatable.init(
             2,
             2,
         ).subUint(@intCast(1)),
@@ -853,14 +853,14 @@ test "KeccakBuiltinRunner: finalStack should return TypeMismatchNotRelocatable e
         CairoVMError.TypeMismatchNotRelocatable,
         keccak_builtin.finalStack(
             memory_segment_manager,
-            Relocatable.new(2, 2),
+            Relocatable.init(2, 2),
         ),
     );
 }
 
 test "KeccakBuiltinRunner: finalStack should return InvalidStopPointerIndex error if segment index of stop pointer is not KeccakBuiltinRunner base" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -875,11 +875,11 @@ test "KeccakBuiltinRunner: finalStack should return InvalidStopPointerIndex erro
     _ = try memory_segment_manager.addSegment();
     try memory_segment_manager.memory.set(
         std.testing.allocator,
-        try Relocatable.new(
+        try Relocatable.init(
             2,
             2,
         ).subUint(@intCast(1)),
-        .{ .relocatable = Relocatable.new(
+        .{ .relocatable = Relocatable.init(
             10,
             2,
         ) },
@@ -890,14 +890,14 @@ test "KeccakBuiltinRunner: finalStack should return InvalidStopPointerIndex erro
         RunnerError.InvalidStopPointerIndex,
         keccak_builtin.finalStack(
             memory_segment_manager,
-            Relocatable.new(2, 2),
+            Relocatable.init(2, 2),
         ),
     );
 }
 
 test "KeccakBuiltinRunner: finalStack should return InvalidStopPointer error if stop pointer offset is not cells used" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -911,11 +911,11 @@ test "KeccakBuiltinRunner: finalStack should return InvalidStopPointer error if 
     _ = try memory_segment_manager.addSegment();
     try memory_segment_manager.memory.set(
         std.testing.allocator,
-        try Relocatable.new(
+        try Relocatable.init(
             2,
             2,
         ).subUint(@intCast(1)),
-        .{ .relocatable = Relocatable.new(
+        .{ .relocatable = Relocatable.init(
             22,
             2,
         ) },
@@ -927,14 +927,14 @@ test "KeccakBuiltinRunner: finalStack should return InvalidStopPointer error if 
         RunnerError.InvalidStopPointer,
         keccak_builtin.finalStack(
             memory_segment_manager,
-            Relocatable.new(2, 2),
+            Relocatable.init(2, 2),
         ),
     );
 }
 
 test "KeccakBuiltinRunner: finalStack should return stop pointer address and update stop_ptr" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -949,11 +949,11 @@ test "KeccakBuiltinRunner: finalStack should return stop pointer address and upd
     _ = try memory_segment_manager.addSegment();
     try memory_segment_manager.memory.set(
         std.testing.allocator,
-        try Relocatable.new(
+        try Relocatable.init(
             2,
             2,
         ).subUint(@intCast(1)),
-        .{ .relocatable = Relocatable.new(
+        .{ .relocatable = Relocatable.init(
             22,
             22 * 16,
         ) },
@@ -962,10 +962,10 @@ test "KeccakBuiltinRunner: finalStack should return stop pointer address and upd
 
     try memory_segment_manager.segment_used_sizes.put(22, 345);
     try expectEqual(
-        Relocatable.new(2, 1),
+        Relocatable.init(2, 1),
         try keccak_builtin.finalStack(
             memory_segment_manager,
-            Relocatable.new(2, 2),
+            Relocatable.init(2, 2),
         ),
     );
     try expectEqual(
@@ -976,7 +976,7 @@ test "KeccakBuiltinRunner: finalStack should return stop pointer address and upd
 
 test "KeccakBuiltinRunner: deduceMemoryCell memory valid" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -1018,7 +1018,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell memory valid" {
         MaybeRelocatable{ .felt = Felt252.fromInteger(1006979841721999878391288827876533441431370448293338267890891) },
         (try keccak_builtin.deduceMemoryCell(
             std.testing.allocator,
-            Relocatable.new(0, 25),
+            Relocatable.init(0, 25),
             mem,
         )).?,
     );
@@ -1026,7 +1026,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell memory valid" {
 
 test "KeccakBuiltinRunner: deduceMemoryCell non relocatable address should return null" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -1053,7 +1053,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell non relocatable address should retur
         @as(?MaybeRelocatable, null),
         try keccak_builtin.deduceMemoryCell(
             std.testing.allocator,
-            Relocatable.new(0, 1),
+            Relocatable.init(0, 1),
             mem,
         ),
     );
@@ -1061,7 +1061,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell non relocatable address should retur
 
 test "KeccakBuiltinRunner: deduceMemoryCell offset less than input cell length should return null" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -1084,7 +1084,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell offset less than input cell length s
         @as(?MaybeRelocatable, null),
         try keccak_builtin.deduceMemoryCell(
             std.testing.allocator,
-            Relocatable.new(0, 2),
+            Relocatable.init(0, 2),
             mem,
         ),
     );
@@ -1092,7 +1092,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell offset less than input cell length s
 
 test "KeccakBuiltinRunner: deduceMemoryCell memory cell expected integer" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -1116,7 +1116,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell memory cell expected integer" {
         RunnerError.BuiltinExpectedInteger,
         keccak_builtin.deduceMemoryCell(
             std.testing.allocator,
-            Relocatable.new(0, 1),
+            Relocatable.init(0, 1),
             mem,
         ),
     );
@@ -1124,7 +1124,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell memory cell expected integer" {
 
 test "KeccakBuiltinRunner: deduceMemoryCell missing input cells" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -1148,7 +1148,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell missing input cells" {
         @as(?MaybeRelocatable, null),
         try keccak_builtin.deduceMemoryCell(
             std.testing.allocator,
-            Relocatable.new(0, 1),
+            Relocatable.init(0, 1),
             mem,
         ),
     );
@@ -1156,7 +1156,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell missing input cells" {
 
 test "KeccakBuiltinRunner: deduceMemoryCell input cell" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -1180,7 +1180,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell input cell" {
         @as(?MaybeRelocatable, null),
         try keccak_builtin.deduceMemoryCell(
             std.testing.allocator,
-            Relocatable.new(0, 0),
+            Relocatable.init(0, 0),
             mem,
         ),
     );
@@ -1189,7 +1189,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell input cell" {
 test "KeccakBuiltinRunner: deduceMemoryCell get memory error" {
     var keccak_instance_def = try KeccakInstanceDef.default(std.testing.allocator);
 
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -1210,7 +1210,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell get memory error" {
         @as(?MaybeRelocatable, null),
         try keccak_builtin.deduceMemoryCell(
             std.testing.allocator,
-            Relocatable.new(0, 15),
+            Relocatable.init(0, 15),
             mem,
         ),
     );
@@ -1220,8 +1220,8 @@ test "KeccakBuiltinRunner: deduceMemoryCell memory int larger than bits" {
     var _state_rep = ArrayList(u32).init(std.testing.allocator);
     defer _state_rep.deinit();
     try _state_rep.appendNTimes(1, 8);
-    var keccak_instance_def = KeccakInstanceDef.new(2048, _state_rep);
-    var keccak_builtin = KeccakBuiltinRunner.new(
+    var keccak_instance_def = KeccakInstanceDef.init(2048, _state_rep);
+    var keccak_builtin = KeccakBuiltinRunner.init(
         std.testing.allocator,
         &keccak_instance_def,
         true,
@@ -1262,7 +1262,7 @@ test "KeccakBuiltinRunner: deduceMemoryCell memory int larger than bits" {
         RunnerError.IntegerBiggerThanPowerOfTwo,
         keccak_builtin.deduceMemoryCell(
             std.testing.allocator,
-            Relocatable.new(0, 25),
+            Relocatable.init(0, 25),
             mem,
         ),
     );

--- a/src/vm/builtins/builtin_runner/output.zig
+++ b/src/vm/builtins/builtin_runner/output.zig
@@ -24,7 +24,7 @@ pub const OutputBuiltinRunner = struct {
     /// # Returns
     ///
     /// A new `OutputBuiltinRunner` instance.
-    pub fn new(included: bool) Self {
+    pub fn init(included: bool) Self {
         return .{
             .base = 0,
             .stop_ptr = null,

--- a/src/vm/builtins/builtin_runner/poseidon.zig
+++ b/src/vm/builtins/builtin_runner/poseidon.zig
@@ -46,7 +46,7 @@ pub const PoseidonBuiltinRunner = struct {
     /// # Returns
     ///
     /// A new `PoseidonBuiltinRunner` instance.
-    pub fn new(
+    pub fn init(
         allocator: Allocator,
         ratio: ?u32,
         included: bool,

--- a/src/vm/builtins/builtin_runner/range_check.zig
+++ b/src/vm/builtins/builtin_runner/range_check.zig
@@ -57,7 +57,7 @@ pub const RangeCheckBuiltinRunner = struct {
     /// # Returns
     ///
     /// A new `RangeCheckBuiltinRunner` instance.
-    pub fn new(
+    pub fn init(
         ratio: ?u32,
         n_parts: u32,
         included: bool,
@@ -107,7 +107,7 @@ pub const RangeCheckBuiltinRunner = struct {
         var result = ArrayList(MaybeRelocatable).init(allocator);
         if (self.included) {
             try result.append(.{
-                .relocatable = Relocatable.new(
+                .relocatable = Relocatable.init(
                     @intCast(self.base),
                     0,
                 ),
@@ -300,7 +300,7 @@ pub fn rangeCheckValidationRule(memory: *Memory, address: Relocatable) MemoryErr
 test "initialize segments for range check" {
 
     // given
-    const builtin = RangeCheckBuiltinRunner.new(8, 8, true);
+    const builtin = RangeCheckBuiltinRunner.init(8, 8, true);
     const allocator = std.testing.allocator;
     var mem = try MemorySegmentManager.init(allocator);
     defer mem.deinit();
@@ -314,7 +314,7 @@ test "initialize segments for range check" {
 
 test "used instances" {
     // given
-    var builtin = RangeCheckBuiltinRunner.new(10, 12, true);
+    var builtin = RangeCheckBuiltinRunner.init(10, 12, true);
 
     var memory_segment_manager = try MemorySegmentManager.init(std.testing.allocator);
     defer memory_segment_manager.deinit();
@@ -328,7 +328,7 @@ test "used instances" {
 test "Range Check: get usage for range check" {
 
     // given
-    var builtin = RangeCheckBuiltinRunner.new(8, 8, true);
+    var builtin = RangeCheckBuiltinRunner.init(8, 8, true);
     const allocator = std.testing.allocator;
     var seg = try MemorySegmentManager.init(allocator);
     defer seg.deinit();
@@ -347,7 +347,7 @@ test "Range Check: get usage for range check" {
 test "Range Check: another successful check of usage for range check" {
 
     // given
-    var builtin = RangeCheckBuiltinRunner.new(8, 8, true);
+    var builtin = RangeCheckBuiltinRunner.init(8, 8, true);
     const allocator = std.testing.allocator;
     var seg = try MemorySegmentManager.init(allocator);
     defer seg.deinit();
@@ -367,7 +367,7 @@ test "Range Check: another successful check of usage for range check" {
 test "Range Check: get usage for range check should be null" {
 
     // given
-    var builtin = RangeCheckBuiltinRunner.new(8, 8, true);
+    var builtin = RangeCheckBuiltinRunner.init(8, 8, true);
     const allocator = std.testing.allocator;
     var seg = try MemorySegmentManager.init(allocator);
     defer seg.deinit();
@@ -384,7 +384,7 @@ test "Range Check: get usage for range check should be null" {
 test "Range Check: validation rule should be empty" {
 
     // given
-    var builtin = RangeCheckBuiltinRunner.new(8, 8, true);
+    var builtin = RangeCheckBuiltinRunner.init(8, 8, true);
     const allocator = std.testing.allocator;
     var mem = try MemorySegmentManager.init(allocator);
     defer mem.deinit();
@@ -407,7 +407,7 @@ test "Range Check: validation rule should return Relocatable in array successful
     const seg = mem.addSegment();
     _ = try seg;
 
-    const relo = Relocatable.new(0, 1);
+    const relo = Relocatable.init(0, 1);
     try mem.memory.set(std.testing.allocator, relo, MaybeRelocatable.fromFelt(Felt252.zero()));
     defer mem.memory.deinitData(std.testing.allocator);
 
@@ -425,7 +425,7 @@ test "Range Check: validation rule should return erorr out of bounds" {
     const seg = mem.addSegment();
     _ = try seg;
 
-    const relo = Relocatable.new(0, 1);
+    const relo = Relocatable.init(0, 1);
     try mem.memory.set(std.testing.allocator, relo, MaybeRelocatable.fromFelt(Felt252.fromInteger(10).neg()));
     defer mem.memory.deinitData(std.testing.allocator);
 
@@ -443,7 +443,7 @@ test "Range Check: validation rule should return erorr non int" {
     const seg = mem.addSegment();
     _ = try seg;
 
-    const relo = Relocatable.new(0, 1);
+    const relo = Relocatable.init(0, 1);
     try mem.memory.set(std.testing.allocator, relo, MaybeRelocatable.fromSegment(0, 2));
     defer mem.memory.deinitData(std.testing.allocator);
 
@@ -461,11 +461,11 @@ test "Range Check: validation rule should return erorr address not in memory" {
     const seg = mem.addSegment();
     _ = try seg;
 
-    const relo = Relocatable.new(0, 1);
+    const relo = Relocatable.init(0, 1);
     try mem.memory.set(std.testing.allocator, relo, MaybeRelocatable.fromFelt(Felt252.zero()));
     defer mem.memory.deinitData(std.testing.allocator);
 
-    const result = rangeCheckValidationRule(mem.memory, Relocatable.new(0, 2));
+    const result = rangeCheckValidationRule(mem.memory, Relocatable.init(0, 2));
     // assert
     try std.testing.expectError(MemoryError.RangeCheckGetError, result);
 }

--- a/src/vm/builtins/builtin_runner/segment_arena.zig
+++ b/src/vm/builtins/builtin_runner/segment_arena.zig
@@ -36,7 +36,7 @@ pub const SegmentArenaBuiltinRunner = struct {
     /// # Returns
     ///
     /// A new `SegmentArenaBuiltinRunner` instance.
-    pub fn new(included: bool) Self {
+    pub fn init(included: bool) Self {
         return .{
             .base = Relocatable.default(),
             .included = included,

--- a/src/vm/builtins/builtin_runner/signature.zig
+++ b/src/vm/builtins/builtin_runner/signature.zig
@@ -46,7 +46,7 @@ pub const SignatureBuiltinRunner = struct {
     /// # Returns
     ///
     /// A new `SignatureBuiltinRunner` instance.
-    pub fn new(allocator: Allocator, instance_def: *ecdsa_instance_def.EcdsaInstanceDef, included: bool) Self {
+    pub fn init(allocator: Allocator, instance_def: *ecdsa_instance_def.EcdsaInstanceDef, included: bool) Self {
         return .{
             .included = included,
             .ratio = instance_def.ratio,

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -44,7 +44,7 @@ test "CairoVM: deduceMemoryCell no builtin" {
     defer vm.deinit();
     try expectEqual(
         @as(?MaybeRelocatable, null),
-        try vm.deduceMemoryCell(std.testing.allocator, Relocatable.new(
+        try vm.deduceMemoryCell(std.testing.allocator, Relocatable.init(
             0,
             0,
         )),
@@ -58,7 +58,7 @@ test "CairoVM: deduceMemoryCell builtin valid" {
     );
     defer vm.deinit();
     var instance_def: BitwiseInstanceDef = .{ .ratio = null, .total_n_bits = 2 };
-    try vm.builtin_runners.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.new(
+    try vm.builtin_runners.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.init(
         &instance_def,
         true,
     ) });
@@ -75,7 +75,7 @@ test "CairoVM: deduceMemoryCell builtin valid" {
     defer vm.segments.memory.deinitData(std.testing.allocator);
     try expectEqual(
         MaybeRelocatable.fromU256(8),
-        (try vm.deduceMemoryCell(std.testing.allocator, Relocatable.new(
+        (try vm.deduceMemoryCell(std.testing.allocator, Relocatable.init(
             0,
             7,
         ))).?,
@@ -180,7 +180,7 @@ test "update pc jump with operands res relocatable" {
     var instruction = defaultTestInstruction;
     instruction.pc_update = .Jump;
     var operands = OperandsResult.default();
-    operands.res = MaybeRelocatable.fromRelocatable(Relocatable.new(
+    operands.res = MaybeRelocatable.fromRelocatable(Relocatable.init(
         0,
         42,
     ));
@@ -229,7 +229,7 @@ test "update pc jump rel with operands res not felt" {
     var instruction = defaultTestInstruction;
     instruction.pc_update = .JumpRel;
     var operands = OperandsResult.default();
-    operands.res = MaybeRelocatable.fromRelocatable(Relocatable.new(
+    operands.res = MaybeRelocatable.fromRelocatable(Relocatable.init(
         0,
         42,
     ));
@@ -307,7 +307,7 @@ test "update pc update jnz with operands dst not zero op1 not felt" {
     instruction.pc_update = .Jnz;
     var operands = OperandsResult.default();
     operands.dst = MaybeRelocatable.fromU64(1);
-    operands.op_1 = MaybeRelocatable.fromRelocatable(Relocatable.new(
+    operands.op_1 = MaybeRelocatable.fromRelocatable(Relocatable.init(
         0,
         42,
     ));
@@ -462,7 +462,7 @@ test "update fp dst relocatable" {
     var instruction = defaultTestInstruction;
     instruction.fp_update = .Dst;
     var operands = OperandsResult.default();
-    operands.dst = MaybeRelocatable.fromRelocatable(Relocatable.new(
+    operands.dst = MaybeRelocatable.fromRelocatable(Relocatable.init(
         0,
         42,
     ));
@@ -600,7 +600,7 @@ test "deduceOp0 when opcode == .Call" {
     const deduceOp0 = try vm.deduceOp0(&instr, &null, &null);
 
     // Test checks
-    const expected_op_0: ?MaybeRelocatable = MaybeRelocatable.fromRelocatable(Relocatable.new(0, 1)); // temp var needed for type inference
+    const expected_op_0: ?MaybeRelocatable = MaybeRelocatable.fromRelocatable(Relocatable.init(0, 1)); // temp var needed for type inference
     const expected_res: ?MaybeRelocatable = null;
     try expectEqual(expected_op_0, deduceOp0.op_0);
     try expectEqual(expected_res, deduceOp0.res);
@@ -873,7 +873,7 @@ test "set get value in vm memory" {
     var vm = try CairoVM.init(allocator, .{});
     defer vm.deinit();
 
-    const address = Relocatable.new(1, 0);
+    const address = Relocatable.init(1, 0);
     const value = MaybeRelocatable.fromFelt(starknet_felt.Felt252.fromInteger(42));
 
     try memory.setUpMemory(
@@ -906,7 +906,7 @@ test "compute res op1 works" {
     var vm = try CairoVM.init(allocator, .{});
     defer vm.deinit();
 
-    vm.run_context.ap.* = Relocatable.new(1, 0);
+    vm.run_context.ap.* = Relocatable.init(1, 0);
     // Test body
 
     const value_op0 = MaybeRelocatable.fromFelt(starknet_felt.Felt252.fromInteger(2));
@@ -931,7 +931,7 @@ test "compute res add felts works" {
     var vm = try CairoVM.init(allocator, .{});
     defer vm.deinit();
 
-    vm.run_context.ap.* = Relocatable.new(1, 0);
+    vm.run_context.ap.* = Relocatable.init(1, 0);
     // Test body
 
     const value_op0 = MaybeRelocatable.fromFelt(starknet_felt.Felt252.fromInteger(2));
@@ -957,16 +957,16 @@ test "compute res add felt to offset works" {
     var vm = try CairoVM.init(allocator, .{});
     defer vm.deinit();
 
-    vm.run_context.ap.* = Relocatable.new(1, 0);
+    vm.run_context.ap.* = Relocatable.init(1, 0);
     // Test body
 
-    const value_op0 = Relocatable.new(1, 1);
+    const value_op0 = Relocatable.init(1, 1);
     const op0 = MaybeRelocatable.fromRelocatable(value_op0);
 
     const op1 = MaybeRelocatable.fromFelt(starknet_felt.Felt252.fromInteger(3));
 
     const actual_res = try computeRes(&instruction, op0, op1);
-    const res = Relocatable.new(1, 4);
+    const res = Relocatable.init(1, 4);
     const expected_res = MaybeRelocatable.fromRelocatable(res);
 
     // Test checks
@@ -984,11 +984,11 @@ test "compute res add fails two relocs" {
     var vm = try CairoVM.init(allocator, .{});
     defer vm.deinit();
 
-    vm.run_context.ap.* = Relocatable.new(1, 0);
+    vm.run_context.ap.* = Relocatable.init(1, 0);
     // Test body
 
-    const value_op0 = Relocatable.new(1, 0);
-    const value_op1 = Relocatable.new(1, 1);
+    const value_op0 = Relocatable.init(1, 0);
+    const value_op1 = Relocatable.init(1, 1);
 
     const op0 = MaybeRelocatable.fromRelocatable(value_op0);
     const op1 = MaybeRelocatable.fromRelocatable(value_op1);
@@ -1008,7 +1008,7 @@ test "compute res mul works" {
     var vm = try CairoVM.init(allocator, .{});
     defer vm.deinit();
 
-    vm.run_context.ap.* = Relocatable.new(1, 0);
+    vm.run_context.ap.* = Relocatable.init(1, 0);
     // Test body
 
     const value_op0 = MaybeRelocatable.fromFelt(starknet_felt.Felt252.fromInteger(2));
@@ -1033,11 +1033,11 @@ test "compute res mul fails two relocs" {
     var vm = try CairoVM.init(allocator, .{});
     defer vm.deinit();
 
-    vm.run_context.ap.* = Relocatable.new(1, 0);
+    vm.run_context.ap.* = Relocatable.init(1, 0);
     // Test body
 
-    const value_op0 = Relocatable.new(1, 0);
-    const value_op1 = Relocatable.new(1, 1);
+    const value_op0 = Relocatable.init(1, 0);
+    const value_op1 = Relocatable.init(1, 1);
 
     const op0 = MaybeRelocatable.fromRelocatable(value_op0);
     const op1 = MaybeRelocatable.fromRelocatable(value_op1);
@@ -1056,7 +1056,7 @@ test "compute res mul fails felt and reloc" {
     defer vm.deinit();
     // Test body
 
-    const value_op0 = Relocatable.new(1, 0);
+    const value_op0 = Relocatable.init(1, 0);
     const op0 = MaybeRelocatable.fromRelocatable(value_op0);
     const op1 = MaybeRelocatable.fromFelt(starknet_felt.Felt252.fromInteger(2));
 
@@ -1074,7 +1074,7 @@ test "compute res Unconstrained should return null" {
     var vm = try CairoVM.init(allocator, .{});
     defer vm.deinit();
 
-    vm.run_context.ap.* = Relocatable.new(1, 0);
+    vm.run_context.ap.* = Relocatable.init(1, 0);
     // Test body
 
     const value_op0 = MaybeRelocatable.fromFelt(starknet_felt.Felt252.fromInteger(2));
@@ -1099,17 +1099,17 @@ test "compute operands add AP" {
     var vm = try CairoVM.init(allocator, .{});
     defer vm.deinit();
 
-    vm.run_context.ap.* = Relocatable.new(1, 0);
+    vm.run_context.ap.* = Relocatable.init(1, 0);
 
     // Test body
 
-    const dst_addr = Relocatable.new(1, 0);
+    const dst_addr = Relocatable.init(1, 0);
     const dst_val = MaybeRelocatable{ .felt = Felt252.fromInteger(5) };
 
-    const op0_addr = Relocatable.new(1, 1);
+    const op0_addr = Relocatable.init(1, 1);
     const op0_val = MaybeRelocatable{ .felt = Felt252.fromInteger(2) };
 
-    const op1_addr = Relocatable.new(1, 2);
+    const op1_addr = Relocatable.init(1, 2);
     const op1_val = MaybeRelocatable{ .felt = Felt252.fromInteger(3) };
 
     try memory.setUpMemory(
@@ -1159,17 +1159,17 @@ test "compute operands mul FP" {
     var vm = try CairoVM.init(allocator, .{});
     defer vm.deinit();
 
-    vm.run_context.fp.* = Relocatable.new(1, 0);
+    vm.run_context.fp.* = Relocatable.init(1, 0);
 
     // Test body
 
-    const dst_addr = Relocatable.new(1, 0);
+    const dst_addr = Relocatable.init(1, 0);
     const dst_val = MaybeRelocatable{ .felt = Felt252.fromInteger(6) };
 
-    const op0_addr = Relocatable.new(1, 1);
+    const op0_addr = Relocatable.init(1, 1);
     const op0_val = MaybeRelocatable{ .felt = Felt252.fromInteger(2) };
 
-    const op1_addr = Relocatable.new(1, 2);
+    const op1_addr = Relocatable.init(1, 2);
     const op1_val = MaybeRelocatable{ .felt = Felt252.fromInteger(3) };
     try memory.setUpMemory(
         vm.segments.memory,
@@ -1262,9 +1262,9 @@ test "updateRegisters all regular" {
         .{},
     );
     defer vm.deinit();
-    vm.run_context.pc.* = Relocatable.new(0, 4);
-    vm.run_context.ap.* = Relocatable.new(0, 5);
-    vm.run_context.fp.* = Relocatable.new(0, 6);
+    vm.run_context.pc.* = Relocatable.init(0, 4);
+    vm.run_context.ap.* = Relocatable.init(0, 5);
+    vm.run_context.fp.* = Relocatable.init(0, 6);
 
     // Test body
     try vm.updateRegisters(
@@ -1275,19 +1275,19 @@ test "updateRegisters all regular" {
     // Test checks
     // Verify the PC offset was incremented by 5.
     try expectEqual(
-        Relocatable.new(0, 5),
+        Relocatable.init(0, 5),
         vm.run_context.pc.*,
     );
 
     // Verify the AP offset was incremented by 5.
     try expectEqual(
-        Relocatable.new(0, 5),
+        Relocatable.init(0, 5),
         vm.run_context.ap.*,
     );
 
     // Verify the FP offset was incremented by 6.
     try expectEqual(
-        Relocatable.new(0, 6),
+        Relocatable.init(0, 6),
         vm.run_context.fp.*,
     );
 }
@@ -1301,7 +1301,7 @@ test "updateRegisters with mixed types" {
     instruction.fp_update = .Dst;
 
     const operands = OperandsResult{
-        .dst = .{ .relocatable = Relocatable.new(
+        .dst = .{ .relocatable = Relocatable.init(
             1,
             11,
         ) },
@@ -1320,9 +1320,9 @@ test "updateRegisters with mixed types" {
         .{},
     );
     defer vm.deinit();
-    vm.run_context.pc.* = Relocatable.new(0, 4);
-    vm.run_context.ap.* = Relocatable.new(0, 5);
-    vm.run_context.fp.* = Relocatable.new(0, 6);
+    vm.run_context.pc.* = Relocatable.init(0, 4);
+    vm.run_context.ap.* = Relocatable.init(0, 5);
+    vm.run_context.fp.* = Relocatable.init(0, 6);
 
     // Test body
     try vm.updateRegisters(
@@ -1333,19 +1333,19 @@ test "updateRegisters with mixed types" {
     // Test checks
     // Verify the PC offset was incremented by 12.
     try expectEqual(
-        Relocatable.new(0, 12),
+        Relocatable.init(0, 12),
         vm.run_context.pc.*,
     );
 
     // Verify the AP offset was incremented by 7.
     try expectEqual(
-        Relocatable.new(0, 7),
+        Relocatable.init(0, 7),
         vm.run_context.ap.*,
     );
 
     // Verify the FP offset was incremented by 11.
     try expectEqual(
-        Relocatable.new(1, 11),
+        Relocatable.init(1, 11),
         vm.run_context.fp.*,
     );
 }
@@ -1363,7 +1363,7 @@ test "CairoVM: computeOp0Deductions should return op0 from deduceOp0 if deduceMe
         MaybeRelocatable.fromSegment(0, 1),
         try vm.computeOp0Deductions(
             std.testing.allocator,
-            Relocatable.new(0, 7),
+            Relocatable.init(0, 7),
             &instr,
             &null,
             &null,
@@ -1379,7 +1379,7 @@ test "CairoVM: computeOp0Deductions with a valid built in and non null deduceMem
     );
     defer vm.deinit();
     var instance_def: BitwiseInstanceDef = .{ .ratio = null, .total_n_bits = 2 };
-    try vm.builtin_runners.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.new(
+    try vm.builtin_runners.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.init(
         &instance_def,
         true,
     ) });
@@ -1399,7 +1399,7 @@ test "CairoVM: computeOp0Deductions with a valid built in and non null deduceMem
         MaybeRelocatable.fromU256(8),
         try vm.computeOp0Deductions(
             std.testing.allocator,
-            Relocatable.new(0, 7),
+            Relocatable.init(0, 7),
             &deduceOpTestInstr,
             &.{ .relocatable = .{} },
             &.{ .relocatable = .{} },
@@ -1421,7 +1421,7 @@ test "CairoVM: computeOp0Deductions should return VM error if deduceOp0 and dedu
         CairoVMError.FailedToComputeOp0,
         vm.computeOp0Deductions(
             std.testing.allocator,
-            Relocatable.new(0, 7),
+            Relocatable.init(0, 7),
             &instr,
             &MaybeRelocatable.fromU64(4),
             &MaybeRelocatable.fromU64(0),
@@ -1487,7 +1487,7 @@ test "CairoVM: deduceDst should return fp Relocatable if Call opcode" {
     // Test setup
     var vm = try CairoVM.init(std.testing.allocator, .{});
     defer vm.deinit();
-    vm.run_context.fp.* = Relocatable.new(3, 23);
+    vm.run_context.fp.* = Relocatable.init(3, 23);
 
     var instruction = testInstruction;
     instruction.opcode = .Call;
@@ -1521,7 +1521,7 @@ test "CairoVM: addMemorySegment should return a proper relocatable address for t
 
     // Test check
     try expectEqual(
-        Relocatable.new(0, 0),
+        Relocatable.init(0, 0),
         try vm.addMemorySegment(),
     );
 }
@@ -1550,7 +1550,7 @@ test "CairoVM: getRelocatable without value raises error" {
     // Test check
     try expectEqual(
         @as(?MaybeRelocatable, null),
-        vm.getRelocatable(Relocatable.new(0, 0)),
+        vm.getRelocatable(Relocatable.init(0, 0)),
     );
 }
 
@@ -1571,7 +1571,7 @@ test "CairoVM: getRelocatable with value should return a MaybeRelocatable" {
     // Test check
     try expectEqual(
         MaybeRelocatable.fromU256(5),
-        (vm.getRelocatable(Relocatable.new(34, 12))).?,
+        (vm.getRelocatable(Relocatable.init(34, 12))).?,
     );
 }
 
@@ -1582,7 +1582,7 @@ test "CairoVM: getBuiltinRunners should return a reference to the builtin runner
     );
     defer vm.deinit();
     var instance_def: BitwiseInstanceDef = .{ .ratio = null, .total_n_bits = 2 };
-    try vm.builtin_runners.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.new(
+    try vm.builtin_runners.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.init(
         &instance_def,
         true,
     ) });
@@ -1592,7 +1592,7 @@ test "CairoVM: getBuiltinRunners should return a reference to the builtin runner
 
     var expected = ArrayList(BuiltinRunner).init(std.testing.allocator);
     defer expected.deinit();
-    try expected.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.new(
+    try expected.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.init(
         &instance_def,
         true,
     ) });
@@ -1650,7 +1650,7 @@ test "CairoVM: getFelt should return UnknownMemoryCell error if no value at the 
     // Test checks
     try expectError(
         error.UnknownMemoryCell,
-        vm.getFelt(Relocatable.new(10, 30)),
+        vm.getFelt(Relocatable.init(10, 30)),
     );
 }
 
@@ -1674,7 +1674,7 @@ test "CairoVM: getFelt should return Felt252 if available at the given address" 
     // Test checks
     try expectEqual(
         Felt252.fromInteger(23),
-        try vm.getFelt(Relocatable.new(10, 30)),
+        try vm.getFelt(Relocatable.init(10, 30)),
     );
 }
 
@@ -1698,7 +1698,7 @@ test "CairoVM: getFelt should return ExpectedInteger error if Relocatable instea
     // Test checks
     try expectError(
         error.ExpectedInteger,
-        vm.getFelt(Relocatable.new(10, 30)),
+        vm.getFelt(Relocatable.init(10, 30)),
     );
 }
 
@@ -1708,7 +1708,7 @@ test "CairoVM: computeOp1Deductions should return op1 from deduceMemoryCell if n
     defer vm.deinit();
 
     var instance_def: BitwiseInstanceDef = .{ .ratio = null, .total_n_bits = 2 };
-    try vm.builtin_runners.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.new(
+    try vm.builtin_runners.append(BuiltinRunner{ .Bitwise = BitwiseBuiltinRunner.init(
         &instance_def,
         true,
     ) });
@@ -1731,7 +1731,7 @@ test "CairoVM: computeOp1Deductions should return op1 from deduceMemoryCell if n
         MaybeRelocatable.fromU256(8),
         try vm.computeOp1Deductions(
             std.testing.allocator,
-            Relocatable.new(0, 7),
+            Relocatable.init(0, 7),
             &res,
             &instr,
             &null,
@@ -1757,7 +1757,7 @@ test "CairoVM: computeOp1Deductions should return op1 from deduceOp1 if deduceMe
         MaybeRelocatable.fromU64(7),
         try vm.computeOp1Deductions(
             std.testing.allocator,
-            Relocatable.new(0, 7),
+            Relocatable.init(0, 7),
             &res,
             &instr,
             &dst,
@@ -1780,7 +1780,7 @@ test "CairoVM: computeOp1Deductions should modify res (if null) using res from d
 
     _ = try vm.computeOp1Deductions(
         std.testing.allocator,
-        Relocatable.new(0, 7),
+        Relocatable.init(0, 7),
         &res,
         &instr,
         &dst,
@@ -1811,7 +1811,7 @@ test "CairoVM: computeOp1Deductions should return CairoVMError error if deduceMe
         CairoVMError.FailedToComputeOp1,
         vm.computeOp1Deductions(
             std.testing.allocator,
-            Relocatable.new(0, 7),
+            Relocatable.init(0, 7),
             &res,
             &instr,
             &null,
@@ -1884,13 +1884,13 @@ test "CairoVM: InserDeducedOperands should insert operands if set as deduced" {
 
     // Test body
 
-    const dst_addr = Relocatable.new(1, 0);
+    const dst_addr = Relocatable.init(1, 0);
     const dst_val = MaybeRelocatable{ .felt = Felt252.fromInteger(6) };
 
-    const op0_addr = Relocatable.new(1, 1);
+    const op0_addr = Relocatable.init(1, 1);
     const op0_val = MaybeRelocatable{ .felt = Felt252.fromInteger(2) };
 
-    const op1_addr = Relocatable.new(1, 2);
+    const op1_addr = Relocatable.init(1, 2);
     const op1_val = MaybeRelocatable{ .felt = Felt252.fromInteger(3) };
     try memory.setUpMemory(
         vm.segments.memory,
@@ -1913,15 +1913,15 @@ test "CairoVM: InserDeducedOperands should insert operands if set as deduced" {
 
     // Test checks
     try expectEqual(
-        vm.segments.memory.get(Relocatable.new(1, 0)),
+        vm.segments.memory.get(Relocatable.init(1, 0)),
         dst_val,
     );
     try expectEqual(
-        vm.segments.memory.get(Relocatable.new(1, 1)),
+        vm.segments.memory.get(Relocatable.init(1, 1)),
         op0_val,
     );
     try expectEqual(
-        vm.segments.memory.get(Relocatable.new(1, 2)),
+        vm.segments.memory.get(Relocatable.init(1, 2)),
         op1_val,
     );
 }
@@ -1938,13 +1938,13 @@ test "CairoVM: InserDeducedOperands insert operands should not be inserted if no
 
     // Test body
 
-    const dst_addr = Relocatable.new(1, 0);
+    const dst_addr = Relocatable.init(1, 0);
     const dst_val = MaybeRelocatable{ .felt = Felt252.fromInteger(6) };
 
-    const op0_addr = Relocatable.new(1, 1);
+    const op0_addr = Relocatable.init(1, 1);
     const op0_val = MaybeRelocatable{ .felt = Felt252.fromInteger(2) };
 
-    const op1_addr = Relocatable.new(1, 2);
+    const op1_addr = Relocatable.init(1, 2);
     const op1_val = MaybeRelocatable{ .felt = Felt252.fromInteger(3) };
     try memory.setUpMemory(
         vm.segments.memory,
@@ -1969,15 +1969,15 @@ test "CairoVM: InserDeducedOperands insert operands should not be inserted if no
     // Test checks
     try expectEqual(
         @as(?MaybeRelocatable, null),
-        vm.segments.memory.get(Relocatable.new(1, 0)),
+        vm.segments.memory.get(Relocatable.init(1, 0)),
     );
     try expectEqual(
         @as(?MaybeRelocatable, null),
-        vm.segments.memory.get(Relocatable.new(1, 1)),
+        vm.segments.memory.get(Relocatable.init(1, 1)),
     );
     try expectEqual(
         @as(?MaybeRelocatable, null),
-        vm.segments.memory.get(Relocatable.new(1, 2)),
+        vm.segments.memory.get(Relocatable.init(1, 2)),
     );
 }
 
@@ -2002,9 +2002,9 @@ test "CairoVM: markAddressRangeAsAccessed should mark memory segments as accesse
     );
     defer vm.segments.memory.deinitData(std.testing.allocator);
 
-    try vm.markAddressRangeAsAccessed(Relocatable.new(0, 0), 3);
-    try vm.markAddressRangeAsAccessed(Relocatable.new(0, 10), 2);
-    try vm.markAddressRangeAsAccessed(Relocatable.new(1, 1), 1);
+    try vm.markAddressRangeAsAccessed(Relocatable.init(0, 0), 3);
+    try vm.markAddressRangeAsAccessed(Relocatable.init(0, 10), 2);
+    try vm.markAddressRangeAsAccessed(Relocatable.init(1, 1), 1);
 
     try expect(vm.segments.memory.data.items[0].items[0].?.is_accessed);
     try expect(vm.segments.memory.data.items[0].items[1].?.is_accessed);
@@ -2024,6 +2024,6 @@ test "CairoVM: markAddressRangeAsAccessed should return an error if the run is n
 
     try expectError(
         CairoVMError.RunNotFinished,
-        vm.markAddressRangeAsAccessed(Relocatable.new(0, 0), 3),
+        vm.markAddressRangeAsAccessed(Relocatable.init(0, 0), 3),
     );
 }

--- a/src/vm/memory/relocatable.zig
+++ b/src/vm/memory/relocatable.zig
@@ -22,7 +22,7 @@ pub const Relocatable = struct {
     // - offset - The offset in the memory segment.
     // # Returns
     // A new Relocatable.
-    pub fn new(segment_index: i64, offset: u64) Self {
+    pub fn init(segment_index: i64, offset: u64) Self {
         return .{ .segment_index = segment_index, .offset = offset };
     }
 
@@ -604,7 +604,7 @@ pub const MaybeRelocatable = union(enum) {
     /// # Returns
     /// A new MaybeRelocatable.
     pub fn fromSegment(segment_index: i64, offset: u64) Self {
-        return fromRelocatable(Relocatable.new(segment_index, offset));
+        return fromRelocatable(Relocatable.init(segment_index, offset));
     }
 };
 
@@ -616,25 +616,25 @@ const expectEqual = std.testing.expectEqual;
 const expectError = std.testing.expectError;
 
 test "Relocatable: eq should return true if two Relocatable are the same." {
-    try expect(Relocatable.new(-1, 4).eq(Relocatable.new(-1, 4)));
-    try expect(Relocatable.new(2, 4).eq(Relocatable.new(2, 4)));
+    try expect(Relocatable.init(-1, 4).eq(Relocatable.init(-1, 4)));
+    try expect(Relocatable.init(2, 4).eq(Relocatable.init(2, 4)));
 }
 
 test "Relocatable: eq should return false if two Relocatable are not the same." {
-    const relocatable1 = Relocatable.new(2, 4);
-    const relocatable2 = Relocatable.new(2, 5);
-    const relocatable3 = Relocatable.new(-1, 4);
+    const relocatable1 = Relocatable.init(2, 4);
+    const relocatable2 = Relocatable.init(2, 5);
+    const relocatable3 = Relocatable.init(-1, 4);
     try expect(!relocatable1.eq(relocatable2));
     try expect(!relocatable1.eq(relocatable3));
 }
 
 test "Relocatable: addUint should add a u64 to a Relocatable and return a new Relocatable." {
-    const relocatable = Relocatable.new(
+    const relocatable = Relocatable.init(
         2,
         4,
     );
     const result = try relocatable.addUint(24);
-    const expected = Relocatable.new(
+    const expected = Relocatable.init(
         2,
         28,
     );
@@ -645,12 +645,12 @@ test "Relocatable: addUint should add a u64 to a Relocatable and return a new Re
 }
 
 test "Relocatable: addInt should add a positive i64 to a Relocatable and return a new Relocatable" {
-    const relocatable = Relocatable.new(
+    const relocatable = Relocatable.init(
         2,
         4,
     );
     const result = try relocatable.addInt(24);
-    const expected = Relocatable.new(
+    const expected = Relocatable.init(
         2,
         28,
     );
@@ -661,12 +661,12 @@ test "Relocatable: addInt should add a positive i64 to a Relocatable and return 
 }
 
 test "Relocatable: addInt should add a negative i64 to a Relocatable and return a new Relocatable" {
-    const relocatable = Relocatable.new(
+    const relocatable = Relocatable.init(
         2,
         4,
     );
     const result = try relocatable.addInt(-4);
-    const expected = Relocatable.new(
+    const expected = Relocatable.init(
         2,
         0,
     );
@@ -677,12 +677,12 @@ test "Relocatable: addInt should add a negative i64 to a Relocatable and return 
 }
 
 test "Relocatable: subUint should substract a u64 from a Relocatable" {
-    const relocatable = Relocatable.new(
+    const relocatable = Relocatable.init(
         2,
         4,
     );
     const result = try relocatable.subUint(2);
-    const expected = Relocatable.new(
+    const expected = Relocatable.init(
         2,
         2,
     );
@@ -693,7 +693,7 @@ test "Relocatable: subUint should substract a u64 from a Relocatable" {
 }
 
 test "Relocatable: subUint should return an error if substraction is impossible" {
-    const relocatable = Relocatable.new(
+    const relocatable = Relocatable.init(
         2,
         4,
     );
@@ -706,57 +706,57 @@ test "Relocatable: subUint should return an error if substraction is impossible"
 
 test "Relocatable: sub two Relocatable with same segment index" {
     try expectEqual(
-        Relocatable.new(2, 3),
-        try Relocatable.new(2, 8).sub(Relocatable.new(2, 5)),
+        Relocatable.init(2, 3),
+        try Relocatable.init(2, 8).sub(Relocatable.init(2, 5)),
     );
 }
 
 test "Relocatable: sub two Relocatable with same segment index but impossible subtraction" {
     try expectError(
         MathError.RelocatableSubUsizeNegOffset,
-        Relocatable.new(2, 2).sub(Relocatable.new(2, 5)),
+        Relocatable.init(2, 2).sub(Relocatable.init(2, 5)),
     );
 }
 
 test "Relocatable: sub two Relocatable with different segment index" {
     try expectError(
         CairoVMError.TypeMismatchNotRelocatable,
-        Relocatable.new(2, 8).sub(Relocatable.new(3, 5)),
+        Relocatable.init(2, 8).sub(Relocatable.init(3, 5)),
     );
 }
 
 test "Relocatable: addUintInPlace should increase offset" {
-    var relocatable = Relocatable.new(2, 8);
+    var relocatable = Relocatable.init(2, 8);
     relocatable.addUintInPlace(10);
     try expectEqual(
-        Relocatable.new(2, 18),
+        Relocatable.init(2, 18),
         relocatable,
     );
 }
 
 test "Relocatable: addFeltInPlace should increase offset" {
-    var relocatable = Relocatable.new(2, 8);
+    var relocatable = Relocatable.init(2, 8);
     try relocatable.addFeltInPlace(Felt252.fromInteger(1000000000000000));
     try expectEqual(
-        Relocatable.new(2, 1000000000000008),
+        Relocatable.init(2, 1000000000000008),
         relocatable,
     );
 }
 
 test "Relocatable: addMaybeRelocatableInplace should increase offset if other is Felt" {
-    var relocatable = Relocatable.new(2, 8);
+    var relocatable = Relocatable.init(2, 8);
     try relocatable.addMaybeRelocatableInplace(MaybeRelocatable{ .felt = Felt252.fromInteger(1000000000000000) });
     try expectEqual(
-        Relocatable.new(2, 1000000000000008),
+        Relocatable.init(2, 1000000000000008),
         relocatable,
     );
 }
 
 test "Relocatable: addMaybeRelocatableInplace should return an error if other is Relocatable" {
-    var relocatable = Relocatable.new(2, 8);
+    var relocatable = Relocatable.init(2, 8);
     try expectError(
         CairoVMError.TypeMismatchNotFelt,
-        relocatable.addMaybeRelocatableInplace(MaybeRelocatable{ .relocatable = Relocatable.new(
+        relocatable.addMaybeRelocatableInplace(MaybeRelocatable{ .relocatable = Relocatable.init(
             0,
             10,
         ) }),
@@ -765,131 +765,131 @@ test "Relocatable: addMaybeRelocatableInplace should return an error if other is
 
 test "Relocatable: lt should return true if other relocatable is greater than or equal, false otherwise" {
     // 1 == 2
-    try expect(!Relocatable.new(2, 4).lt(Relocatable.new(2, 4)));
+    try expect(!Relocatable.init(2, 4).lt(Relocatable.init(2, 4)));
 
     // 1 < 2
-    try expect(Relocatable.new(-1, 2).lt(Relocatable.new(-1, 3)));
-    try expect(Relocatable.new(1, 5).lt(Relocatable.new(2, 4)));
+    try expect(Relocatable.init(-1, 2).lt(Relocatable.init(-1, 3)));
+    try expect(Relocatable.init(1, 5).lt(Relocatable.init(2, 4)));
 
     // 1 > 2
-    try expect(!Relocatable.new(2, 5).lt(Relocatable.new(2, 4)));
-    try expect(!Relocatable.new(3, 3).lt(Relocatable.new(2, 4)));
+    try expect(!Relocatable.init(2, 5).lt(Relocatable.init(2, 4)));
+    try expect(!Relocatable.init(3, 3).lt(Relocatable.init(2, 4)));
 }
 
 test "Relocatable: le should return true if other relocatable is greater, false otherwise" {
     // 1 == 2
-    try expect(Relocatable.new(2, 4).le(Relocatable.new(2, 4)));
+    try expect(Relocatable.init(2, 4).le(Relocatable.init(2, 4)));
 
     // 1 < 2
-    try expect(Relocatable.new(-1, 2).le(Relocatable.new(-1, 3)));
-    try expect(Relocatable.new(1, 5).le(Relocatable.new(2, 4)));
+    try expect(Relocatable.init(-1, 2).le(Relocatable.init(-1, 3)));
+    try expect(Relocatable.init(1, 5).le(Relocatable.init(2, 4)));
 
     // 1 > 2
-    try expect(!Relocatable.new(2, 5).le(Relocatable.new(2, 4)));
-    try expect(!Relocatable.new(3, 3).le(Relocatable.new(2, 4)));
+    try expect(!Relocatable.init(2, 5).le(Relocatable.init(2, 4)));
+    try expect(!Relocatable.init(3, 3).le(Relocatable.init(2, 4)));
 }
 
 test "Relocatable: gt should return true if other relocatable is less than or 1 == 2ual, false otherwise" {
     // 1 == 2
-    try expect(!Relocatable.new(2, 4).gt(Relocatable.new(2, 4)));
+    try expect(!Relocatable.init(2, 4).gt(Relocatable.init(2, 4)));
 
     // 1 < 2
-    try expect(!Relocatable.new(-1, 2).gt(Relocatable.new(-1, 3)));
-    try expect(!Relocatable.new(1, 5).gt(Relocatable.new(2, 4)));
+    try expect(!Relocatable.init(-1, 2).gt(Relocatable.init(-1, 3)));
+    try expect(!Relocatable.init(1, 5).gt(Relocatable.init(2, 4)));
 
     // 1 > 2
-    try expect(Relocatable.new(2, 5).gt(Relocatable.new(2, 4)));
-    try expect(Relocatable.new(3, 3).gt(Relocatable.new(2, 4)));
+    try expect(Relocatable.init(2, 5).gt(Relocatable.init(2, 4)));
+    try expect(Relocatable.init(3, 3).gt(Relocatable.init(2, 4)));
 }
 
 test "Relocatable: ge should return true if other relocatable is less, false otherwise" {
     // 1 == 2
-    try expect(Relocatable.new(2, 4).ge(Relocatable.new(2, 4)));
+    try expect(Relocatable.init(2, 4).ge(Relocatable.init(2, 4)));
 
     // 1 < 2
-    try expect(!Relocatable.new(-1, 2).ge(Relocatable.new(-1, 3)));
-    try expect(!Relocatable.new(1, 5).ge(Relocatable.new(2, 4)));
+    try expect(!Relocatable.init(-1, 2).ge(Relocatable.init(-1, 3)));
+    try expect(!Relocatable.init(1, 5).ge(Relocatable.init(2, 4)));
 
     // 1 > 2
-    try expect(Relocatable.new(2, 5).ge(Relocatable.new(2, 4)));
-    try expect(Relocatable.new(3, 3).ge(Relocatable.new(2, 4)));
+    try expect(Relocatable.init(2, 5).ge(Relocatable.init(2, 4)));
+    try expect(Relocatable.init(3, 3).ge(Relocatable.init(2, 4)));
 }
 
 test "Relocatable: cmpt should return .eq if self and other are the same" {
     try expectEqual(
         std.math.Order.eq,
-        Relocatable.new(2, 4).cmp(Relocatable.new(2, 4)),
+        Relocatable.init(2, 4).cmp(Relocatable.init(2, 4)),
     );
 }
 
 test "Relocatable: cmpt should return .lt if self and other segment are the same but self offset < other offset" {
     try expectEqual(
         std.math.Order.lt,
-        Relocatable.new(2, 2).cmp(Relocatable.new(2, 4)),
+        Relocatable.init(2, 2).cmp(Relocatable.init(2, 4)),
     );
 }
 
 test "Relocatable: cmpt should return .gt if self and other segment are the same but self offset > other offset" {
     try expectEqual(
         std.math.Order.gt,
-        Relocatable.new(2, 14).cmp(Relocatable.new(2, 4)),
+        Relocatable.init(2, 14).cmp(Relocatable.init(2, 4)),
     );
 }
 
 test "Relocatable: cmpt should return .lt if self segment < other segment" {
     try expectEqual(
         std.math.Order.lt,
-        Relocatable.new(1, 4).cmp(Relocatable.new(2, 4)),
+        Relocatable.init(1, 4).cmp(Relocatable.init(2, 4)),
     );
     try expectEqual(
         std.math.Order.lt,
-        Relocatable.new(1, 44).cmp(Relocatable.new(2, 4)),
+        Relocatable.init(1, 44).cmp(Relocatable.init(2, 4)),
     );
 }
 
 test "Relocatable: cmpt should return .gt if self segment > other segment" {
     try expectEqual(
         std.math.Order.gt,
-        Relocatable.new(10, 4).cmp(Relocatable.new(2, 4)),
+        Relocatable.init(10, 4).cmp(Relocatable.init(2, 4)),
     );
     try expectEqual(
         std.math.Order.gt,
-        Relocatable.new(10, 4).cmp(Relocatable.new(2, 44)),
+        Relocatable.init(10, 4).cmp(Relocatable.init(2, 44)),
     );
 }
 
 test "Relocatable: addFelt should add a relocatable and a Felt252" {
     try expectEqual(
         Relocatable{ .segment_index = 2, .offset = 54 },
-        try Relocatable.new(2, 44).addFelt(Felt252.fromInteger(10)),
+        try Relocatable.init(2, 44).addFelt(Felt252.fromInteger(10)),
     );
 }
 
 test "Relocatable: addFelt should return an error if number after offset addition is too large" {
     try expectError(
         MathError.ValueTooLarge,
-        Relocatable.new(2, 44).addFelt(Felt252.fromInteger(std.math.maxInt(u256))),
+        Relocatable.init(2, 44).addFelt(Felt252.fromInteger(std.math.maxInt(u256))),
     );
 }
 
 test "Relocatable: subFelt should subtract a Felt252 from a relocatable" {
     try expectEqual(
         Relocatable{ .segment_index = 2, .offset = 34 },
-        try Relocatable.new(2, 44).subFelt(Felt252.fromInteger(10)),
+        try Relocatable.init(2, 44).subFelt(Felt252.fromInteger(10)),
     );
 }
 
 test "Relocatable: subFelt should return an error if relocatable cannot be coerced to u64" {
     try expectError(
         MathError.ValueTooLarge,
-        Relocatable.new(2, 44).subFelt(Felt252.fromInteger(std.math.maxInt(u256))),
+        Relocatable.init(2, 44).subFelt(Felt252.fromInteger(std.math.maxInt(u256))),
     );
 }
 
 test "Relocatable: subFelt should return an error if relocatable offset is smaller than Felt252" {
     try expectError(
         MathError.RelocatableSubUsizeNegOffset,
-        Relocatable.new(2, 7).subFelt(Felt252.fromInteger(10)),
+        Relocatable.init(2, 7).subFelt(Felt252.fromInteger(10)),
     );
 }
 
@@ -897,7 +897,7 @@ test "Relocatable: relocateAddress should return an error if relocatable segment
     var relocation_table = [_]usize{ 1, 2, 3, 4 };
     try expectError(
         MemoryError.TemporarySegmentInRelocation,
-        Relocatable.new(-2, 7).relocateAddress(&relocation_table),
+        Relocatable.init(-2, 7).relocateAddress(&relocation_table),
     );
 }
 
@@ -905,7 +905,7 @@ test "Relocatable: relocateAddress should return an error relocation table lengt
     var relocation_table = [_]usize{ 1, 2, 3, 4 };
     try expectError(
         MemoryError.Relocation,
-        Relocatable.new(5, 7).relocateAddress(&relocation_table),
+        Relocatable.init(5, 7).relocateAddress(&relocation_table),
     );
 }
 
@@ -913,7 +913,7 @@ test "Relocatable: relocateAddress should return an error relocation table lengt
     var relocation_table = [_]usize{ 1, 2, 3, 4 };
     try expectError(
         MemoryError.Relocation,
-        Relocatable.new(4, 7).relocateAddress(&relocation_table),
+        Relocatable.init(4, 7).relocateAddress(&relocation_table),
     );
 }
 
@@ -921,7 +921,7 @@ test "Relocatable: relocateAddress should return a proper usize to relocate the 
     var relocation_table = [_]usize{ 1, 2, 3, 4 };
     try expectEqual(
         @as(usize, 11),
-        try Relocatable.new(3, 7).relocateAddress(&relocation_table),
+        try Relocatable.init(3, 7).relocateAddress(&relocation_table),
     );
 }
 
@@ -1116,7 +1116,7 @@ test "MaybeRelocatable: cmp should return proper order results for Felt252 compa
 test "MaybeRelocatable: tryIntoRelocatable should return Relocatable if MaybeRelocatable is Relocatable" {
     var maybeRelocatable = MaybeRelocatable.fromSegment(0, 10);
     try expectEqual(
-        Relocatable.new(0, 10),
+        Relocatable.init(0, 10),
         try maybeRelocatable.tryIntoRelocatable(),
     );
 }
@@ -1311,7 +1311,7 @@ test "MaybeRelocatable: relocateValue with index out of bounds" {
 test "fromRelocatable: should create a MaybeRelocatable from a Relocatable" {
     try expectEqual(
         MaybeRelocatable.fromSegment(0, 3),
-        MaybeRelocatable.fromRelocatable(Relocatable.new(0, 3)),
+        MaybeRelocatable.fromRelocatable(Relocatable.init(0, 3)),
     );
 }
 

--- a/src/vm/memory/segments.zig
+++ b/src/vm/memory/segments.zig
@@ -417,11 +417,11 @@ test "set get integer value in segment memory" {
     // *                      TEST BODY                           *
     // ************************************************************
 
-    const address_1 = Relocatable.new(
+    const address_1 = Relocatable.init(
         0,
         0,
     );
-    const address_2 = Relocatable.new(
+    const address_2 = Relocatable.init(
         -1,
         0,
     );
@@ -808,7 +808,7 @@ test "MemorySegmentManager: isValidMemoryValue should return false if invalid se
     var memory_segment_manager = try MemorySegmentManager.init(std.testing.allocator);
     defer memory_segment_manager.deinit();
     try memory_segment_manager.segment_used_sizes.put(0, 10);
-    var value: MaybeRelocatable = .{ .relocatable = Relocatable.new(1, 1) };
+    var value: MaybeRelocatable = .{ .relocatable = Relocatable.init(1, 1) };
     try expect(!memory_segment_manager.isValidMemoryValue(&value));
 }
 
@@ -877,10 +877,10 @@ test "MemorySegmentManager: loadData with empty data" {
     defer data.deinit();
 
     try expectEqual(
-        Relocatable.new(0, 3),
+        Relocatable.init(0, 3),
         try memory_segment_manager.loadData(
             allocator,
-            Relocatable.new(0, 3),
+            Relocatable.init(0, 3),
             &data,
         ),
     );
@@ -900,15 +900,15 @@ test "MemorySegmentManager: loadData with one element" {
 
     const actual = try memory_segment_manager.loadData(
         allocator,
-        Relocatable.new(0, 0),
+        Relocatable.init(0, 0),
         &data,
     );
     defer memory_segment_manager.memory.deinitData(std.testing.allocator);
 
-    try expectEqual(Relocatable.new(0, 1), actual);
+    try expectEqual(Relocatable.init(0, 1), actual);
     try expectEqual(
         MaybeRelocatable.fromU256(4),
-        (memory_segment_manager.memory.get(Relocatable.new(0, 0))).?,
+        (memory_segment_manager.memory.get(Relocatable.init(0, 0))).?,
     );
 }
 
@@ -928,23 +928,23 @@ test "MemorySegmentManager: loadData with three elements" {
 
     const actual = try memory_segment_manager.loadData(
         allocator,
-        Relocatable.new(0, 0),
+        Relocatable.init(0, 0),
         &data,
     );
     defer memory_segment_manager.memory.deinitData(std.testing.allocator);
 
-    try expectEqual(Relocatable.new(0, 3), actual);
+    try expectEqual(Relocatable.init(0, 3), actual);
     try expectEqual(
         MaybeRelocatable.fromU256(4),
-        (memory_segment_manager.memory.get(Relocatable.new(0, 0))).?,
+        (memory_segment_manager.memory.get(Relocatable.init(0, 0))).?,
     );
     try expectEqual(
         MaybeRelocatable.fromU256(5),
-        (memory_segment_manager.memory.get(Relocatable.new(0, 1))).?,
+        (memory_segment_manager.memory.get(Relocatable.init(0, 1))).?,
     );
     try expectEqual(
         MaybeRelocatable.fromU256(6),
-        (memory_segment_manager.memory.get(Relocatable.new(0, 2))).?,
+        (memory_segment_manager.memory.get(Relocatable.init(0, 2))).?,
     );
 }
 
@@ -990,9 +990,9 @@ test "MemorySegmentManager: getPublicMemoryAddresses with correct segment offset
     try public_memory_offsets.append(inner_list_4);
     try public_memory_offsets.append(inner_list_5);
 
-    try expectEqual(memory_segment_manager.addSegment(), Relocatable.new(5, 0));
-    try expectEqual(memory_segment_manager.addSegment(), Relocatable.new(6, 0));
-    try memory_segment_manager.memory.set(allocator, Relocatable.new(5, 4), .{ .felt = Felt252.fromInteger(0) });
+    try expectEqual(memory_segment_manager.addSegment(), Relocatable.init(5, 0));
+    try expectEqual(memory_segment_manager.addSegment(), Relocatable.init(6, 0));
+    try memory_segment_manager.memory.set(allocator, Relocatable.init(5, 4), .{ .felt = Felt252.fromInteger(0) });
     defer memory_segment_manager.memory.deinitData(allocator);
 
     // memory_segment_manager.memory.freeze();
@@ -1065,9 +1065,9 @@ test "MemorySegmentManager: getPublicMemoryAddresses with incorrect segment offs
     try public_memory_offsets.append(inner_list_4);
     try public_memory_offsets.append(inner_list_5);
 
-    try expectEqual(memory_segment_manager.addSegment(), Relocatable.new(5, 0));
-    try expectEqual(memory_segment_manager.addSegment(), Relocatable.new(6, 0));
-    try memory_segment_manager.memory.set(allocator, Relocatable.new(5, 4), .{ .felt = Felt252.fromInteger(0) });
+    try expectEqual(memory_segment_manager.addSegment(), Relocatable.init(5, 0));
+    try expectEqual(memory_segment_manager.addSegment(), Relocatable.init(6, 0));
+    try memory_segment_manager.memory.set(allocator, Relocatable.init(5, 4), .{ .felt = Felt252.fromInteger(0) });
     defer memory_segment_manager.memory.deinitData(allocator);
 
     // memory_segment_manager.memory.freeze();

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -177,22 +177,22 @@ const expectError = std.testing.expectError;
 test "RunContext: computeDstAddr should return self.ap - instruction.off_0 if instruction.off_0 is negative" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             25,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             15,
         ),
@@ -215,22 +215,22 @@ test "RunContext: computeDstAddr should return self.ap - instruction.off_0 if in
 test "RunContext: computeDstAddr should return self.ap + instruction.off_0 if instruction.off_0 is positive" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             25,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             35,
         ),
@@ -253,22 +253,22 @@ test "RunContext: computeDstAddr should return self.ap + instruction.off_0 if in
 test "RunContext: computeDstAddr should return self.fp - instruction.off_0 if instruction.off_0 is negative" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             25,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             40,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             30,
         ),
@@ -291,22 +291,22 @@ test "RunContext: computeDstAddr should return self.fp - instruction.off_0 if in
 test "RunContext: computeDstAddr should return self.fp + instruction.off_0 if instruction.off_0 is positive" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             25,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             30,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             40,
         ),
@@ -329,22 +329,22 @@ test "RunContext: computeDstAddr should return self.fp + instruction.off_0 if in
 test "RunContext: computeOp0Addr should return self.ap - instruction.off_1 if instruction.off_1 is negative" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             25,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             23,
         ),
@@ -367,22 +367,22 @@ test "RunContext: computeOp0Addr should return self.ap - instruction.off_1 if in
 test "RunContext: computeOp0Addr should return self.ap + instruction.off_1 if instruction.off_1 is positive" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             25,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             27,
         ),
@@ -405,22 +405,22 @@ test "RunContext: computeOp0Addr should return self.ap + instruction.off_1 if in
 test "RunContext: computeOp0Addr should return self.fp - instruction.off_1 if instruction.off_1 is negative" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             25,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             40,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             38,
         ),
@@ -443,22 +443,22 @@ test "RunContext: computeOp0Addr should return self.fp - instruction.off_1 if in
 test "RunContext: computeOp0Addr should return self.fp + instruction.off_1 if instruction.off_1 is positive" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             25,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             30,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             32,
         ),
@@ -481,22 +481,22 @@ test "RunContext: computeOp0Addr should return self.fp + instruction.off_1 if in
 test "RunContext: compute_op1_addr for FP op1 addr and instruction off_2 < 0" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             5,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             3,
         ),
@@ -522,22 +522,22 @@ test "RunContext: compute_op1_addr for FP op1 addr and instruction off_2 < 0" {
 test "RunContext: compute_op1_addr for FP op1 addr and instruction off_2 > 0" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             5,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             9,
         ),
@@ -563,22 +563,22 @@ test "RunContext: compute_op1_addr for FP op1 addr and instruction off_2 > 0" {
 test "RunContext: compute_op1_addr for AP op1 addr and instruction off_2 < 0" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             5,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             2,
         ),
@@ -604,22 +604,22 @@ test "RunContext: compute_op1_addr for AP op1 addr and instruction off_2 < 0" {
 test "RunContext: compute_op1_addr for AP op1 addr and instruction off_2 > 0" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             5,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             8,
         ),
@@ -645,15 +645,15 @@ test "RunContext: compute_op1_addr for AP op1 addr and instruction off_2 > 0" {
 test "RunContext: compute_op1_addr for IMM op1 addr and instruction off_2 != 1" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             5,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
@@ -683,22 +683,22 @@ test "RunContext: compute_op1_addr for IMM op1 addr and instruction off_2 != 1" 
 test "RunContext: compute_op1_addr for IMM op1 addr and instruction off_2 == 1" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             5,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             5,
         ),
@@ -724,15 +724,15 @@ test "RunContext: compute_op1_addr for IMM op1 addr and instruction off_2 == 1" 
 test "RunContext: compute_op1_addr for OP0 op1 addr and instruction op_0 is null" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             5,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
@@ -762,22 +762,22 @@ test "RunContext: compute_op1_addr for OP0 op1 addr and instruction op_0 is null
 test "RunContext: compute_op1_addr for OP0 op1 addr and instruction off_2 < 0" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             5,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             28,
         ),
@@ -795,7 +795,7 @@ test "RunContext: compute_op1_addr for OP0 op1 addr and instruction off_2 < 0" {
                 .fp_update = .Regular,
                 .opcode = .NOp,
             },
-            .{ .relocatable = Relocatable.new(
+            .{ .relocatable = Relocatable.init(
                 0,
                 32,
             ) },
@@ -806,22 +806,22 @@ test "RunContext: compute_op1_addr for OP0 op1 addr and instruction off_2 < 0" {
 test "RunContext: compute_op1_addr for OP0 op1 addr and instruction off_2 > 0" {
     const run_context = try RunContext.initWithValues(
         std.testing.allocator,
-        Relocatable.new(
+        Relocatable.init(
             0,
             4,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             5,
         ),
-        Relocatable.new(
+        Relocatable.init(
             0,
             6,
         ),
     );
     defer run_context.deinit();
     try expectEqual(
-        Relocatable.new(
+        Relocatable.init(
             0,
             36,
         ),
@@ -839,7 +839,7 @@ test "RunContext: compute_op1_addr for OP0 op1 addr and instruction off_2 > 0" {
                 .fp_update = .Regular,
                 .opcode = .NOp,
             },
-            .{ .relocatable = Relocatable.new(
+            .{ .relocatable = Relocatable.init(
                 0,
                 32,
             ) },

--- a/src/vm/types/keccak_instance_def.zig
+++ b/src/vm/types/keccak_instance_def.zig
@@ -40,7 +40,7 @@ pub const KeccakInstanceDef = struct {
     /// # Returns
     ///
     /// A new `KeccakInstanceDef` instance with the specified parameters.
-    pub fn new(ratio: ?u32, _state_rep: ArrayList(u32)) Self {
+    pub fn init(ratio: ?u32, _state_rep: ArrayList(u32)) Self {
         return .{
             .ratio = ratio,
             ._state_rep = _state_rep,


### PR DESCRIPTION
Replace 'new' with 'init' for initializations

Changed method name 'new' to 'init' in different classes in our program for clear context. This is part of our coding conventions to use 'init' for initialization. The change applies globally including to the classes such as 'Relocatable', 'BitwiseBuiltinRunner', 'EcOpBuiltinRunner', and 'KeccakBuiltinRunner'. This change advances code readability and conceptual clarity by better adhering to common naming patterns.