### PR TITLE
feat/builtin segments and stack initialized in runner

### DIFF
--- a/cairo_programs/array_sum.json
+++ b/cairo_programs/array_sum.json
@@ -1,0 +1,1371 @@
+{
+    "attributes": [],
+    "builtins": [
+        "output"
+    ],
+    "compiler_version": "0.12.2",
+    "data": [
+        "0x40780017fff7fff",
+        "0x1",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffc7ffd",
+        "0x482680017ffc8000",
+        "0x1",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffd",
+        "0x5",
+        "0x480680017fff8000",
+        "0x0",
+        "0x208b7fff7fff7ffe",
+        "0x482680017ffc8000",
+        "0x1",
+        "0x482680017ffd8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff8",
+        "0x480280007ffc8000",
+        "0x48307ffe7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffec",
+        "0x480680017fff8000",
+        "0x9",
+        "0x400080007ffe7fff",
+        "0x480680017fff8000",
+        "0x10",
+        "0x400080017ffd7fff",
+        "0x480680017fff8000",
+        "0x19",
+        "0x400080027ffc7fff",
+        "0x48127ffc7fff8000",
+        "0x480680017fff8000",
+        "0x3",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe5",
+        "0x480a7ffd7fff8000",
+        "0x48127ffe7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdd",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.alloc",
+                    "starkware.cairo.common.alloc.alloc"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 38,
+                            "end_line": 3,
+                            "input_file": {
+                                "filename": "/Users/lana/github/cairo-vm/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 3
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 12,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "/Users/lana/github/cairo-vm/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 4
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.alloc",
+                    "starkware.cairo.common.alloc.alloc"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "/Users/lana/github/cairo-vm/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 5
+                }
+            },
+            "3": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 1,
+                        "starkware.cairo.common.serialize.serialize_word.word": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "/Users/lana/github/cairo-vm/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 3
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 2,
+                        "starkware.cairo.common.serialize.serialize_word.word": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "/Users/lana/github/cairo-vm/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/Users/lana/github/cairo-vm/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 15,
+                                    "end_line": 5,
+                                    "input_file": {
+                                        "filename": "/Users/lana/github/cairo-vm/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 5
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 22,
+                    "start_line": 4
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 2,
+                        "starkware.cairo.common.serialize.serialize_word.word": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "/Users/lana/github/cairo-vm/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 5
+                }
+            },
+            "7": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 9
+                }
+            },
+            "9": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 10
+                }
+            },
+            "11": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 10
+                }
+            },
+            "12": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 14,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 39,
+                    "start_line": 14
+                }
+            },
+            "14": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 61,
+                    "end_line": 14,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 53,
+                    "start_line": 14
+                }
+            },
+            "16": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 62,
+                    "end_line": 14,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 14
+                }
+            },
+            "18": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4,
+                        "__main__.array_sum.sum_of_rest": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 15
+                }
+            },
+            "19": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.__temp0": 6,
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4,
+                        "__main__.array_sum.sum_of_rest": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 15
+                }
+            },
+            "20": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.__temp0": 6,
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4,
+                        "__main__.array_sum.sum_of_rest": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 15
+                }
+            },
+            "21": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 22,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 22
+                }
+            },
+            "23": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 21,
+                    "end_line": 25,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 25
+                }
+            },
+            "25": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 25,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 25
+                }
+            },
+            "26": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 26,
+                    "end_line": 26,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 26
+                }
+            },
+            "28": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 26,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 26
+                }
+            },
+            "29": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 26,
+                    "end_line": 27,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 27
+                }
+            },
+            "31": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 27,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 27
+                }
+            },
+            "32": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 22,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 34,
+                            "end_line": 30,
+                            "input_file": {
+                                "filename": "cairo_programs/array_sum.cairo"
+                            },
+                            "start_col": 31,
+                            "start_line": 30
+                        },
+                        "While expanding the reference 'ptr' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 22
+                }
+            },
+            "33": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 30,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 41,
+                    "start_line": 30
+                }
+            },
+            "35": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 52,
+                    "end_line": 30,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 30
+                }
+            },
+            "37": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8,
+                        "__main__.main.sum": 12
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 28,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/Users/lana/github/cairo-vm/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 24,
+                                    "end_line": 33,
+                                    "input_file": {
+                                        "filename": "cairo_programs/array_sum.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 33
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 18
+                }
+            },
+            "38": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8,
+                        "__main__.main.sum": 12
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 30,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 23,
+                            "end_line": 33,
+                            "input_file": {
+                                "filename": "cairo_programs/array_sum.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 33
+                        },
+                        "While expanding the reference 'sum' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 30
+                }
+            },
+            "39": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8,
+                        "__main__.main.sum": 12
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 33,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 33
+                }
+            },
+            "41": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 13,
+                        "__main__.main.ptr": 8,
+                        "__main__.main.sum": 12
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 35,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 35
+                }
+            }
+        }
+    },
+    "hints": {
+        "0": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.alloc",
+                    "starkware.cairo.common.alloc.alloc"
+                ],
+                "code": "memory[ap] = segments.add()",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                }
+            }
+        ]
+    },
+    "identifiers": {
+        "__main__.alloc": {
+            "destination": "starkware.cairo.common.alloc.alloc",
+            "type": "alias"
+        },
+        "__main__.array_sum": {
+            "decorators": [],
+            "pc": 7,
+            "type": "function"
+        },
+        "__main__.array_sum.Args": {
+            "full_name": "__main__.array_sum.Args",
+            "members": {
+                "arr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                },
+                "size": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.array_sum.ImplicitArgs": {
+            "full_name": "__main__.array_sum.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.array_sum.Return": {
+            "cairo_type": "(sum: felt)",
+            "type": "type_definition"
+        },
+        "__main__.array_sum.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.array_sum.__temp0": {
+            "cairo_type": "felt",
+            "full_name": "__main__.array_sum.__temp0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 1
+                    },
+                    "pc": 19,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.array_sum.arr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.array_sum.arr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 7,
+                    "value": "[cast(fp + (-4), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.array_sum.size": {
+            "cairo_type": "felt",
+            "full_name": "__main__.array_sum.size",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 7,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.array_sum.sum_of_rest": {
+            "cairo_type": "felt",
+            "full_name": "__main__.array_sum.sum_of_rest",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 18,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 21,
+            "type": "function"
+        },
+        "__main__.main.ARRAY_SIZE": {
+            "type": "const",
+            "value": 3
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.__temp1": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.__temp1",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "pc": 25,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.__temp2": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.__temp2",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 5
+                    },
+                    "pc": 28,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.__temp3": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.__temp3",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 6
+                    },
+                    "pc": 31,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.main.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 21,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 5
+                    },
+                    "pc": 41,
+                    "value": "[cast(ap + (-1), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.ptr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.main.ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 3
+                    },
+                    "pc": 23,
+                    "value": "[cast(ap + (-1), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.sum": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.sum",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 37,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.serialize_word": {
+            "destination": "starkware.cairo.common.serialize.serialize_word",
+            "type": "alias"
+        },
+        "starkware.cairo.common.alloc.alloc": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "starkware.cairo.common.alloc.alloc.Args": {
+            "full_name": "starkware.cairo.common.alloc.alloc.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "starkware.cairo.common.alloc.alloc.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.alloc.alloc.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "starkware.cairo.common.alloc.alloc.Return": {
+            "cairo_type": "(ptr: felt*)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.alloc.alloc.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.serialize.serialize_word": {
+            "decorators": [],
+            "pc": 3,
+            "type": "function"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Args": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.Args",
+            "members": {
+                "word": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.ImplicitArgs",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.serialize.serialize_word.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.serialize.serialize_word.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 3,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 4,
+                    "value": "cast([fp + (-4)] + 1, felt*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.serialize.serialize_word.word": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.word",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 3,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 3,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 3,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 4,
+                "value": "cast([fp + (-4)] + 1, felt*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 7,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 7,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 18,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 1
+                },
+                "pc": 19,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 21,
+                "value": "[cast(fp + (-3), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 3
+                },
+                "pc": 23,
+                "value": "[cast(ap + (-1), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 4
+                },
+                "pc": 25,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 5
+                },
+                "pc": 28,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 6
+                },
+                "pc": 31,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 37,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 5
+                },
+                "pc": 41,
+                "value": "[cast(ap + (-1), felt**)]"
+            }
+        ]
+    }
+}

