### PR TITLE
feat/builtin segments and stack initialized in runner 

### DIFF
--- a/src/vm/builtins/builtin_runner/builtin_runner.zig
+++ b/src/vm/builtins/builtin_runner/builtin_runner.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
+
 const BitwiseBuiltinRunner = @import("./bitwise.zig").BitwiseBuiltinRunner;
 const EcOpBuiltinRunner = @import("./ec_op.zig").EcOpBuiltinRunner;
 const HashBuiltinRunner = @import("./hash.zig").HashBuiltinRunner;
@@ -14,6 +16,8 @@ const SignatureBuiltinRunner = @import("./signature.zig").SignatureBuiltinRunner
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+
+const ArrayList = std.ArrayList;
 
 /// Built-in runner
 pub const BuiltinRunner = union(enum) {
@@ -59,6 +63,44 @@ pub const BuiltinRunner = union(enum) {
         };
     }
 
+    /// Initializes a builtin with its required memory segments.
+    ///
+    /// # Arguments
+    ///
+    /// - `segments`: A pointer to the MemorySegmentManager managing memory segments.
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager) !void {
+        switch (self.*) {
+            .Bitwise => |*bitwise| try bitwise.initSegments(segments),
+            .EcOp => |*ec| try ec.initSegments(segments),
+            .Hash => |*hash| try hash.initSegments(segments),
+            .Output => |*output| try output.initSegments(segments),
+            .RangeCheck => |*range_check| try range_check.initSegments(segments),
+            .Keccak => |*keccak| try keccak.initSegments(segments),
+            .Signature => |*signature| try signature.initSegments(segments),
+            .Poseidon => |*poseidon| try poseidon.initSegments(segments),
+            .SegmentArena => |*segment_arena| try segment_arena.initSegments(segments),
+        }
+    }
+
+    /// Derives necessary stack for a builtin.
+    ///
+    /// # Arguments
+    ///
+    ///  - `allocator`: The allocator to initialize the ArrayList.
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        return switch (self.*) {
+            .Bitwise => |*bitwise| try bitwise.initialStack(allocator),
+            .EcOp => |*ec| try ec.initialStack(allocator),
+            .Hash => |*hash| try hash.initialStack(allocator),
+            .Output => |*output| try output.initialStack(allocator),
+            .RangeCheck => |*range_check| try range_check.initialStack(allocator),
+            .Keccak => |*keccak| try keccak.initialStack(allocator),
+            .Signature => |*signature| try signature.initialStack(allocator),
+            .Poseidon => |*poseidon| try poseidon.initialStack(allocator),
+            .SegmentArena => |*segment_arena| try segment_arena.initialStack(allocator),
+        };
+    }
+    
     /// Deduces memory cell information for the built-in runner.
     ///
     /// This function deduces memory cell information for the specific type of built-in runner.
@@ -78,7 +120,6 @@ pub const BuiltinRunner = union(enum) {
         memory: *Memory,
     ) !?MaybeRelocatable {
         return switch (self.*) {
-            // TODO: switch to `BitwiseBuiltinRunner` `deduceMemoryCell` function after migration of `deduce` to `BitwiseBuiltinRunner`
             .Bitwise => |bitwise| try bitwise.deduceMemoryCell(address, memory),
             .EcOp => |ec| ec.deduceMemoryCell(address, memory),
             .Hash => |hash| hash.deduceMemoryCell(address, memory),

--- a/src/vm/builtins/builtin_runner/ec_op.zig
+++ b/src/vm/builtins/builtin_runner/ec_op.zig
@@ -5,8 +5,10 @@ const Felt252 = @import("../../../math/fields/starknet.zig").Felt252;
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
 
 const AutoHashMap = std.AutoHashMap;
+const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
 
 /// EC Operation built-in runner
@@ -62,6 +64,18 @@ pub const EcOpBuiltinRunner = struct {
             .instances_per_component = 1,
             .cache = AutoHashMap(Relocatable, Felt252).init(allocator),
         };
+    }
+
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager)  !void {
+        _ = self;
+        _ = segments;
+    }
+
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        _ = self;
+        var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();        
+        return result;
     }
 
     pub fn deduceMemoryCell(

--- a/src/vm/builtins/builtin_runner/hash.zig
+++ b/src/vm/builtins/builtin_runner/hash.zig
@@ -3,6 +3,8 @@ const pedersen_instance_def = @import("../../types/pedersen_instance_def.zig");
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
+
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
 
@@ -57,6 +59,19 @@ pub const HashBuiltinRunner = struct {
             .verified_addresses = ArrayList(bool).init(allocator),
         };
     }
