### PR TITLE
improve init methods in `CairoRunner` with unit tests

### DIFF
--- a/src/vm/builtins/builtin_runner/builtin_runner.zig
+++ b/src/vm/builtins/builtin_runner/builtin_runner.zig
@@ -18,6 +18,33 @@ const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatabl
 const Memory = @import("../../memory/memory.zig").Memory;
 const ArrayList = std.ArrayList;
 
+/// The name of the output builtin.
+pub const OUTPUT_BUILTIN_NAME = "output_builtin";
+
+/// The name of the Pedersen hash builtin.
+pub const HASH_BUILTIN_NAME = "pedersen_builtin";
+
+/// The name of the range check builtin.
+pub const RANGE_CHECK_BUILTIN_NAME = "range_check_builtin";
+
+/// The name of the ECDSA signature verification builtin.
+pub const SIGNATURE_BUILTIN_NAME = "ecdsa_builtin";
+
+/// The name of the bitwise operations builtin.
+pub const BITWISE_BUILTIN_NAME = "bitwise_builtin";
+
+/// The name of the elliptic curve operations builtin.
+pub const EC_OP_BUILTIN_NAME = "ec_op_builtin";
+
+/// The name of the Keccak hash builtin.
+pub const KECCAK_BUILTIN_NAME = "keccak_builtin";
+
+/// The name of the Poseidon hash builtin.
+pub const POSEIDON_BUILTIN_NAME = "poseidon_builtin";
+
+/// The name of the segment arena builtin.
+pub const SEGMENT_ARENA_BUILTIN_NAME = "segment_arena_builtin";
+
 /// Built-in runner
 pub const BuiltinRunner = union(enum) {
     const Self = @This();
@@ -155,5 +182,46 @@ pub const BuiltinRunner = union(enum) {
             .Poseidon => |*poseidon| poseidon.getMemorySegmentAddresses(),
             .SegmentArena => .{ 0, 0 },
         };
+    }
+
+    /// Gets the name of the built-in runner.
+    ///
+    /// This function returns the name associated with the specific type of built-in runner.
+    ///
+    /// # Returns
+    ///
+    /// A null-terminated byte slice representing the name of the built-in runner.
+    pub fn name(self: *Self) []const u8 {
+        return switch (self.*) {
+            .Bitwise => BITWISE_BUILTIN_NAME,
+            .EcOp => EC_OP_BUILTIN_NAME,
+            .Hash => HASH_BUILTIN_NAME,
+            .Output => OUTPUT_BUILTIN_NAME,
+            .RangeCheck => RANGE_CHECK_BUILTIN_NAME,
+            .Keccak => KECCAK_BUILTIN_NAME,
+            .Signature => SIGNATURE_BUILTIN_NAME,
+            .Poseidon => POSEIDON_BUILTIN_NAME,
+            .SegmentArena => SEGMENT_ARENA_BUILTIN_NAME,
+        };
+    }
+
+    /// Adds a validation rule to the built-in runner for memory validation.
+    ///
+    /// This method is used to add a validation rule specific to the type of built-in runner.
+    /// For certain built-ins, like the Range Check built-in, additional memory validation rules may
+    /// be necessary to ensure proper execution.
+    ///
+    /// # Arguments
+    ///
+    /// - `memory`: A pointer to the Memory manager for the current context.
+    ///
+    /// # Errors
+    ///
+    /// An error is returned if adding the validation rule fails.
+    pub fn addValidationRule(self: *Self, memory: *Memory) !void {
+        switch (self.*) {
+            .RangeCheck => |*range_check| try range_check.addValidationRule(memory),
+            else => {},
+        }
     }
 };

--- a/src/vm/error.zig
+++ b/src/vm/error.zig
@@ -136,6 +136,14 @@ pub const RunnerError = error{
     IntegerBiggerThanPowerOfTwo,
     /// Memory-related errors in the built-in runners.
     Memory,
+    /// Raised when attempting to access the program counter (PC) when it is not available.
+    NoPC,
+    /// Raised when attempting to access the allocation pointer (AP) when it is not available.
+    NoAP,
+    /// Raised when attempting to access the function pointer (FP) when it is not available.
+    NoFP,
+    /// Raised when there are errors related to memory validation in Cairo runner.
+    MemoryValidationError,
 };
 
 /// Represents different error conditions that occur during mathematical operations.