--- a/src/vm/builtins/builtin_runner/builtin_runner.zig
+++ b/src/vm/builtins/builtin_runner/builtin_runner.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
+
 const BitwiseBuiltinRunner = @import("./bitwise.zig").BitwiseBuiltinRunner;
 const EcOpBuiltinRunner = @import("./ec_op.zig").EcOpBuiltinRunner;
 const HashBuiltinRunner = @import("./hash.zig").HashBuiltinRunner;
@@ -14,6 +16,8 @@ const SignatureBuiltinRunner = @import("./signature.zig").SignatureBuiltinRunner
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+
+const ArrayList = std.ArrayList;
 
 /// Built-in runner
 pub const BuiltinRunner = union(enum) {
@@ -59,6 +63,44 @@ pub const BuiltinRunner = union(enum) {
         };
     }
 
+    /// Initializes a builtin with its required memory segments.
+    ///
+    /// # Arguments
+    ///
+    /// - `segments`: A pointer to the MemorySegmentManager managing memory segments.
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager) !void {
+        switch (self.*) {
+            .Bitwise => |*bitwise| try bitwise.initSegments(segments),
+            .EcOp => |*ec| try ec.initSegments(segments),
+            .Hash => |*hash| try hash.initSegments(segments),
+            .Output => |*output| try output.initSegments(segments),
+            .RangeCheck => |*range_check| try range_check.initSegments(segments),
+            .Keccak => |*keccak| try keccak.initSegments(segments),
+            .Signature => |*signature| try signature.initSegments(segments),
+            .Poseidon => |*poseidon| try poseidon.initSegments(segments),
+            .SegmentArena => |*segment_arena| try segment_arena.initSegments(segments),
+        }
+    }
+
+    /// Initializes a builtin with its required memory segments.
+    ///
+    /// # Arguments
+    ///
+    /// - `allocator`: A pointer to the MemorySegmentManager managing memory segments.
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        return switch (self.*) {
+            .Bitwise => |*bitwise| try bitwise.initialStack(allocator),
+            .EcOp => |*ec| try ec.initialStack(allocator),
+            .Hash => |*hash| try hash.initialStack(allocator),
+            .Output => |*output| try output.initialStack(allocator),
+            .RangeCheck => |*range_check| try range_check.initialStack(allocator),
+            .Keccak => |*keccak| try keccak.initialStack(allocator),
+            .Signature => |*signature| try signature.initialStack(allocator),
+            .Poseidon => |*poseidon| try poseidon.initialStack(allocator),
+            .SegmentArena => |*segment_arena| try segment_arena.initialStack(allocator),
+        };
+    }
+    
     /// Deduces memory cell information for the built-in runner.
     ///
     /// This function deduces memory cell information for the specific type of built-in runner.
