### PR TITLE
move some operands methods to `MaybeRelocatable` implementation

### DIFF
--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -1181,7 +1181,6 @@ pub fn computeRes(
 ) !?MaybeRelocatable {
     return switch (instruction.res_logic) {
         .Op1 => op_1,
-        // .Add => try addOperands(op_0, op_1),
         .Add => try op_0.add(op_1),
         .Mul => try op_0.mul(op_1),
         .Unconstrained => null,

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -594,7 +594,7 @@ pub const CairoVM = struct {
                 const op1_val = op1.* orelse return .{ .op_0 = null, .res = null };
                 if ((inst.res_logic == .Add)) {
                     return .{
-                        .op_0 = try subOperands(dst_val, op1_val),
+                        .op_0 = try dst_val.sub(op1_val),
                         .res = dst_val,
                     };
                 } else if (dst_val.isFelt() and op1_val.isFelt() and !op1_val.felt.isZero()) {
@@ -1181,90 +1181,10 @@ pub fn computeRes(
 ) !?MaybeRelocatable {
     return switch (instruction.res_logic) {
         .Op1 => op_1,
-        .Add => try addOperands(op_0, op_1),
-        .Mul => try mulOperands(op_0, op_1),
+        // .Add => try addOperands(op_0, op_1),
+        .Add => try op_0.add(op_1),
+        .Mul => try op_0.mul(op_1),
         .Unconstrained => null,
-    };
-}
-
-/// Add two operands which can either be a "relocatable" or a "felt".
-/// The operation is allowed between:
-/// 1. A felt and another felt.
-/// 2. A felt and a relocatable.
-/// Adding two relocatables is forbidden.
-/// # Arguments
-/// - `op_0`: The operand 0.
-/// - `op_1`: The operand 1.
-/// # Returns
-/// - `MaybeRelocatable`: The result of the operation or an error.
-pub fn addOperands(
-    op_0: MaybeRelocatable,
-    op_1: MaybeRelocatable,
-) !MaybeRelocatable {
-    // Both operands are relocatables, operation forbidden
-    if (op_0.isRelocatable() and op_1.isRelocatable()) {
-        return error.AddRelocToRelocForbidden;
-    }
-
-    // One of the operands is relocatable, the other is felt
-    if (op_0.isRelocatable() or op_1.isRelocatable()) {
-        // Determine which operand is relocatable and which one is felt
-        const reloc_op = if (op_0.isRelocatable()) op_0 else op_1;
-        const felt_op = if (op_0.isRelocatable()) op_1 else op_0;
-
-        var reloc = try reloc_op.tryIntoRelocatable();
-
-        // Add the felt to the relocatable's offset
-        try reloc.addFeltInPlace(try felt_op.tryIntoFelt());
-
-        return MaybeRelocatable.fromRelocatable(reloc);
-    }
-
-    // Add the felts and return as a new felt wrapped in a relocatable
-    return MaybeRelocatable.fromFelt((try op_0.tryIntoFelt()).add(
-        try op_1.tryIntoFelt(),
-    ));
-}
-
-/// Compute the product of two operands op 0 and op 1.
-/// # Arguments
-/// - `op_0`: The operand 0.
-/// - `op_1`: The operand 1.
-/// # Returns
-/// - `MaybeRelocatable`: The result of the operation or an error.
-pub fn mulOperands(
-    op_0: MaybeRelocatable,
-    op_1: MaybeRelocatable,
-) CairoVMError!MaybeRelocatable {
-    // At least one of the operands is relocatable
-    if (op_0.isRelocatable() or op_1.isRelocatable()) {
-        return CairoVMError.MulRelocForbidden;
-    }
-
-    // Multiply the felts and return as a new felt wrapped in a relocatable
-    return MaybeRelocatable.fromFelt(
-        (try op_0.tryIntoFelt()).mul(try op_1.tryIntoFelt()),
-    );
-}
-
-/// Subtracts a `MaybeRelocatable` from this one and returns the new value.
-///
-/// Only values of the same type may be subtracted. Specifically, attempting to
-/// subtract a `.felt` with a `.relocatable` will result in an error.
-pub fn subOperands(self: MaybeRelocatable, other: MaybeRelocatable) !MaybeRelocatable {
-    return switch (self) {
-        .felt => |self_value| switch (other) {
-            .felt => |other_value| return MaybeRelocatable.fromFelt(
-                self_value.sub(other_value),
-            ),
-            .relocatable => error.TypeMismatchNotFelt,
-        },
-        .relocatable => |self_value| switch (other) {
-            .felt => error.TypeMismatchNotFelt,
-            .relocatable => |other_value| return MaybeRelocatable.fromRelocatable(
-                try self_value.sub(other_value),
-            ),
-        },
     };
 }
 
@@ -1292,7 +1212,7 @@ pub fn deduceOp1(
         },
         .Add => if (dst.* != null and op0.* != null) {
             return .{
-                .op_1 = try subOperands(dst.*.?, op0.*.?),
+                .op_1 = try dst.*.?.sub(op0.*.?),
                 .res = dst.*.?,
             };
         },

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -16,6 +16,7 @@ const RunContext = @import("run_context.zig").RunContext;
 const CairoVMError = @import("error.zig").CairoVMError;
 const TraceError = @import("error.zig").TraceError;
 const MemoryError = @import("error.zig").MemoryError;
+const MathError = @import("error.zig").MathError;
 const Config = @import("config.zig").Config;
 const TraceContext = @import("trace_context.zig").TraceContext;
 const build_options = @import("../build_options.zig");
@@ -475,7 +476,7 @@ test "update pc update jnz with operands dst not zero op1 felt" {
     );
 }
 
-test "update ap add with operands res unconstrained" {
+test "CairoVM: updateAp using Add for AP update with null operands res" {
     // Test setup
     const allocator = std.testing.allocator;
     var operands = OperandsResult.default();
@@ -485,7 +486,41 @@ test "update ap add with operands res unconstrained" {
     defer vm.deinit();
 
     // Test body
-    try expectError(error.ApUpdateAddResUnconstrained, vm.updateAp(
+    try expectError(
+        error.ApUpdateAddResUnconstrained,
+        vm.updateAp(
+            &.{
+                .off_0 = 0,
+                .off_1 = 1,
+                .off_2 = 2,
+                .dst_reg = .FP,
+                .op_0_reg = .FP,
+                .op_1_addr = .Imm,
+                .res_logic = .Add,
+                .pc_update = .Jump,
+                .ap_update = .Add,
+                .fp_update = .Regular,
+                .opcode = .Call,
+            },
+            operands,
+        ),
+    );
+}
+
+test "CairoVM: updateAp using Add for AP update with non-null operands result" {
+    // Create an allocator for testing purposes.
+    const allocator = std.testing.allocator;
+    // Initialize operands result with a non-null result value.
+    var operands = OperandsResult.default();
+    operands.res = MaybeRelocatable.fromU256(10);
+
+    // Create a new VM instance.
+    var vm = try CairoVM.init(allocator, .{});
+    // Ensure VM instance is deallocated after the test.
+    defer vm.deinit();
+
+    // Invoke the updateAp function with specified parameters.
+    try vm.updateAp(
         &.{
             .off_0 = 0,
             .off_1 = 1,
@@ -500,10 +535,16 @@ test "update ap add with operands res unconstrained" {
             .opcode = .Call,
         },
         operands,
-    ));
+    );
+
+    // Expectation: The AP offset should be updated to the expected value after the operation.
+    try expectEqual(
+        @as(u64, 10),
+        vm.run_context.ap.*.offset,
+    );
 }
 
-test "update ap add1" {
+test "CairoVM: updateAp using Add1 for AP update" {
     // Test setup
     const allocator = std.testing.allocator;
     const operands = OperandsResult.default();
@@ -1541,23 +1582,26 @@ test "compute res add fails two relocs" {
     const op1 = MaybeRelocatable.fromRelocatable(value_op1);
 
     // Test checks
-    try expectError(error.AddRelocToRelocForbidden, computeRes(
-        &.{
-            .off_0 = 0,
-            .off_1 = 1,
-            .off_2 = 2,
-            .dst_reg = .AP,
-            .op_0_reg = .AP,
-            .op_1_addr = .AP,
-            .res_logic = .Add,
-            .pc_update = .Regular,
-            .ap_update = .Regular,
-            .fp_update = .Regular,
-            .opcode = .NOp,
-        },
-        op0,
-        op1,
-    ));
+    try expectError(
+        MathError.RelocatableAdd,
+        computeRes(
+            &.{
+                .off_0 = 0,
+                .off_1 = 1,
+                .off_2 = 2,
+                .dst_reg = .AP,
+                .op_0_reg = .AP,
+                .op_1_addr = .AP,
+                .res_logic = .Add,
+                .pc_update = .Regular,
+                .ap_update = .Regular,
+                .fp_update = .Regular,
+                .opcode = .NOp,
+            },
+            op0,
+            op1,
+        ),
+    );
 }
 
 test "compute res mul works" {
@@ -1619,23 +1663,26 @@ test "compute res mul fails two relocs" {
     const op1 = MaybeRelocatable.fromRelocatable(value_op1);
 
     // Test checks
-    try expectError(error.MulRelocForbidden, computeRes(
-        &.{
-            .off_0 = 0,
-            .off_1 = 1,
-            .off_2 = 2,
-            .dst_reg = .AP,
-            .op_0_reg = .AP,
-            .op_1_addr = .AP,
-            .res_logic = .Mul,
-            .pc_update = .Regular,
-            .ap_update = .Regular,
-            .fp_update = .Regular,
-            .opcode = .NOp,
-        },
-        op0,
-        op1,
-    ));
+    try expectError(
+        MathError.RelocatableMul,
+        computeRes(
+            &.{
+                .off_0 = 0,
+                .off_1 = 1,
+                .off_2 = 2,
+                .dst_reg = .AP,
+                .op_0_reg = .AP,
+                .op_1_addr = .AP,
+                .res_logic = .Mul,
+                .pc_update = .Regular,
+                .ap_update = .Regular,
+                .fp_update = .Regular,
+                .opcode = .NOp,
+            },
+            op0,
+            op1,
+        ),
+    );
 }
 
 test "compute res mul fails felt and reloc" {
@@ -1652,19 +1699,22 @@ test "compute res mul fails felt and reloc" {
     const op1 = MaybeRelocatable.fromFelt(starknet_felt.Felt252.fromInteger(2));
 
     // Test checks
-    try expectError(error.MulRelocForbidden, computeRes(&.{
-        .off_0 = 0,
-        .off_1 = 1,
-        .off_2 = 2,
-        .dst_reg = .AP,
-        .op_0_reg = .AP,
-        .op_1_addr = .AP,
-        .res_logic = .Mul,
-        .pc_update = .Regular,
-        .ap_update = .Regular,
-        .fp_update = .Regular,
-        .opcode = .NOp,
-    }, op0, op1));
+    try expectError(
+        MathError.RelocatableMul,
+        computeRes(&.{
+            .off_0 = 0,
+            .off_1 = 1,
+            .off_2 = 2,
+            .dst_reg = .AP,
+            .op_0_reg = .AP,
+            .op_1_addr = .AP,
+            .res_logic = .Mul,
+            .pc_update = .Regular,
+            .ap_update = .Regular,
+            .fp_update = .Regular,
+            .opcode = .NOp,
+        }, op0, op1),
+    );
 }
 
 test "compute res Unconstrained should return null" {

--- a/src/vm/error.zig
+++ b/src/vm/error.zig
@@ -133,6 +133,7 @@ pub const MathError = error{
     SubWithOverflow,
     /// Error indicating that the addition operation on the Relocatable offset exceeds the maximum limit.
     RelocatableAdditionOffsetExceeded,
+    RelocatableMul,
 };
 
 /// Represents different error conditions that occur in trace relocation

--- a/src/vm/memory/relocatable.zig
+++ b/src/vm/memory/relocatable.zig
@@ -32,7 +32,7 @@ pub const Relocatable = struct {
             .offset = offset,
         };
     }
-    
+
     // Creates a new Relocatable.
     // # Arguments
     // - segment_index - The index of the memory segment.
@@ -277,9 +277,9 @@ pub const MaybeRelocatable = union(enum) {
     /// ## Returns:
     ///   * `true` if the two instances are equal.
     ///   * `false` otherwise.
-    pub fn eq(self: Self, other: Self) bool {
+    pub fn eq(self: *const Self, other: Self) bool {
         // Switch on the type of `self`
-        return switch (self) {
+        return switch (self.*) {
             // If `self` is of type `relocatable`
             .relocatable => |self_value| switch (other) {
                 // Compare the `relocatable` values if both `self` and `other` are `relocatable`
@@ -305,9 +305,9 @@ pub const MaybeRelocatable = union(enum) {
     /// ## Returns:
     ///   * `true` if self is less than other
     ///   * `false` otherwise.
-    pub fn lt(self: Self, other: Self) bool {
+    pub fn lt(self: *const Self, other: Self) bool {
         // Switch on the type of `self`
-        return switch (self) {
+        return switch (self.*) {
             // If `self` is of type `relocatable`
             .relocatable => |self_value| switch (other) {
                 // Compare the `relocatable` values if both `self` and `other` are `relocatable`
@@ -333,9 +333,9 @@ pub const MaybeRelocatable = union(enum) {
     /// ## Returns:
     ///   * `true` if self is less than or equal to other
     ///   * `false` otherwise.
-    pub fn le(self: Self, other: Self) bool {
+    pub fn le(self: *const Self, other: Self) bool {
         // Switch on the type of `self`
-        return switch (self) {
+        return switch (self.*) {
             // If `self` is of type `relocatable`
             .relocatable => |self_value| switch (other) {
                 // Compare the `relocatable` values if both `self` and `other` are `relocatable`
@@ -361,9 +361,9 @@ pub const MaybeRelocatable = union(enum) {
     /// ## Returns:
     ///   * `true` if self is greater than other
     ///   * `false` otherwise.
-    pub fn gt(self: Self, other: Self) bool {
+    pub fn gt(self: *const Self, other: Self) bool {
         // Switch on the type of `self`
-        return switch (self) {
+        return switch (self.*) {
             // If `self` is of type `relocatable`
             .relocatable => |self_value| switch (other) {
                 // Compare the `relocatable` values if both `self` and `other` are `relocatable`
@@ -389,9 +389,9 @@ pub const MaybeRelocatable = union(enum) {
     /// ## Returns:
     ///   * `true` if self is greater than other
     ///   * `false` otherwise.
-    pub fn ge(self: Self, other: Self) bool {
+    pub fn ge(self: *const Self, other: Self) bool {
         // Switch on the type of `self`
-        return switch (self) {
+        return switch (self.*) {
             // If `self` is of type `relocatable`
             .relocatable => |self_value| switch (other) {
                 // Compare the `relocatable` values if both `self` and `other` are `relocatable`
@@ -424,9 +424,9 @@ pub const MaybeRelocatable = union(enum) {
     /// and `.eq` if they are equal based on their `segment_index` and `offset` values.
     ///
     /// Returns `MathError.IncompatibleComparisonTypes` if the comparison involves incompatible types.
-    pub fn cmp(self: Self, other: Self) std.math.Order {
+    pub fn cmp(self: *const Self, other: Self) std.math.Order {
         // Compare the `self` variant type against `other`
-        return switch (self) {
+        return switch (self.*) {
             // If `self` is of type `relocatable`
             .relocatable => |self_value| switch (other) {
                 // If `other` is also `relocatable`, compare the `relocatable` values
@@ -447,8 +447,8 @@ pub const MaybeRelocatable = union(enum) {
     /// Return the value of the MaybeRelocatable as a felt or error.
     /// # Returns
     /// The value of the MaybeRelocatable as a Relocatable felt or error.
-    pub fn tryIntoFelt(self: Self) CairoVMError!Felt252 {
-        return switch (self) {
+    pub fn tryIntoFelt(self: *const Self) CairoVMError!Felt252 {
+        return switch (self.*) {
             .relocatable => CairoVMError.TypeMismatchNotFelt,
             .felt => |felt| felt,
         };
@@ -457,11 +457,11 @@ pub const MaybeRelocatable = union(enum) {
     /// Return the value of the MaybeRelocatable as a felt or error.
     /// # Returns
     /// The value of the MaybeRelocatable as a Relocatable felt or error.
-    pub fn tryIntoU64(self: Self) error{
+    pub fn tryIntoU64(self: *const Self) error{
         TypeMismatchNotFelt,
         ValueTooLarge,
     }!u64 {
-        return switch (self) {
+        return switch (self.*) {
             .relocatable => CairoVMError.TypeMismatchNotFelt,
             .felt => |felt| felt.tryIntoU64(),
         };
@@ -470,8 +470,8 @@ pub const MaybeRelocatable = union(enum) {
     /// Return the value of the MaybeRelocatable as a Relocatable.
     /// # Returns
     /// The value of the MaybeRelocatable as a Relocatable.
-    pub fn tryIntoRelocatable(self: Self) CairoVMError!Relocatable {
-        return switch (self) {
+    pub fn tryIntoRelocatable(self: *const Self) CairoVMError!Relocatable {
+        return switch (self.*) {
             .relocatable => |relocatable| relocatable,
             .felt => CairoVMError.TypeMismatchNotRelocatable,
         };
@@ -480,8 +480,8 @@ pub const MaybeRelocatable = union(enum) {
     /// Whether the MaybeRelocatable is zero or not.
     /// # Returns
     /// true if the MaybeRelocatable is zero, false otherwise.
-    pub fn isZero(self: Self) bool {
-        return switch (self) {
+    pub fn isZero(self: *const Self) bool {
+        return switch (self.*) {
             .relocatable => false,
             .felt => |felt| felt.isZero(),
         };
@@ -490,8 +490,8 @@ pub const MaybeRelocatable = union(enum) {
     /// Whether the MaybeRelocatable is a relocatable or not.
     /// # Returns
     /// true if the MaybeRelocatable is a relocatable, false otherwise.
-    pub fn isRelocatable(self: MaybeRelocatable) bool {
-        return std.meta.activeTag(self) == .relocatable;
+    pub fn isRelocatable(self: *const MaybeRelocatable) bool {
+        return std.meta.activeTag(self.*) == .relocatable;
     }
 
     /// Returns whether the MaybeRelocatable is a felt or not.
@@ -515,9 +515,9 @@ pub const MaybeRelocatable = union(enum) {
     /// # Returns:
     ///   * A new MaybeRelocatable value after the addition operation.
     ///   * An error in case of type mismatch or specific math errors.
-    pub fn add(self: Self, other: Self) MathError!Self {
+    pub fn add(self: *const Self, other: Self) MathError!Self {
         // Switch on the type of `self`
-        return switch (self) {
+        return switch (self.*) {
             // If `self` is of type `relocatable`
             .relocatable => |self_value| switch (other) {
                 // If `other` is also `relocatable`, addition is not supported, return an error
@@ -547,9 +547,9 @@ pub const MaybeRelocatable = union(enum) {
     /// # Returns:
     ///   * A new MaybeRelocatable value after the subtraction operation.
     ///   * An error in case of type mismatch or specific math errors.
-    pub fn sub(self: Self, other: Self) !Self {
+    pub fn sub(self: *const Self, other: Self) !Self {
         // Switch on the type of `self`
-        return switch (self) {
+        return switch (self.*) {
             // If `self` is of type `relocatable`
             .relocatable => |self_value| switch (other) {
                 // If `other` is also `relocatable`, call `sub` method on `self_value`
@@ -563,6 +563,32 @@ pub const MaybeRelocatable = union(enum) {
                 .felt => |fe| .{ .felt = self_value.sub(fe) },
                 // If `other` is `relocatable`, return an error as subtraction is not supported
                 .relocatable => MathError.SubRelocatableFromInt,
+            },
+        };
+    }
+
+    /// Multiplies two MaybeRelocatable values.
+    ///
+    /// This method performs multiplication between two MaybeRelocatable instances, either Felt252 or Felt.
+    /// It returns an error if either operand is Relocatable.
+    ///
+    /// # Arguments:
+    ///   * self: The first MaybeRelocatable value.
+    ///   * other: The second MaybeRelocatable value to multiply with `self`.
+    ///
+    /// # Returns:
+    ///   * A new MaybeRelocatable value after the multiplication operation.
+    ///   * An error in case either operand is Relocatable.
+    pub fn mul(self: *const Self, other: Self) !Self {
+        return switch (self.*) {
+            // If `self` is of type `relocatable`
+            .relocatable => MathError.RelocatableMul,
+            // If `self` is of type `felt`
+            .felt => |self_value| switch (other) {
+                // If `other` is also `relocatable`, multiplication is not supported, return an error
+                .relocatable => MathError.RelocatableMul,
+                // If `other` is `felt`, call `mul` method on `self_value`
+                .felt => |fe| .{ .felt = self_value.mul(fe) },
             },
         };
     }
@@ -1373,5 +1399,75 @@ test "MaybeRelocatable.fromU64: should create a MaybeRelocatable from a u64" {
     try expectEqual(
         MaybeRelocatable.fromU256(45),
         MaybeRelocatable.fromU64(@intCast(45)),
+    );
+}
+
+test "MaybeRelocatable.mul: should return an error if lhs is Relocatable" {
+    // Test Case 1
+    // Try to perform multiplication with Relocatable value on the left-hand side.
+    try expectError(
+        MathError.RelocatableMul,
+        MaybeRelocatable.fromSegment(
+            0,
+            1,
+        ).mul(MaybeRelocatable.fromU256(45)),
+    );
+
+    // Test Case 2
+    // Try to perform multiplication with two Relocatable values.
+    try expectError(
+        MathError.RelocatableMul,
+        MaybeRelocatable.fromSegment(
+            0,
+            1,
+        ).mul(MaybeRelocatable.fromSegment(
+            0,
+            1,
+        )),
+    );
+}
+
+test "MaybeRelocatable.mul: should return an error if rhs is Relocatable" {
+    // Test Case
+    // Try to perform multiplication with Relocatable value on the right-hand side.
+    try expectError(
+        MathError.RelocatableMul,
+        MaybeRelocatable.fromU256(45).mul(MaybeRelocatable.fromSegment(
+            0,
+            1,
+        )),
+    );
+}
+
+test "MaybeRelocatable.mul: should return Felt multiplication operation if both lhs and rhs are Felt252" {
+    // Test Case 1
+    // Perform multiplication with two Felt values (10 and 5).
+    const result1 = (try MaybeRelocatable.fromU256(10).mul(
+        MaybeRelocatable.fromU256(5),
+    ));
+    // Expectation: Result should be equal to 0x32.
+    try expectEqual(
+        @as(
+            u256,
+            0x32,
+        ),
+        (try result1.tryIntoFelt()).toInteger(),
+    );
+
+    // Test Case 2
+    // Perform multiplication with two large Felt values.
+    const result2 = (try MaybeRelocatable.fromU256(
+        std.math.maxInt(u256),
+    ).mul(
+        MaybeRelocatable.fromU256(2),
+    ));
+
+    // Expectation: Result should be equal to 0x7fffffffffffbd0ffffffffffffffffffffffffffffffffffffffffffffffbf.
+    try expectEqual(
+        @as(
+            u256,
+            0x7fffffffffffbd0ffffffffffffffffffffffffffffffffffffffffffffffbf,
+        ),
+        (try result2.tryIntoFelt()).toInteger(),
     );
 }


### PR DESCRIPTION
## Summary

This pull request addresses and should close #131.

## Changes Made

This pull request focuses on the following key points:

- **Unit Tests:** Added new unit tests to cover various configurations of the `updateAp` function.
- **Code Refactoring:** Moved operand calculation methods to the `MaybeRelocatable` implementation. These methods involve multiplicative, additive, or subtractive operations between `MaybeRelocatable` instances, making it a more suitable place for their implementation compared to the previous location in the core of the VM.
- **Performance Optimization:** Modified the function signature to pass the first argument as a pointer with a constant. This change aims to enhance performance and improve access time by avoiding unnecessary value copying.

