### PR TITLE
implement HintProcessorData

### DIFF
--- a/src/hint_processor/hint_processor_def.zig
+++ b/src/hint_processor/hint_processor_def.zig
@@ -38,7 +38,6 @@ pub const HintProcessorData = struct {
         return .{
             .allocator = allocator,
             .code = code,
-            .ap_tracking = ApTracking{}, 
             .ids_data = ids_data,  
         };
     }
@@ -115,15 +114,14 @@ pub fn getIdsData(allocator: Allocator, reference_ids: StringHashMap(usize), ref
         const path  = ref_id_entry.key_ptr.*;
         const ref_id = ref_id_entry.value_ptr.*;
 
-        var name_iterator = std.mem.splitBackwards(u8, path, @as([]const u8, "."));
+        if (ref_id >= references.len) return CairoVMError.Unexpected;        
+
+        var name_iterator = std.mem.splitBackwardsSequence(u8, path, ".");
         
         const name = name_iterator.next() orelse return CairoVMError.Unexpected;
-
-        if (ref_id >= references.len) return CairoVMError.Unexpected;
         const ref_hint = references[ref_id];
 
         try ids_data.put(name, ref_hint);
-        
     }
 
     return ids_data;

--- a/src/vm/error.zig
+++ b/src/vm/error.zig
@@ -57,6 +57,8 @@ pub const CairoVMError = error{
     InvalidApUpdate,
     /// Invalid Opcode
     InvalidOpcode,
+    /// Unexpected Failure
+    Unexpected,
 };
 
 /// Represents different error conditions that are memory-related.

--- a/src/vm/types/programjson.zig
+++ b/src/vm/types/programjson.zig
@@ -63,17 +63,10 @@ pub const OffsetValue = union(enum) {
 pub const ApTracking = struct {
     const Self = @This();
     /// Indicates register state deducibility (increases by 1 after an unknown change).
-    group: usize,
+    group: usize = 0,
     /// Reflects Ap register changes within the same `group`.
-    offset: usize,
-
-    /// Initializes a new `ApTracking` instance.
-    ///
-    /// Returns:
-    ///     A new `ApTracking` instance with `group` and `offset` set to 0.
-    pub fn init() Self {
-        return .{ .group = 0, .offset = 0 };
-    }
+    offset: usize = 0,
+   
 };
 
 /// Represents tracking data for references considering various program flows.


### PR DESCRIPTION
## Description
This pull request adds the `HintProcessorData` type along with the `getIdsData` helper function that is used in the `compileHint` method of the HintProcessor interface

## Notable differences from porting from the rust impl

- We implement the type in the `hint_processor_def` as opposed to defining it within the `builtin_hint_processors_def` to avoid circular dependences.