@@ -78,7 +120,6 @@ pub const BuiltinRunner = union(enum) {
         memory: *Memory,
     ) !?MaybeRelocatable {
         return switch (self.*) {
-            // TODO: switch to `BitwiseBuiltinRunner` `deduceMemoryCell` function after migration of `deduce` to `BitwiseBuiltinRunner`
             .Bitwise => |bitwise| try bitwise.deduceMemoryCell(address, memory),
             .EcOp => |ec| ec.deduceMemoryCell(address, memory),
             .Hash => |hash| hash.deduceMemoryCell(address, memory),

--- a/src/vm/builtins/builtin_runner/ec_op.zig
+++ b/src/vm/builtins/builtin_runner/ec_op.zig
@@ -5,8 +5,10 @@ const Felt252 = @import("../../../math/fields/starknet.zig").Felt252;
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
 
 const AutoHashMap = std.AutoHashMap;
+const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
 
 /// EC Operation built-in runner
@@ -62,6 +64,18 @@ pub const EcOpBuiltinRunner = struct {
             .instances_per_component = 1,
             .cache = AutoHashMap(Relocatable, Felt252).init(allocator),
         };
+    }
+
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager)  !void {
+        _ = self;
+        _ = segments;
+    }
+
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        _ = self;
+        var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();        
+        return result;
     }
 
     pub fn deduceMemoryCell(

--- a/src/vm/builtins/builtin_runner/hash.zig
+++ b/src/vm/builtins/builtin_runner/hash.zig
@@ -3,6 +3,8 @@ const pedersen_instance_def = @import("../../types/pedersen_instance_def.zig");
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
+
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
 
@@ -57,6 +59,19 @@ pub const HashBuiltinRunner = struct {
             .verified_addresses = ArrayList(bool).init(allocator),
         };
     }
