### PR TITLE
add `getBuiltinSegmentsInfo` implementation for `CairoRunner` and unit tests

### DIFF
--- a/src/vm/builtins/builtin_runner/bitwise.zig
+++ b/src/vm/builtins/builtin_runner/bitwise.zig
@@ -233,7 +233,7 @@ pub const BitwiseBuiltinRunner = struct {
     ///
     /// # Returns
     /// A tuple of `usize` and `?usize` addresses.
-    pub fn getMemorySegmentAddresses(self: *Self) Tuple(&.{
+    pub fn getMemorySegmentAddresses(self: *const Self) Tuple(&.{
         usize,
         ?usize,
     }) {

--- a/src/vm/builtins/builtin_runner/builtin_runner.zig
+++ b/src/vm/builtins/builtin_runner/builtin_runner.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const Tuple = std.meta.Tuple;
 
 const MemorySegmentManager = @import("../../memory/segments.zig").MemorySegmentManager;
 
@@ -12,11 +13,9 @@ const PoseidonBuiltinRunner = @import("./poseidon.zig").PoseidonBuiltinRunner;
 const RangeCheckBuiltinRunner = @import("./range_check.zig").RangeCheckBuiltinRunner;
 const SegmentArenaBuiltinRunner = @import("./segment_arena.zig").SegmentArenaBuiltinRunner;
 const SignatureBuiltinRunner = @import("./signature.zig").SignatureBuiltinRunner;
-
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
-
 const ArrayList = std.ArrayList;
 
 /// Built-in runner
@@ -129,6 +128,32 @@ pub const BuiltinRunner = union(enum) {
             .Signature => |signature| signature.deduceMemoryCell(address, memory),
             .Poseidon => |poseidon| poseidon.deduceMemoryCell(address, memory),
             .SegmentArena => |segment_arena| segment_arena.deduceMemoryCell(address, memory),
+        };
+    }
+
+    /// Retrieves the memory segment addresses associated with the built-in runner.
+    ///
+    /// This function returns a `Tuple` containing the starting address and optional stop address
+    /// for each memory segment used by the specific type of built-in runner. The stop address may
+    /// be `null` if the built-in runner doesn't have a distinct stop address for its memory segment.
+    ///
+    /// # Returns
+    ///
+    /// A `Tuple` containing the memory segment addresses as follows:
+    /// - The starting address of the memory segment.
+    /// - An optional stop address of the memory segment (may be `null`).
+    pub fn getMemorySegmentAddresses(self: *Self) Tuple(&.{ usize, ?usize }) {
+        // TODO: fill-in missing builtins when implemented
+        return switch (self.*) {
+            .Bitwise => |*bitwise| bitwise.getMemorySegmentAddresses(),
+            .EcOp => .{ 0, 0 },
+            .Hash => .{ 0, 0 },
+            .Output => |*output| output.getMemorySegmentAddresses(),
+            .RangeCheck => |*range_check| range_check.getMemorySegmentAddresses(),
+            .Keccak => |*keccak| keccak.getMemorySegmentAddresses(),
+            .Signature => .{ 0, 0 },
+            .Poseidon => .{ 0, 0 },
+            .SegmentArena => .{ 0, 0 },
         };
     }
 };

--- a/src/vm/builtins/builtin_runner/keccak.zig
+++ b/src/vm/builtins/builtin_runner/keccak.zig
@@ -149,7 +149,7 @@ pub const KeccakBuiltinRunner = struct {
     ///
     /// # Returns
     /// A tuple of `usize` and `?usize` addresses.
-    pub fn getMemorySegmentAddresses(self: *Self) std.meta.Tuple(&.{
+    pub fn getMemorySegmentAddresses(self: *const Self) std.meta.Tuple(&.{
         usize,
         ?usize,
     }) {

--- a/src/vm/builtins/builtin_runner/output.zig
+++ b/src/vm/builtins/builtin_runner/output.zig
@@ -260,7 +260,7 @@ pub const OutputBuiltinRunner = struct {
     /// # Returns
     ///
     /// A Tuple containing the base and stop pointer addresses, indicating the memory segment configuration.
-    pub fn getMemorySegmentAddresses(self: *Self) std.meta.Tuple(&.{ usize, ?usize }) {
+    pub fn getMemorySegmentAddresses(self: *const Self) std.meta.Tuple(&.{ usize, ?usize }) {
         return .{ self.base, self.stop_ptr };
     }
 

--- a/src/vm/builtins/builtin_runner/range_check.zig
+++ b/src/vm/builtins/builtin_runner/range_check.zig
@@ -163,7 +163,7 @@ pub const RangeCheckBuiltinRunner = struct {
     ///
     /// # Returns
     /// A tuple of `usize` and `?usize` addresses.
-    pub fn getMemorySegmentAddresses(self: *Self) std.meta.Tuple(&.{
+    pub fn getMemorySegmentAddresses(self: *const Self) std.meta.Tuple(&.{
         usize,
         ?usize,
     }) {

--- a/src/vm/runners/cairo_runner.zig
+++ b/src/vm/runners/cairo_runner.zig
@@ -17,6 +17,15 @@ const trace_context = @import("../trace_context.zig");
 const RelocatedTraceEntry = trace_context.TraceContext.RelocatedTraceEntry;
 const starknet_felt = @import("../../math/fields/starknet.zig");
 const Felt252 = starknet_felt.Felt252;
+const OutputBuiltinRunner = @import("../builtins/builtin_runner/output.zig").OutputBuiltinRunner;
+const BitwiseBuiltinRunner = @import("../builtins/builtin_runner/bitwise.zig").BitwiseBuiltinRunner;
+
+const expect = std.testing.expect;
+const expectEqual = std.testing.expectEqual;
+const expectError = std.testing.expectError;
+const expectEqualSlices = std.testing.expectEqualSlices;
+
+const BuiltinInfo = struct { segment_index: usize, stop_pointer: usize };
 
 pub const CairoRunner = struct {
     const Self = @This();
@@ -194,6 +203,53 @@ pub const CairoRunner = struct {
         self.relocated_trace = try self.vm.getRelocatedTrace();
     }
 
+    /// Retrieves information about the builtin segments.
+    ///
+    /// This function iterates through the builtin runners of the CairoRunner and gathers
+    /// information about the memory segments, including their indices and stop pointers.
+    /// The gathered information is stored in an ArrayList of BuiltinInfo structures.
+    ///
+    /// # Arguments
+    /// - `self`: A mutable reference to the CairoRunner instance.
+    /// - `allocator`: The allocator to be used for initializing the ArrayList.
+    ///
+    /// # Returns
+    /// An ArrayList containing information about the builtin segments.
+    ///
+    /// # Errors
+    /// - Returns a RunnerError if any builtin runner does not have a stop pointer.
+    pub fn getBuiltinSegmentsInfo(self: *Self, allocator: Allocator) !ArrayList(BuiltinInfo) {
+        // Initialize an ArrayList to store information about builtin segments.
+        var builtin_segment_info = ArrayList(BuiltinInfo).init(allocator);
+
+        // Defer the deinitialization of the ArrayList to ensure cleanup in case of errors.
+        errdefer builtin_segment_info.deinit();
+
+        // Iterate through each builtin runner.
+        for (self.vm.builtin_runners.items) |*builtin| {
+            // Retrieve the memory segment addresses from the builtin runner.
+            const memory_segment_addresses = builtin.getMemorySegmentAddresses();
+
+            // Uncomment the following line for debugging purposes.
+            // std.debug.print("memory_segment_addresses = {any}\n", .{memory_segment_addresses});
+
+            // Check if the stop pointer is present.
+            if (memory_segment_addresses[1]) |stop_pointer| {
+                // Append information about the segment to the ArrayList.
+                try builtin_segment_info.append(.{
+                    .segment_index = memory_segment_addresses[0],
+                    .stop_pointer = stop_pointer,
+                });
+            } else {
+                // Return an error if a stop pointer is missing.
+                return RunnerError.NoStopPointer;
+            }
+        }
+
+        // Return the ArrayList containing information about the builtin segments.
+        return builtin_segment_info;
+    }
+
     pub fn deinit(self: *Self) void {
         // currently handling the deinit of the json.Parsed(ProgramJson) outside of constructor
         // otherwise the runner would always assume json in its interface
@@ -205,3 +261,98 @@ pub const CairoRunner = struct {
         self.vm.deinit();
     }
 };
+
+test "CairoRunner: getBuiltinSegmentsInfo with segment info empty should return an empty vector" {
+    // Create a CairoRunner instance for testing.
+    var cairo_runner = try CairoRunner.init(
+        std.testing.allocator,
+        ProgramJson{},
+        "plain",
+        ArrayList(MaybeRelocatable).init(std.testing.allocator),
+        try CairoVM.init(
+            std.testing.allocator,
+            .{},
+        ),
+        false,
+    );
+    defer cairo_runner.deinit();
+
+    // Retrieve the builtin segment info from the CairoRunner.
+    var builtin_segment_info = try cairo_runner.getBuiltinSegmentsInfo(std.testing.allocator);
+    defer builtin_segment_info.deinit();
+
+    // Ensure that the length of the vector is zero.
+    try expect(builtin_segment_info.items.len == 0);
+}
+
+test "CairoRunner: getBuiltinSegmentsInfo info based not finished" {
+    // Create a CairoRunner instance for testing.
+    var cairo_runner = try CairoRunner.init(
+        std.testing.allocator,
+        ProgramJson{},
+        "plain",
+        ArrayList(MaybeRelocatable).init(std.testing.allocator),
+        try CairoVM.init(
+            std.testing.allocator,
+            .{},
+        ),
+        false,
+    );
+    defer cairo_runner.deinit();
+
+    // Add an OutputBuiltinRunner to the CairoRunner without setting the stop pointer.
+    try cairo_runner.vm.builtin_runners.append(.{ .Output = OutputBuiltinRunner.initDefault(std.testing.allocator) });
+
+    // Ensure that calling getBuiltinSegmentsInfo results in a RunnerError.NoStopPointer.
+    try expectError(
+        RunnerError.NoStopPointer,
+        cairo_runner.getBuiltinSegmentsInfo(std.testing.allocator),
+    );
+}
+
+test "CairoRunner: getBuiltinSegmentsInfo should provide builtin segment information" {
+    // Create a CairoRunner instance for testing.
+    var cairo_runner = try CairoRunner.init(
+        std.testing.allocator,
+        ProgramJson{},
+        "plain",
+        ArrayList(MaybeRelocatable).init(std.testing.allocator),
+        try CairoVM.init(
+            std.testing.allocator,
+            .{},
+        ),
+        false,
+    );
+    defer cairo_runner.deinit();
+
+    // Create instances of OutputBuiltinRunner and BitwiseBuiltinRunner with stop pointers.
+    var output_builtin = OutputBuiltinRunner.initDefault(std.testing.allocator);
+    output_builtin.stop_ptr = 10;
+
+    var bitwise_builtin = BitwiseBuiltinRunner.initDefault();
+    bitwise_builtin.stop_ptr = 25;
+
+    // Append instances of OutputBuiltinRunner and BitwiseBuiltinRunner to the CairoRunner.
+    try cairo_runner.vm.builtin_runners.appendNTimes(.{ .Output = output_builtin }, 5);
+    try cairo_runner.vm.builtin_runners.appendNTimes(.{ .Bitwise = bitwise_builtin }, 3);
+
+    // Retrieve the builtin segment info from the CairoRunner.
+    var builtin_segment_info = try cairo_runner.getBuiltinSegmentsInfo(std.testing.allocator);
+    defer builtin_segment_info.deinit();
+
+    // Verify that the obtained information matches the expected values.
+    try expectEqualSlices(
+        BuiltinInfo,
+        &[_]BuiltinInfo{
+            .{ .segment_index = 0, .stop_pointer = 10 },
+            .{ .segment_index = 0, .stop_pointer = 10 },
+            .{ .segment_index = 0, .stop_pointer = 10 },
+            .{ .segment_index = 0, .stop_pointer = 10 },
+            .{ .segment_index = 0, .stop_pointer = 10 },
+            .{ .segment_index = 0, .stop_pointer = 25 },
+            .{ .segment_index = 0, .stop_pointer = 25 },
+            .{ .segment_index = 0, .stop_pointer = 25 },
+        },
+        builtin_segment_info.items,
+    );
+}


### PR DESCRIPTION
## Description

This pull request implements the `getBuiltinSegmentsInfo` function for the `CairoRunner` module. The function retrieves information about built-in segments, allowing better insight into the memory layout and associated data.

## Changes Made

- Implemented the `getBuiltinSegmentsInfo` function in the `CairoRunner` module.
- Added unit tests to ensure the correctness of the new function.

## Testing

- Added unit tests to cover various scenarios, ensuring the proper functioning of the `getBuiltinSegmentsInfo` function.


