### PR TITLE
refactor relocateTrace unit tests

### DIFF
--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -739,54 +739,66 @@ test "CairoVM: relocateTrace and trace comparison (more complex use case)" {
     // Initial Trace Entries
     // Define and append initial trace entries to the VM trace context.
     // pc, ap, and fp values are initialized and appended in pairs.
-    const pc = Relocatable.init(0, 4);
-    const ap = Relocatable.init(1, 3);
-    const fp = Relocatable.init(1, 3);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc, .ap = ap, .fp = fp });
-    const pc1 = Relocatable.init(0, 5);
-    const ap1 = Relocatable.init(1, 4);
-    const fp1 = Relocatable.init(1, 3);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc1, .ap = ap1, .fp = fp1 });
-    const pc2 = Relocatable.init(0, 7);
-    const ap2 = Relocatable.init(1, 5);
-    const fp2 = Relocatable.init(1, 3);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc2, .ap = ap2, .fp = fp2 });
-    const pc3 = Relocatable.init(0, 0);
-    const ap3 = Relocatable.init(1, 7);
-    const fp3 = Relocatable.init(1, 7);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc3, .ap = ap3, .fp = fp3 });
-    const pc4 = Relocatable.init(0, 1);
-    const ap4 = Relocatable.init(1, 7);
-    const fp4 = Relocatable.init(1, 7);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc4, .ap = ap4, .fp = fp4 });
-    const pc5 = Relocatable.init(0, 3);
-    const ap5 = Relocatable.init(1, 8);
-    const fp5 = Relocatable.init(1, 7);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc5, .ap = ap5, .fp = fp5 });
-    const pc6 = Relocatable.init(0, 9);
-    const ap6 = Relocatable.init(1, 8);
-    const fp6 = Relocatable.init(1, 3);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc6, .ap = ap6, .fp = fp6 });
-    const pc7 = Relocatable.init(0, 11);
-    const ap7 = Relocatable.init(1, 9);
-    const fp7 = Relocatable.init(1, 3);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc7, .ap = ap7, .fp = fp7 });
-    const pc8 = Relocatable.init(0, 0);
-    const ap8 = Relocatable.init(1, 11);
-    const fp8 = Relocatable.init(1, 11);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc8, .ap = ap8, .fp = fp8 });
-    const pc9 = Relocatable.init(0, 1);
-    const ap9 = Relocatable.init(1, 11);
-    const fp9 = Relocatable.init(1, 11);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc9, .ap = ap9, .fp = fp9 });
-    const pc10 = Relocatable.init(0, 3);
-    const ap10 = Relocatable.init(1, 12);
-    const fp10 = Relocatable.init(1, 11);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc10, .ap = ap10, .fp = fp10 });
-    const pc11 = Relocatable.init(0, 13);
-    const ap11 = Relocatable.init(1, 12);
-    const fp11 = Relocatable.init(1, 3);
-    try vm.trace_context.state.enabled.entries.append(.{ .pc = pc11, .ap = ap11, .fp = fp11 });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 4),
+        .ap = Relocatable.init(1, 3),
+        .fp = Relocatable.init(1, 3),
+    });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 5),
+        .ap = Relocatable.init(1, 4),
+        .fp = Relocatable.init(1, 3),
+    });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 7),
+        .ap = Relocatable.init(1, 5),
+        .fp = Relocatable.init(1, 3),
+    });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 0),
+        .ap = Relocatable.init(1, 7),
+        .fp = Relocatable.init(1, 7),
+    });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 1),
+        .ap = Relocatable.init(1, 7),
+        .fp = Relocatable.init(1, 7),
+    });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 3),
+        .ap = Relocatable.init(1, 8),
+        .fp = Relocatable.init(1, 7),
+    });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 9),
+        .ap = Relocatable.init(1, 8),
+        .fp = Relocatable.init(1, 3),
+    });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 11),
+        .ap = Relocatable.init(1, 9),
+        .fp = Relocatable.init(1, 3),
+    });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 0),
+        .ap = Relocatable.init(1, 11),
+        .fp = Relocatable.init(1, 11),
+    });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 1),
+        .ap = Relocatable.init(1, 11),
+        .fp = Relocatable.init(1, 11),
+    });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 3),
+        .ap = Relocatable.init(1, 12),
+        .fp = Relocatable.init(1, 11),
+    });
+    try vm.trace_context.state.enabled.entries.append(.{
+        .pc = Relocatable.init(0, 13),
+        .ap = Relocatable.init(1, 12),
+        .fp = Relocatable.init(1, 3),
+    });
 
     // Create a relocation table
     // Create a relocation table and append specific values to it.


### PR DESCRIPTION
Now that `TraceContext.Entry` fields are values and not pointers, it is possible to refactor our current complex `relocateTrace` unit test declarations for something less verbose.