+
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager)  !void {
+        _ = self;
+        _ = segments;
+    }
+
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        _ = self;
+        var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();        
+        return result;
+    }
+
 
     pub fn deduceMemoryCell(
         self: *const Self,

--- a/src/vm/builtins/builtin_runner/poseidon.zig
+++ b/src/vm/builtins/builtin_runner/poseidon.zig
@@ -5,8 +5,10 @@ const poseidon_instance_def = @import("../../types/poseidon_instance_def.zig");
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
 
 const AutoHashMap = std.AutoHashMap;
+const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
 
 /// Poseidon built-in runner
@@ -61,6 +63,18 @@ pub const PoseidonBuiltinRunner = struct {
             .cache = AutoHashMap(Relocatable, Felt252).init(allocator),
             .instances_per_component = 1,
         };
+    }
+
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager)  !void {
+        _ = self;
+        _ = segments;
+    }
+
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        _ = self;
+        var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();        
+        return result;
     }
 
     pub fn deduceMemoryCell(

--- a/src/vm/builtins/builtin_runner/segment_arena.zig
+++ b/src/vm/builtins/builtin_runner/segment_arena.zig
@@ -1,6 +1,11 @@
+const std = @import("std");
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
+
+const ArrayList = std.ArrayList;
+const Allocator = std.mem.Allocator;
 
 /// Arena builtin size
 const ARENA_BUILTIN_SIZE: u32 = 3;
@@ -44,6 +49,18 @@ pub const SegmentArenaBuiltinRunner = struct {
             .n_input_cells_per_instance = ARENA_BUILTIN_SIZE,
             .stop_ptr = null,
         };
+    }
+
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager)  !void {
+        _ = self;
+        _ = segments;
+    }
+    
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        _ = self;
+        var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();        
+        return result;
     }
 
     pub fn deduceMemoryCell(

--- a/src/vm/builtins/builtin_runner/signature.zig
+++ b/src/vm/builtins/builtin_runner/signature.zig
@@ -3,10 +3,12 @@ const Signature = @import("../../../math/crypto/signatures.zig").Signature;
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
 const Felt252 = @import("../../../math/fields/starknet.zig").Felt252;
 const ecdsa_instance_def = @import("../../types/ecdsa_instance_def.zig");
 
 const AutoHashMap = std.AutoHashMap;
+const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
 
 /// Signature built-in runner
@@ -58,6 +60,18 @@ pub const SignatureBuiltinRunner = struct {
             .instances_per_component = 1,
             .signatures = AutoHashMap(Relocatable, Signature).init(allocator),
         };
+    }
+
+    pub fn initSegments(self: *Self, segments: *MemorySegmentManager)  !void {
+        _ = self;
+        _ = segments;
+    }
+
+    pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
+        _ = self;
+        var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();        
+        return result;
     }
 
     pub fn deduceMemoryCell(

--- a/src/vm/runners/cairo_runner.zig
+++ b/src/vm/runners/cairo_runner.zig
@@ -70,7 +70,9 @@ pub const CairoRunner = struct {
         // stores the execution stack
         self.execution_base = try self.vm.segments.addSegment();
 
-        // TODO, add builtin segments when fib milestone is completed
+        for (self.vm.builtin_runners.items) |*builtin_runner| {
+            try builtin_runner.initSegments(self.vm.segments);
+        }
     }
 
     /// Initializes runner state for execution, as in:
@@ -119,8 +121,14 @@ pub const CairoRunner = struct {
 
     /// Initializes runner state for execution of a program from the `main()` entrypoint.
     pub fn initMainEntrypoint(self: *Self) !Relocatable {
-        // TODO handle the necessary stack initializing for builtins
-        // and the case where we are running in proof mode
+        for (self.vm.builtin_runners.items) |*builtin_runner| {
+            const builtin_stack = try builtin_runner.initialStack(self.allocator);
+            defer builtin_stack.deinit();
+            for (builtin_stack.items) |item| {
+                try self.function_call_stack.append(item);
+            }
+        }
+        // TODO handle the case where we are running in proof mode
         const return_fp = try self.vm.segments.addSegment();
         // Buffer for concatenation
         var buffer: [100]u8 = undefined;
@@ -152,14 +160,12 @@ pub const CairoRunner = struct {
             return CairoRunnerError.EndRunAlreadyCalled;
         }
 
-        // Presuming the default case of `allow_tmp_segments` in python version
-
         // TODO handle proof_mode case
-
         self.run_ended = true;
     }
 
     pub fn relocate(self: *Self) !void {
+        // Presuming the default case of `allow_tmp_segments` in python version
         _ = try self.vm.segments.computeEffectiveSize(false);
 
         const relocation_table = try self.vm.segments.relocateSegments(self.allocator);


### PR DESCRIPTION
closes: #264 

slightly coupled with #268, but PRing separately because as I was comparing output with the cairovm in rust I noticed that our initial fp wasn't lined up, and it was coupled with having a builtin's stack append the runners, which shifts the initial fp. 

can add test coverage  to the `builtin_runner` in subsequent pr