+
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager)  !void {
+        _ = self;
+        _ = segments;
+    }
+
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        _ = self;
+        var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();        
+        return result;
+    }
+
 
     pub fn deduceMemoryCell(
         self: *const Self,

--- a/src/vm/builtins/builtin_runner/poseidon.zig
+++ b/src/vm/builtins/builtin_runner/poseidon.zig
@@ -5,8 +5,10 @@ const poseidon_instance_def = @import("../../types/poseidon_instance_def.zig");
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
 
 const AutoHashMap = std.AutoHashMap;
+const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
 
 /// Poseidon built-in runner
@@ -61,6 +63,18 @@ pub const PoseidonBuiltinRunner = struct {
             .cache = AutoHashMap(Relocatable, Felt252).init(allocator),
             .instances_per_component = 1,
         };
+    }
+
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager)  !void {
+        _ = self;
+        _ = segments;
+    }
+
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        _ = self;
+        var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();        
+        return result;
     }
 
     pub fn deduceMemoryCell(

--- a/src/vm/builtins/builtin_runner/segment_arena.zig
+++ b/src/vm/builtins/builtin_runner/segment_arena.zig
@@ -1,6 +1,11 @@
+const std = @import("std");
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
+
+const ArrayList = std.ArrayList;
+const Allocator = std.mem.Allocator;
 
 /// Arena builtin size
 const ARENA_BUILTIN_SIZE: u32 = 3;
@@ -44,6 +49,18 @@ pub const SegmentArenaBuiltinRunner = struct {
             .n_input_cells_per_instance = ARENA_BUILTIN_SIZE,
             .stop_ptr = null,
         };
+    }
+
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager)  !void {
+        _ = self;
+        _ = segments;
+    }
+    
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        _ = self;
+        var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();        
+        return result;
     }
 
     pub fn deduceMemoryCell(

--- a/src/vm/builtins/builtin_runner/signature.zig
+++ b/src/vm/builtins/builtin_runner/signature.zig
@@ -3,10 +3,12 @@ const Signature = @import("../../../math/crypto/signatures.zig").Signature;
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
 const Felt252 = @import("../../../math/fields/starknet.zig").Felt252;
 const ecdsa_instance_def = @import("../../types/ecdsa_instance_def.zig");
 
 const AutoHashMap = std.AutoHashMap;
+const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
 
 /// Signature built-in runner
@@ -58,6 +60,18 @@ pub const SignatureBuiltinRunner = struct {
             .instances_per_component = 1,
             .signatures = AutoHashMap(Relocatable, Signature).init(allocator),
         };
+    }
+
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager)  !void {
+        _ = self;
+        _ = segments;
+    }
+
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        _ = self;
+        var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();        
+        return result;
     }
 
     pub fn deduceMemoryCell(

--- a/src/vm/cairo_run.zig
+++ b/src/vm/cairo_run.zig
@@ -55,7 +55,7 @@ pub fn runConfig(allocator: Allocator, config: Config) !void {
     const instructions = try parsed_program.value.readData(allocator);
     defer parsed_program.deinit();
 
-    var runner = try CairoRunner.init(allocator, parsed_program.value, instructions, vm, config.proof_mode);
+    var runner = try CairoRunner.init(allocator, parsed_program.value, config.layout, instructions, vm, config.proof_mode);
     defer runner.deinit();
     const end = try runner.setupExecutionState();
     try runner.runUntilPC(end);
@@ -183,6 +183,7 @@ test "Fibonacci: can evaluate without runtime error" {
     var runner = try CairoRunner.init(
         allocator,
         parsed_program.value,
+        "plain",
         instructions,
         vm,
         false,
@@ -217,6 +218,44 @@ test "Factorial: can evaluate without runtime error" {
     var runner = try CairoRunner.init(
         allocator,
         parsed_program.value,
+        "plain",
+        instructions,
+        vm,
+        false,
+    );
+    defer runner.deinit();
+    const end = try runner.setupExecutionState();
+    errdefer std.debug.print("failed on step: {}\n", .{runner.vm.current_step});
+
+    // then
+    try runner.runUntilPC(end);
+    try runner.endRun();
+}
+
+test "Array sum: can evaluate without runtime error" {
+
+    // Given
+    const allocator = std.testing.allocator;
+    var buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    const path = try std.os.realpath("cairo_programs/array_sum.json", &buffer);
+
+    var parsed_program = try Program.parseFromFile(allocator, path);
+    defer parsed_program.deinit();
+
+    const instructions = try parsed_program.value.readData(allocator);
+    const builtins = try parsed_program.value.readBuiltins(allocator);
+    _ = builtins;
+
+    const vm = try CairoVM.init(
+        allocator,
+        .{},
+    );
+
+    // when
+    var runner = try CairoRunner.init(
+        allocator,
+        parsed_program.value,
+        "small",
         instructions,
         vm,
         false,

--- a/src/vm/cairo_run.zig
+++ b/src/vm/cairo_run.zig
@@ -243,8 +243,8 @@ test "Array sum: can evaluate without runtime error" {
     defer parsed_program.deinit();
 
     const instructions = try parsed_program.value.readData(allocator);
-    const builtins = try parsed_program.value.readBuiltins(allocator);
-    _ = builtins;
+    // const builtins = parsed_program.value.builtins;
+    // _ = builtins;
 
     const vm = try CairoVM.init(
         allocator,

--- a/src/vm/config.zig
+++ b/src/vm/config.zig
@@ -10,6 +10,8 @@ pub const Config = struct {
     enable_trace: bool = false,
     /// The location of the program to be evaluated
     filename: []const u8 = undefined,
+    /// The layout of the memory
+    layout: []const u8 = undefined,
     /// Write trace to binary file
     output_trace: ?[]const u8 = undefined,
     /// Write memory to binary file

--- a/src/vm/config.zig
+++ b/src/vm/config.zig
@@ -11,7 +11,7 @@ pub const Config = struct {
     /// The location of the program to be evaluated
     filename: []const u8 = undefined,
     /// The layout of the memory
-    layout: []const u8 = undefined,
+    layout: []const u8 = "small",
     /// Write trace to binary file
     output_trace: ?[]const u8 = undefined,
     /// Write memory to binary file

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -349,6 +349,7 @@ pub const CairoVM = struct {
         allocator: Allocator,
         instruction: *const instructions.Instruction,
     ) !OperandsResult {
+        std.debug.print("COMPUTING OPERANDS FOR INSTRUCTION: {any}\n", .{instruction});
         var op_res = OperandsResult.default();
         op_res.res = null;
 
@@ -357,9 +358,11 @@ pub const CairoVM = struct {
 
         op_res.op_0_addr = try self.run_context.computeOp0Addr(instruction);
 
+        const op_0_op = self.segments.memory.get(op_res.op_0_addr);
+
         op_res.op_1_addr = try self.run_context.computeOp1Addr(
             instruction,
-            op_res.op_0,
+            op_0_op,
         );
         const op_1_op = self.segments.memory.get(op_res.op_1_addr);
 
@@ -403,6 +406,13 @@ pub const CairoVM = struct {
             op_res.dst = try self.deduceDst(instruction, op_res.res);
         }
 
+        std.debug.print("COMPUTED op_res dst: {any}\n", .{op_res.dst});
+        std.debug.print("COMPUTED op_res op_0: {any}\n", .{op_res.op_0});
+        std.debug.print("COMPUTED op_res op_1: {any}\n", .{op_res.op_1});
+        std.debug.print("COMPUTED op_res res: {any}\n", .{op_res.res});
+        std.debug.print("COMPUTED op_res op_0 addr: {any}\n", .{op_res.op_0_addr});
+        std.debug.print("COMPUTED op_res op_1 addr: {any}\n", .{op_res.op_1_addr});
+        std.debug.print("COMPUTED op_res dst addr: {any}\n", .{op_res.dst_addr});
         return op_res;
     }
 

--- a/src/vm/error.zig
+++ b/src/vm/error.zig
@@ -85,6 +85,8 @@ pub const MemoryError = error{
 pub const CairoRunnerError = error{
     // Raised when `end_run` hook of a runner is called more than once.
     EndRunAlreadyCalled,
+    // Unable to convert provided layout to a valid layout.
+    InvalidLayout,
 };
 
 /// Represents different error conditions that occur in the built-in runners.

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -150,9 +150,6 @@ pub const RunContext = struct {
         instruction: *const Instruction,
         op_0: ?MaybeRelocatable,
     ) !Relocatable {
-        std.debug.print("OP0: {any}\n", .{op_0});
-        std.debug.print("INSTRUCTION: {}\n", .{instruction});
-        std.debug.print("OP1 ADDR: {}\n", .{instruction.op_1_addr});
         const base_addr = switch (instruction.op_1_addr) {
             .FP => self.fp.*,
             .AP => self.ap.*,

--- a/src/vm/run_context.zig
+++ b/src/vm/run_context.zig
@@ -150,6 +150,9 @@ pub const RunContext = struct {
         instruction: *const Instruction,
         op_0: ?MaybeRelocatable,
     ) !Relocatable {
+        std.debug.print("OP0: {any}\n", .{op_0});
+        std.debug.print("INSTRUCTION: {}\n", .{instruction});
+        std.debug.print("OP1 ADDR: {}\n", .{instruction.op_1_addr});
         const base_addr = switch (instruction.op_1_addr) {
             .FP => self.fp.*,
             .AP => self.ap.*,

--- a/src/vm/runners/cairo_runner.zig
+++ b/src/vm/runners/cairo_runner.zig
@@ -196,7 +196,6 @@ pub const CairoRunner = struct {
         // self.program.deinit();
         self.function_call_stack.deinit();
         self.instructions.deinit();
-        self.vm.builtin_runners.deinit();
         self.vm.segments.memory.deinitData(self.allocator);
         self.vm.deinit();
     }

--- a/src/vm/types/program.zig
+++ b/src/vm/types/program.zig
@@ -175,6 +175,16 @@ pub const Program = struct {
         }
         return parsed_data;
     }
+
+    pub fn readBuiltins(self: Self, allocator: Allocator) !std.ArrayList([]const u8) {
+        var parsed_builtins = std.ArrayList([]const u8).init(allocator);
+        errdefer parsed_builtins.deinit();
+
+        for (self.builtins) |builtin| {
+            try parsed_builtins.append(builtin);
+        }
+        return parsed_builtins;
+    }
 };
 
 // ************************************************************


### PR DESCRIPTION
closes: #264 

slightly coupled with #268, but PRing separately because as I was comparing output with the cairovm in rust I noticed that our initial fp wasn't lined up, and it was coupled with having a builtin's stack append the runners, which shifts the initial fp. 