### PR TITLE
Implement Automated Management for Stale and Locked Issues/PRs

### DIFF
--- a/.github/workflows/cron-daily.yml
+++ b/.github/workflows/cron-daily.yml
@@ -1,0 +1,16 @@
+---
+name: Workflow - Daily Cron
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale_issues:
+    name: Stale issues
+    uses: ./.github/workflows/stale-issues.yml
+
+  lock_closed:
+    name: Lock closed issues/PRs
+    uses: ./.github/workflows/lock-closed.yml

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -1,0 +1,31 @@
+---
+name: Task - Lock Closed Issues/PRs
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  lock:
+    name: 🔒 Lock closed issues and PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2.0.3
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: "30"
+          issue-lock-reason: ""
+          issue-comment: >
+            Issue closed and locked due to lack of activity.
+
+            If you encounter this same issue, please open a new issue and refer
+            to this closed one.
+          pr-lock-inactive-days: "1"
+          pr-lock-reason: ""
+          pr-comment: >
+            Pull Request closed and locked due to lack of activity.
+
+            If you'd like to build on this closed PR, you can clone it using
+            this method: https://stackoverflow.com/a/14969986
+
+            Then open a new PR, referencing this closed PR in your message.

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,42 @@
+---
+name: Task - Stale Issues
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  stale:
+    name: 🧹 Clean up stale issues and PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🚀 Run stale
+        uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: -1
+          remove-stale-when-updated: true
+          stale-issue-label: "stale"
+          exempt-issue-labels: "no-stale,help-wanted"
+          stale-issue-message: >
+            There hasn't been any activity on this issue recently, and in order
+            to prioritize active issues, it will be marked as stale.
+
+            Please make sure to update to the latest version and check if that
+            solves the issue. Let us know if that works for you by leaving a 👍
+
+            Because this issue is marked as stale, it will be closed and locked
+            in 7 days if no further activity occurs.
+
+            Thank you for your contributions!
+          stale-pr-label: "stale"
+          exempt-pr-labels: "no-stale"
+          stale-pr-message: >
+            There hasn't been any activity on this pull request recently, and in
+            order to prioritize active work, it has been marked as stale.
+
+            This PR will be closed and locked in 7 days if no further activity
+            occurs.
+
+            Thank you for your contributions!


### PR DESCRIPTION
# Summary
Following conventions of madara (hat tip @d-roak), this PR introduces two GitHub Actions to enhance our repository's issue and PR management. One action marks issues/PRs as stale, and the other locks closed issues/PRs after specified periods of inactivity. These changes aim to streamline our backlog and maintain a focus on active contributions.

## Changes
1. **Stale Issues/PRs Management**
   - Issues and PRs will be marked as stale after 30 days of inactivity.
   - Stale items receive a comment prompting for updates or closure.
   - Items with certain labels (e.g., 'no-stale', 'help-wanted') are exempt from being marked as stale.

2. **Locking Closed Issues/PRs**
   - Closed issues are locked after 30 days of inactivity; closed PRs after 1 day.
   - Locking prevents further comments on closed items.
   - Custom comments explain the locking rationale and guide contributors on subsequent steps.