--- a/src/vm/runners/cairo_runner.zig
+++ b/src/vm/runners/cairo_runner.zig
@@ -167,7 +167,7 @@ pub const CairoRunner = struct {
         try self.initBuiltins(&self.vm);
         try self.initSegments(null);
         const end = try self.initMainEntrypoint();
-        self.initVM();
+        try self.initVM();
         return end;
     }
 
@@ -204,7 +204,7 @@ pub const CairoRunner = struct {
     /// - `entrypoint:` The address, relative to the program segment, where execution begins.
     pub fn initState(self: *Self, entrypoint: usize) !void {
         self.initial_pc = self.program_base;
-        self.initial_pc.addUintInPlace(entrypoint);
+        self.initial_pc.?.addUintInPlace(entrypoint);
 
         _ = try self.vm.segments.loadData(
             self.allocator,
@@ -232,7 +232,7 @@ pub const CairoRunner = struct {
         try self.function_call_stack.append(MaybeRelocatable.fromRelocatable(end));
 
         self.initial_fp = self.execution_base;
-        self.initial_fp.addUintInPlace(@as(u64, self.function_call_stack.items.len));
+        self.initial_fp.?.addUintInPlace(@as(u64, self.function_call_stack.items.len));
         self.initial_ap = self.initial_fp;
 
         self.final_pc = &end;

--- a/src/vm/runners/cairo_runner.zig
+++ b/src/vm/runners/cairo_runner.zig
@@ -20,6 +20,7 @@ const starknet_felt = @import("../../math/fields/starknet.zig");
 const Felt252 = starknet_felt.Felt252;
 const OutputBuiltinRunner = @import("../builtins/builtin_runner/output.zig").OutputBuiltinRunner;
 const BitwiseBuiltinRunner = @import("../builtins/builtin_runner/bitwise.zig").BitwiseBuiltinRunner;
+const RangeCheckBuiltinRunner = @import("../builtins/builtin_runner/range_check.zig").RangeCheckBuiltinRunner;
 
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
@@ -28,14 +29,14 @@ const expectEqualSlices = std.testing.expectEqualSlices;
 
 /// Tracks the step resources of a cairo execution run.
 const RunResources = struct {
-    const Self = @This();    
+    const Self = @This();
     // We consider the 'default' mode of RunResources having infinite steps.
     n_steps: ?usize = null,
 
     pub fn init(n_steps: usize) Self {
-        return .{.n_steps = n_steps};
+        return .{ .n_steps = n_steps };
     }
-    
+
     pub fn consumed(self: *Self) bool {
         if (self.n_steps) |n_steps| {
             return n_steps == 0;
@@ -57,7 +58,7 @@ const RunResources = struct {
 /// It is primarily used in the context of Starknet and implemented by HintProcessors.
 const ResourceTracker = struct {
     const Self = @This();
-    
+
     // define interface fields: ptr,vtab
     ptr: *anyopaque, //ptr to instance
     vtab: *const VTab, //ptr to vtab
@@ -85,14 +86,14 @@ const ResourceTracker = struct {
         std.debug.assert(@typeInfo(PtrInfo.Pointer.child) == .Struct); // Must point to a struct
         const impl = struct {
             fn consumed(ptr: *anyopaque) bool {
-                const self: Ptr = @ptrCast(@alignCast(ptr));                
+                const self: Ptr = @ptrCast(@alignCast(ptr));
                 return self.consumed();
             }
             fn consumeStep(ptr: *anyopaque) void {
-                const self: Ptr = @ptrCast(@alignCast(ptr));                                
+                const self: Ptr = @ptrCast(@alignCast(ptr));
                 self.consumeStep();
             }
-        }; 
+        };
         return .{
             .ptr = obj,
             .vtab = &.{
@@ -113,9 +114,9 @@ pub const CairoRunner = struct {
     vm: CairoVM,
     program_base: Relocatable = undefined,
     execution_base: Relocatable = undefined,
-    initial_pc: Relocatable = undefined,
-    initial_ap: Relocatable = undefined,
-    initial_fp: Relocatable = undefined,
+    initial_pc: ?Relocatable = null,
+    initial_ap: ?Relocatable = null,
+    initial_fp: ?Relocatable = null,
     final_pc: *Relocatable = undefined,
     instructions: std.ArrayList(MaybeRelocatable),
     function_call_stack: std.ArrayList(MaybeRelocatable),
@@ -164,21 +165,32 @@ pub const CairoRunner = struct {
 
     pub fn setupExecutionState(self: *Self) !Relocatable {
         try self.initBuiltins(&self.vm);
-        try self.initSegments();
+        try self.initSegments(null);
         const end = try self.initMainEntrypoint();
         self.initVM();
         return end;
     }
 
     /// Initializes common segments for the execution of a cairo program.
-    pub fn initSegments(self: *Self) !void {
+    ///
+    /// This function initializes the memory segments required for the execution of a Cairo program.
+    /// It creates segments for the program base, execution stack, and built-in runners.
+    ///
+    /// # Arguments
+    ///
+    /// - `program_base`: An optional `Relocatable` representing the base address for the program.
+    ///
+    /// # Returns
+    ///
+    /// This function returns `void`.
+    pub fn initSegments(self: *Self, program_base: ?Relocatable) !void {
+        // Set the program base to the provided value or create a new segment.
+        self.program_base = if (program_base) |base| base else try self.vm.segments.addSegment();
 
-        // Common segments, as defined in pg 41 of the cairo paper
-        // stores the bytecode of the executed Cairo ProgramJson
-        self.program_base = try self.vm.segments.addSegment();
-        // stores the execution stack
+        // Create a segment for the execution stack.
         self.execution_base = try self.vm.segments.addSegment();
 
+        // Initialize segments for each built-in runner.
         for (self.vm.builtin_runners.items) |*builtin_runner| {
             try builtin_runner.initSegments(self.vm.segments);
         }
@@ -251,10 +263,32 @@ pub const CairoRunner = struct {
         return end;
     }
 
-    pub fn initVM(self: *Self) void {
-        self.vm.run_context.ap.* = self.initial_ap;
-        self.vm.run_context.fp.* = self.initial_fp;
-        self.vm.run_context.pc.* = self.initial_pc;
+    /// Initializes the runner's virtual machine (VM) state for execution.
+    ///
+    /// This function sets up the initial state of the VM, including the program counter (PC),
+    /// activation pointer (AP), and frame pointer (FP). It also adds validation rules for built-in runners
+    /// and validates the existing memory segments.
+    ///
+    /// # Arguments
+    ///
+    /// - `self`: A mutable reference to the `CairoRunner` instance.
+    ///
+    /// # Returns
+    ///
+    /// This function returns `void`. In case of errors, it returns a `RunnerError`.
+    pub fn initVM(self: *Self) !void {
+        // Set VM state: AP, FP, PC
+        self.vm.run_context.ap.* = self.initial_ap orelse return RunnerError.NoAP;
+        self.vm.run_context.fp.* = self.initial_fp orelse return RunnerError.NoFP;
+        self.vm.run_context.pc.* = self.initial_pc orelse return RunnerError.NoPC;
+
+        // Add validation rules for built-in runners
+        for (self.vm.builtin_runners.items) |*builtin_runner| {
+            try builtin_runner.addValidationRule(self.vm.segments.memory);
+        }
+
+        // Validate existing memory segments
+        self.vm.segments.memory.validateExistingMemory() catch return RunnerError.MemoryValidationError;
     }
 
     pub fn runUntilPC(self: *Self, end: Relocatable) !void {
@@ -390,6 +424,155 @@ pub const CairoRunner = struct {
     }
 };
 
+test "CairoRunner: initVM should initialize the VM properly with no builtins" {
+    // Initialize a CairoRunner with an empty program, "plain" layout, and empty instructions.
+    var cairo_runner = try CairoRunner.init(
+        std.testing.allocator,
+        ProgramJson{},
+        "plain",
+        ArrayList(MaybeRelocatable).init(std.testing.allocator),
+        try CairoVM.init(
+            std.testing.allocator,
+            .{},
+        ),
+        false,
+    );
+    // Defer the deinitialization of the CairoRunner to ensure proper cleanup.
+    defer cairo_runner.deinit();
+
+    // Set initial values for program_base, initial_pc, initial_ap, and initial_fp.
+    cairo_runner.program_base = Relocatable.init(0, 0);
+    cairo_runner.initial_pc = Relocatable.init(0, 1);
+    cairo_runner.initial_ap = Relocatable.init(1, 2);
+    cairo_runner.initial_fp = Relocatable.init(1, 2);
+
+    // Initialize the VM state using the initVM function.
+    try cairo_runner.initVM();
+
+    // Expect that the program counter (PC) is initialized correctly.
+    try expectEqual(
+        Relocatable.init(0, 1),
+        cairo_runner.vm.run_context.pc.*,
+    );
+    // Expect that the allocation pointer (AP) is initialized correctly.
+    try expectEqual(
+        Relocatable.init(1, 2),
+        cairo_runner.vm.run_context.ap.*,
+    );
+    // Expect that the frame pointer (FP) is initialized correctly.
+    try expectEqual(
+        Relocatable.init(1, 2),
+        cairo_runner.vm.run_context.fp.*,
+    );
+}
+
+test "CairoRunner: initVM should initialize the VM properly with Range Check builtin" {
+    // Initialize a CairoRunner with an empty program, "plain" layout, and empty instructions.
+    var cairo_runner = try CairoRunner.init(
+        std.testing.allocator,
+        ProgramJson{},
+        "plain",
+        ArrayList(MaybeRelocatable).init(std.testing.allocator),
+        try CairoVM.init(
+            std.testing.allocator,
+            .{},
+        ),
+        false,
+    );
+    // Defer the deinitialization of the CairoRunner to ensure proper cleanup.
+    defer cairo_runner.deinit();
+
+    // Append a RangeCheckBuiltinRunner to the CairoRunner's list of built-in runners.
+    try cairo_runner.vm.builtin_runners.append(.{ .RangeCheck = RangeCheckBuiltinRunner{} });
+
+    // Set initial values for program_base, initial_pc, initial_ap, and initial_fp.
+    cairo_runner.initial_pc = Relocatable.init(0, 1);
+    cairo_runner.initial_ap = Relocatable.init(1, 2);
+    cairo_runner.initial_fp = Relocatable.init(1, 2);
+
+    // Initialize memory segments for the CairoRunner.
+    try cairo_runner.initSegments(null);
+
+    // Set up memory for the VM with specific addresses and values.
+    try cairo_runner.vm.segments.memory.setUpMemory(
+        std.testing.allocator,
+        .{
+            .{ .{ 2, 0 }, .{23} },
+            .{ .{ 2, 1 }, .{233} },
+        },
+    );
+    // Ensure data memory is deallocated after the test.
+    defer cairo_runner.vm.segments.memory.deinitData(std.testing.allocator);
+
+    // Expect that the name of the first built-in runner is "range_check_builtin".
+    try expect(std.mem.eql(
+        u8,
+        cairo_runner.vm.builtin_runners.items[0].name(),
+        "range_check_builtin",
+    ));
+    // Expect that the base address of the first built-in runner is 2.
+    try expectEqual(
+        @as(usize, 2),
+        cairo_runner.vm.builtin_runners.items[0].base(),
+    );
+
+    // Initialize the VM state using the initVM function.
+    try cairo_runner.initVM();
+
+    // Expect that the validated addresses in memory match the expected addresses.
+    try expect(cairo_runner.vm.segments.memory.validated_addresses.contains(Relocatable.init(2, 0)));
+    try expect(cairo_runner.vm.segments.memory.validated_addresses.contains(Relocatable.init(2, 1)));
+
+    // Expect that the total number of validated addresses is 2.
+    try expect(cairo_runner.vm.segments.memory.validated_addresses.len() == 2);
+}
+
+test "CairoRunner: initVM should return an error with invalid Range Check builtin" {
+    // Initialize a CairoRunner with an empty program, "plain" layout, and empty instructions.
+    var cairo_runner = try CairoRunner.init(
+        std.testing.allocator,
+        ProgramJson{},
+        "plain",
+        ArrayList(MaybeRelocatable).init(std.testing.allocator),
+        try CairoVM.init(
+            std.testing.allocator,
+            .{},
+        ),
+        false,
+    );
+    // Defer the deinitialization of the CairoRunner to ensure proper cleanup.
+    defer cairo_runner.deinit();
+
+    // Append a RangeCheckBuiltinRunner to the CairoRunner's list of built-in runners.
+    try cairo_runner.vm.builtin_runners.append(.{ .RangeCheck = RangeCheckBuiltinRunner{} });
+
+    // Set initial values for program_base, initial_pc, initial_ap, and initial_fp.
+    cairo_runner.initial_pc = Relocatable.init(0, 1);
+    cairo_runner.initial_ap = Relocatable.init(1, 2);
+    cairo_runner.initial_fp = Relocatable.init(1, 2);
+
+    // Initialize memory segments for the CairoRunner.
+    try cairo_runner.initSegments(null);
+
+    // Set up memory for the VM with specific addresses and values.
+    try cairo_runner.vm.segments.memory.setUpMemory(
+        std.testing.allocator,
+        .{
+            .{ .{ 2, 0 }, .{23} },
+        },
+    );
+    // Set an invalid value in memory for the Range Check builtin.
+    try cairo_runner.vm.segments.memory.set(
+        std.testing.allocator,
+        Relocatable.init(2, 4),
+        .{ .felt = Felt252.fromInt(u8, 1).neg() },
+    );
+    // Ensure data memory is deallocated after the test.
+    defer cairo_runner.vm.segments.memory.deinitData(std.testing.allocator);
+
+    // Expect an error of type RunnerError.MemoryValidationError when initializing the VM.
+    try expectError(RunnerError.MemoryValidationError, cairo_runner.initVM());
+}
 
 test "RunResources: consumed and consumeStep" {
     // given
@@ -419,7 +602,7 @@ test "RunResources: with unlimited steps" {
     var run_resources = RunResources{};
 
     // default case has null for n_steps
-    try std.testing.expectEqual(null,run_resources.n_steps);
+    try std.testing.expectEqual(null, run_resources.n_steps);
 
     var tracker = ResourceTracker.init(&run_resources);
 
@@ -540,7 +723,8 @@ test "CairoRunner: relocateMemory should relocated memory properly with gaps" {
         ),
         false,
     );
-    defer cairo_runner.deinit(); // Ensure CairoRunner resources are cleaned up.
+    // Ensure CairoRunner resources are cleaned up.
+    defer cairo_runner.deinit();
 
     // Create four memory segments in the VM.
     inline for (0..4) |_| {
@@ -587,5 +771,110 @@ test "CairoRunner: relocateMemory should relocated memory properly with gaps" {
             Felt252.fromInt(u8, 5),
         },
         cairo_runner.relocated_memory.items,
+    );
+}
+
+test "CairoRunner: initSegments should initialize the segments properly with base" {
+    // Initialize a CairoRunner with an empty program, "plain" layout, and instructions.
+    var cairo_runner = try CairoRunner.init(
+        std.testing.allocator,
+        ProgramJson{},
+        "plain",
+        ArrayList(MaybeRelocatable).init(std.testing.allocator),
+        try CairoVM.init(
+            std.testing.allocator,
+            .{},
+        ),
+        false,
+    );
+    // Defer the deinitialization of the CairoRunner to ensure cleanup.
+    defer cairo_runner.deinit();
+
+    // Append an OutputBuiltinRunner to the CairoRunner's list of built-in runners.
+    try cairo_runner.vm.builtin_runners.append(.{ .Output = OutputBuiltinRunner.initDefault(std.testing.allocator) });
+
+    // Add six additional segments to the CairoRunner's virtual machine.
+    inline for (0..6) |_| {
+        _ = try cairo_runner.vm.segments.addSegment();
+    }
+
+    // Initialize the segments for the CairoRunner with a provided base address (Relocatable).
+    try cairo_runner.initSegments(Relocatable.init(5, 9));
+
+    // Expect that the program base is initialized correctly.
+    try expectEqual(
+        Relocatable.init(5, 9),
+        cairo_runner.program_base,
+    );
+    // Expect that the execution base is initialized correctly.
+    try expectEqual(
+        Relocatable.init(6, 0),
+        cairo_runner.execution_base,
+    );
+    // Expect that the name of the first built-in runner is "output_builtin".
+    try expect(std.mem.eql(
+        u8,
+        cairo_runner.vm.builtin_runners.items[0].name(),
+        "output_builtin",
+    ));
+    // Expect that the base address of the first built-in runner is 7.
+    try expectEqual(
+        @as(usize, 7),
+        cairo_runner.vm.builtin_runners.items[0].base(),
+    );
+    // Expect that the total number of segments in the virtual machine is 8.
+    try expectEqual(
+        @as(usize, 8),
+        cairo_runner.vm.segments.numSegments(),
+    );
+}
+
+test "CairoRunner: initSegments should initialize the segments properly with no base" {
+    // Initialize a CairoRunner with an empty program, "plain" layout, and instructions.
+    var cairo_runner = try CairoRunner.init(
+        std.testing.allocator,
+        ProgramJson{},
+        "plain",
+        ArrayList(MaybeRelocatable).init(std.testing.allocator),
+        try CairoVM.init(
+            std.testing.allocator,
+            .{},
+        ),
+        false,
+    );
+    // Defer the deinitialization of the CairoRunner to ensure cleanup.
+    defer cairo_runner.deinit();
+
+    // Append an OutputBuiltinRunner to the CairoRunner's list of built-in runners.
+    try cairo_runner.vm.builtin_runners.append(.{ .Output = OutputBuiltinRunner.initDefault(std.testing.allocator) });
+
+    // Initialize the segments for the CairoRunner with no provided base address (null).
+    try cairo_runner.initSegments(null);
+
+    // Expect that the program base is initialized correctly to (0, 0).
+    try expectEqual(
+        Relocatable.init(0, 0),
+        cairo_runner.program_base,
+    );
+    // Expect that the execution base is initialized correctly to (1, 0).
+    try expectEqual(
+        Relocatable.init(1, 0),
+        cairo_runner.execution_base,
+    );
+    // Expect that the name of the first built-in runner is "output_builtin".
+    try expect(std.mem.eql(
+        u8,
+        cairo_runner.vm.builtin_runners.items[0].name(),
+        "output_builtin",
+    ));
+    // Expect that the base address of the first built-in runner is 2.
+    try expectEqual(
+        @as(usize, 2),
+        cairo_runner.vm.builtin_runners.items[0].base(),
+    );
+    // Expect that the total number of segments in the virtual machine is 3.
+    try expectEqual(
+        @as(usize, 3),
+        cairo_runner.vm.segments.numSegments(),
     );
 }


### PR DESCRIPTION
## Description
This pull request enhances the initialization methods (`init`) in the `CairoRunner` module by refining the logic and adding comprehensive unit tests for better coverage.

Related #248.

## Changes Made
- Updated the `init` methods in the `CairoRunner` module to improve clarity, maintainability, and consistency.
- Added a set of unit tests to thoroughly cover the initialization process and ensure correct behavior.
