### PR TITLE
Add generic method calls for `BuiltinRunner`

### DIFF
--- a/src/vm/builtins/builtin_runner/bitwise.zig
+++ b/src/vm/builtins/builtin_runner/bitwise.zig
@@ -227,14 +227,8 @@ pub const BitwiseBuiltinRunner = struct {
     ///
     /// # Returns
     /// A tuple of `usize` and `?usize` addresses.
-    pub fn getMemorySegmentAddresses(self: *const Self) Tuple(&.{
-        usize,
-        ?usize,
-    }) {
-        return .{
-            self.base,
-            self.stop_ptr,
-        };
+    pub fn getMemorySegmentAddresses(self: *const Self) Tuple(&.{ usize, ?usize }) {
+        return .{ self.base, self.stop_ptr };
     }
 
     /// Calculates the number of used instances for the BitwiseBuiltinRunner.

--- a/src/vm/builtins/builtin_runner/builtin_runner.zig
+++ b/src/vm/builtins/builtin_runner/builtin_runner.zig
@@ -16,6 +16,8 @@ const SignatureBuiltinRunner = @import("./signature.zig").SignatureBuiltinRunner
 const Relocatable = @import("../../memory/relocatable.zig").Relocatable;
 const MaybeRelocatable = @import("../../memory/relocatable.zig").MaybeRelocatable;
 const Memory = @import("../../memory/memory.zig").Memory;
+const KeccakInstanceDef = @import("../../types/keccak_instance_def.zig").KeccakInstanceDef;
+
 const ArrayList = std.ArrayList;
 
 /// The name of the output builtin.
@@ -78,7 +80,42 @@ pub const BuiltinRunner = union(enum) {
     pub fn base(self: *const Self) usize {
         return switch (self.*) {
             .SegmentArena => |*segment_arena| @intCast(segment_arena.base.segment_index),
-            inline else => |*case| case.base,
+            inline else => |*builtin| builtin.base,
+        };
+    }
+
+    /// Retrieves the ratio associated with the built-in runner.
+    ///
+    /// For built-in runners other than SegmentArena and Output, this function returns the ratio
+    /// specific to the type of built-in runner.
+    ///
+    /// For SegmentArena and Output built-in runners, `null` is returned, as they do not have an associated ratio.
+    ///
+    /// # Returns
+    ///
+    /// If applicable, the ratio associated with the built-in runner as a `u32`. If the built-in runner
+    /// does not have an associated ratio, `null` is returned.
+    pub fn ratio(self: *const BuiltinRunner) ?u32 {
+        return switch (self.*) {
+            .SegmentArena, .Output => null,
+            inline else => |*builtin| builtin.ratio,
+        };
+    }
+
+    /// Retrieves the number of cells per instance associated with the built-in runner.
+    ///
+    /// This function returns the number of memory cells per instance managed by the specific
+    /// type of built-in runner. For built-in runners other than Output, it returns the value
+    /// specific to the type of built-in runner. For Output built-in runners, it returns 0
+    /// as Outputs do not have associated memory cells per instance.
+    ///
+    /// # Returns
+    ///
+    /// The number of cells per instance as a `u32`.
+    pub fn cellsPerInstance(self: *const BuiltinRunner) u32 {
+        return switch (self.*) {
+            .Output => 0,
+            inline else => |*builtin| builtin.cells_per_instance,
         };
     }
 
@@ -89,7 +126,7 @@ pub const BuiltinRunner = union(enum) {
     /// - `segments`: A pointer to the MemorySegmentManager managing memory segments.
     pub fn initSegments(self: *Self, segments: *MemorySegmentManager) !void {
         switch (self.*) {
-            inline else => |*case| try case.initSegments(segments),
+            inline else => |*builtin| try builtin.initSegments(segments),
         }
     }
 
@@ -100,7 +137,7 @@ pub const BuiltinRunner = union(enum) {
     ///  - `allocator`: The allocator to initialize the ArrayList.
     pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
         return switch (self.*) {
-            inline else => |*case| try case.initialStack(allocator),
+            inline else => |*builtin| try builtin.initialStack(allocator),
         };
     }
 
@@ -128,7 +165,7 @@ pub const BuiltinRunner = union(enum) {
             .Poseidon => |*poseidon| try poseidon.deduceMemoryCell(allocator, address, memory),
             .Bitwise => |bitwise| try bitwise.deduceMemoryCell(address, memory),
             .Hash => |*hash| try hash.deduceMemoryCell(address, memory),
-            inline else => |*case| case.deduceMemoryCell(address, memory),
+            inline else => |*builtin| builtin.deduceMemoryCell(address, memory),
         };
     }
 
@@ -147,7 +184,45 @@ pub const BuiltinRunner = union(enum) {
         // TODO: fill-in missing builtins when implemented
         return switch (self.*) {
             .Signature, .SegmentArena => .{ 0, 0 },
-            inline else => |*case| case.getMemorySegmentAddresses(),
+            inline else => |*builtin| builtin.getMemorySegmentAddresses(),
+        };
+    }
+
+    /// Retrieves the number of used memory cells associated with the built-in runner.
+    ///
+    /// This function calculates and returns the total number of used memory cells managed by
+    /// the specific type of built-in runner. It utilizes the provided `segments` to determine
+    /// the used cells based on the memory segments allocated.
+    ///
+    /// # Arguments
+    ///
+    /// - `segments`: A pointer to the `MemorySegmentManager` managing memory segments.
+    ///
+    /// # Returns
+    ///
+    /// The total number of used memory cells as a `usize`, or an error if calculation fails.
+    pub fn getUsedCells(self: *Self, segments: *MemorySegmentManager) !usize {
+        return switch (self.*) {
+            inline else => |*builtin| try builtin.getUsedCells(segments),
+        };
+    }
+
+    /// Retrieves the number of used instances associated with the built-in runner.
+    ///
+    /// This function calculates and returns the total number of used instances managed by
+    /// the specific type of built-in runner. It utilizes the provided `segments` to determine
+    /// the used instances based on the memory segments allocated.
+    ///
+    /// # Arguments
+    ///
+    /// - `segments`: A pointer to the `MemorySegmentManager` managing memory segments.
+    ///
+    /// # Returns
+    ///
+    /// The total number of used instances as a `usize`, or an error if calculation fails.
+    pub fn getUsedInstances(self: *Self, segments: *MemorySegmentManager) !usize {
+        return switch (self.*) {
+            inline else => |*builtin| try builtin.getUsedInstances(segments),
         };
     }
 
@@ -191,4 +266,140 @@ pub const BuiltinRunner = union(enum) {
             else => {},
         }
     }
+
+    pub fn deinit(self: *Self) void {
+        switch (self.*) {
+            .EcOp => |*ec_op| ec_op.deinit(),
+            .Hash => |*hash| hash.deinit(),
+            .Keccak => |*keccak| keccak.deinit(),
+            else => {},
+        }
+    }
 };
+
+const expectError = std.testing.expectError;
+const expectEqual = std.testing.expectEqual;
+const expect = std.testing.expect;
+
+test "BuiltinRunner: ratio method" {
+    // Initialize a BuiltinRunner for bitwise operations.
+    const bitwise_builtin: BuiltinRunner = .{ .Bitwise = .{} };
+    // Test the ratio method for bitwise_builtin.
+    // We expect the ratio to be 256.
+    try expectEqual(@as(?u32, 256), bitwise_builtin.ratio());
+
+    // Initialize a BuiltinRunner for EC operations.
+    var ec_op_builtin: BuiltinRunner = .{ .EcOp = EcOpBuiltinRunner.initDefault(std.testing.allocator) };
+    // Defer deinitialization of ec_op_builtin.
+    defer ec_op_builtin.deinit();
+    // Test the ratio method for ec_op_builtin.
+    // We expect the ratio to be 256.
+    try expectEqual(@as(?u32, 256), ec_op_builtin.ratio());
+
+    // Initialize a BuiltinRunner for hash operations.
+    var hash_builtin: BuiltinRunner = .{
+        .Hash = HashBuiltinRunner.init(
+            std.testing.allocator,
+            100,
+            true,
+        ),
+    };
+    // Defer deinitialization of hash_builtin.
+    defer hash_builtin.deinit();
+    // Test the ratio method for hash_builtin.
+    // We expect the ratio to be 100.
+    try expectEqual(@as(?u32, 100), hash_builtin.ratio());
+
+    // Initialize a BuiltinRunner for output operations.
+    var output_builtin: BuiltinRunner = .{
+        .Output = OutputBuiltinRunner.initDefault(std.testing.allocator),
+    };
+    defer output_builtin.deinit(); // Defer deinitialization of output_builtin.
+    // Test the ratio method for output_builtin.
+    // Since output operations do not have an associated ratio, we expect null.
+    try expectEqual(null, output_builtin.ratio());
+
+    // Initialize a BuiltinRunner for range check operations.
+    const rangecheck_builtin: BuiltinRunner = .{ .RangeCheck = .{} };
+    // Test the ratio method for rangecheck_builtin.
+    // We expect the ratio to be 8.
+    try expectEqual(@as(?u32, 8), rangecheck_builtin.ratio());
+
+    // Initialize a Keccak instance definition.
+    var keccak_instance_def = try KeccakInstanceDef.initDefault(std.testing.allocator);
+    // Initialize a BuiltinRunner for Keccak operations.
+    var keccak_builtin: BuiltinRunner = .{
+        .Keccak = KeccakBuiltinRunner.init(
+            std.testing.allocator,
+            &keccak_instance_def,
+            true,
+        ),
+    };
+    // Defer deinitialization of keccak_builtin.
+    defer keccak_builtin.deinit();
+    // Test the ratio method for keccak_builtin.
+    // We expect the ratio to be 2048.
+    try expectEqual(@as(?u32, 2048), keccak_builtin.ratio());
+}
+
+test "BuiltinRunner: cellsPerInstance method" {
+    // Initialize a BuiltinRunner for bitwise operations.
+    const bitwise_builtin: BuiltinRunner = .{ .Bitwise = .{} };
+    // Test the cellsPerInstance method for bitwise_builtin.
+    // We expect the number of cells per instance to be 256.
+    try expectEqual(@as(u32, 5), bitwise_builtin.cellsPerInstance());
+
+    // Initialize a BuiltinRunner for EC operations.
+    var ec_op_builtin: BuiltinRunner = .{ .EcOp = EcOpBuiltinRunner.initDefault(std.testing.allocator) };
+    // Defer deinitialization of ec_op_builtin.
+    defer ec_op_builtin.deinit();
+    // Test the cellsPerInstance method for ec_op_builtin.
+    // We expect the number of cells per instance to be 256.
+    try expectEqual(@as(u32, 7), ec_op_builtin.cellsPerInstance());
+
+    // Initialize a BuiltinRunner for hash operations.
+    var hash_builtin: BuiltinRunner = .{
+        .Hash = HashBuiltinRunner.init(
+            std.testing.allocator,
+            100,
+            true,
+        ),
+    };
+    // Defer deinitialization of hash_builtin.
+    defer hash_builtin.deinit();
+    // Test the cellsPerInstance method for hash_builtin.
+    // We expect the number of cells per instance to be 100.
+    try expectEqual(@as(?u32, 3), hash_builtin.cellsPerInstance());
+
+    // Initialize a BuiltinRunner for output operations.
+    var output_builtin: BuiltinRunner = .{
+        .Output = OutputBuiltinRunner.initDefault(std.testing.allocator),
+    };
+    // Defer deinitialization of output_builtin.
+    defer output_builtin.deinit();
+    // Test the cellsPerInstance method for output_builtin.
+    // Since output operations do not have associated cells per instance, we expect 0.
+    try expectEqual(@as(u32, 0), output_builtin.cellsPerInstance());
+
+    // Initialize a BuiltinRunner for range check operations.
+    const rangecheck_builtin: BuiltinRunner = .{ .RangeCheck = .{} };
+    // Test the cellsPerInstance method for rangecheck_builtin.
+    // We expect the number of cells per instance to be 8.
+    try expectEqual(@as(u32, 1), rangecheck_builtin.cellsPerInstance());
+
+    // Initialize a Keccak instance definition.
+    var keccak_instance_def = try KeccakInstanceDef.initDefault(std.testing.allocator);
+    // Initialize a BuiltinRunner for Keccak operations.
+    var keccak_builtin: BuiltinRunner = .{
+        .Keccak = KeccakBuiltinRunner.init(
+            std.testing.allocator,
+            &keccak_instance_def,
+            true,
+        ),
+    };
+    // Defer deinitialization of keccak_builtin.
+    defer keccak_builtin.deinit();
+    // Test the cellsPerInstance method for keccak_builtin.
+    // We expect the number of cells per instance to be 2048.
+    try expectEqual(@as(u32, 16), keccak_builtin.cellsPerInstance());
+}

--- a/src/vm/builtins/builtin_runner/ec_op.zig
+++ b/src/vm/builtins/builtin_runner/ec_op.zig
@@ -111,6 +111,7 @@ pub const EcOpBuiltinRunner = struct {
     /// An `ArrayList` of `MaybeRelocatable` values.
     pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
         var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();
         if (self.included) {
             try result.append(MaybeRelocatable.fromSegment(
                 @intCast(self.base),
@@ -198,7 +199,9 @@ pub const EcOpBuiltinRunner = struct {
     /// The number of used cells as a `u32`, or `MemoryError.MissingSegmentUsedSizes` if
     /// the size is not available.
     pub fn getUsedCells(self: *Self, segments: *MemorySegmentManager) !u32 {
-        return segments.getSegmentUsedSize(@intCast(self.base)) orelse MemoryError.MissingSegmentUsedSizes;
+        return segments.getSegmentUsedSize(
+            @intCast(self.base),
+        ) orelse MemoryError.MissingSegmentUsedSizes;
     }
 
     /// Calculates the number of used instances for the EC OP runner.

--- a/src/vm/builtins/builtin_runner/hash.zig
+++ b/src/vm/builtins/builtin_runner/hash.zig
@@ -81,11 +81,7 @@ pub const HashBuiltinRunner = struct {
     /// - `self`: Updates the `base` value to the new segment's index.
     pub fn initSegments(self: *Self, segments: *MemorySegmentManager) !void {
         // `segments.addSegment()` always returns a positive index
-        const seg = try segments.addSegment();
-        self.base = @as(
-            usize,
-            @intCast(seg.segment_index),
-        );
+        self.base = @intCast((try segments.addSegment()).segment_index);
     }
 
     /// Initializes and returns an `ArrayList` of `MaybeRelocatable` values.
@@ -100,6 +96,7 @@ pub const HashBuiltinRunner = struct {
     /// An `ArrayList` of `MaybeRelocatable` values.
     pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
         var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();
         if (self.included) {
             try result.append(.{
                 .relocatable = Relocatable.init(
@@ -135,10 +132,7 @@ pub const HashBuiltinRunner = struct {
     /// # Returns
     /// A tuple of `usize` and `?usize` addresses.
     pub fn getMemorySegmentAddresses(self: *Self) std.meta.Tuple(&.{ usize, ?usize }) {
-        return .{
-            self.base,
-            self.stop_ptr,
-        };
+        return .{ self.base, self.stop_ptr };
     }
 
     /// Calculates the number of used instances for the Hash runner.
@@ -261,6 +255,11 @@ pub const HashBuiltinRunner = struct {
         try self.verified_addresses.insert(address.offset, true);
 
         return (MaybeRelocatable.fromFelt(pedersen_result));
+    }
+
+    /// Frees the resources owned by this instance of `HashBuiltinRunner`.
+    pub fn deinit(self: *Self) void {
+        self.verified_addresses.deinit();
     }
 };
 

--- a/src/vm/builtins/builtin_runner/keccak.zig
+++ b/src/vm/builtins/builtin_runner/keccak.zig
@@ -111,6 +111,7 @@ pub const KeccakBuiltinRunner = struct {
     /// An `ArrayList` of `MaybeRelocatable` values.
     pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
         var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();
         if (self.included) {
             try result.append(MaybeRelocatable.fromSegment(
                 @intCast(self.base),
@@ -143,14 +144,8 @@ pub const KeccakBuiltinRunner = struct {
     ///
     /// # Returns
     /// A tuple of `usize` and `?usize` addresses.
-    pub fn getMemorySegmentAddresses(self: *const Self) std.meta.Tuple(&.{
-        usize,
-        ?usize,
-    }) {
-        return .{
-            self.base,
-            self.stop_ptr,
-        };
+    pub fn getMemorySegmentAddresses(self: *const Self) std.meta.Tuple(&.{ usize, ?usize }) {
+        return .{ self.base, self.stop_ptr };
     }
 
     /// Calculates the number of used instances for the Keccak runner.

--- a/src/vm/builtins/builtin_runner/output.zig
+++ b/src/vm/builtins/builtin_runner/output.zig
@@ -131,7 +131,6 @@ pub const OutputBuiltinRunner = struct {
                 @intCast(self.base),
                 0,
             ));
-            return result;
         }
         return result;
     }

--- a/src/vm/builtins/builtin_runner/poseidon.zig
+++ b/src/vm/builtins/builtin_runner/poseidon.zig
@@ -79,26 +79,19 @@ pub const PoseidonBuiltinRunner = struct {
         self.base = @intCast((try segments.addSegment()).segment_index);
     }
 
-    pub fn getMemorySegmentAddresses(self: *const Self) std.meta.Tuple(&.{
-        usize,
-        ?usize,
-    }) {
-        return .{
-            self.base,
-            self.stop_ptr,
-        };
+    pub fn getMemorySegmentAddresses(self: *const Self) std.meta.Tuple(&.{ usize, ?usize }) {
+        return .{ self.base, self.stop_ptr };
     }
 
     pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
         var result = ArrayList(MaybeRelocatable).init(allocator);
-
+        errdefer result.deinit();
         if (self.included) {
             try result.append(MaybeRelocatable.fromSegment(
                 @intCast(self.base),
                 0,
             ));
         }
-
         return result;
     }
 

--- a/src/vm/builtins/builtin_runner/range_check.zig
+++ b/src/vm/builtins/builtin_runner/range_check.zig
@@ -83,8 +83,7 @@ pub const RangeCheckBuiltinRunner = struct {
     /// # Modifies
     /// - `self`: Updates the `base` value to the new segment's index.
     pub fn initSegments(self: *Self, segments: *MemorySegmentManager) !void {
-        const seg = try segments.addSegment();
-        self.base = @intCast(seg.segment_index);
+        self.base = @intCast((try segments.addSegment()).segment_index);
     }
 
     /// Initializes and returns an `ArrayList` of `MaybeRelocatable` values.
@@ -99,6 +98,7 @@ pub const RangeCheckBuiltinRunner = struct {
     /// An `ArrayList` of `MaybeRelocatable` values.
     pub fn initialStack(self: *Self, allocator: Allocator) !ArrayList(MaybeRelocatable) {
         var result = ArrayList(MaybeRelocatable).init(allocator);
+        errdefer result.deinit();
         if (self.included) {
             try result.append(.{
                 .relocatable = Relocatable.init(
@@ -152,14 +152,8 @@ pub const RangeCheckBuiltinRunner = struct {
     ///
     /// # Returns
     /// A tuple of `usize` and `?usize` addresses.
-    pub fn getMemorySegmentAddresses(self: *const Self) std.meta.Tuple(&.{
-        usize,
-        ?usize,
-    }) {
-        return .{
-            self.base,
-            self.stop_ptr,
-        };
+    pub fn getMemorySegmentAddresses(self: *const Self) std.meta.Tuple(&.{ usize, ?usize }) {
+        return .{ self.base, self.stop_ptr };
     }
 
     /// Calculate the final stack.


### PR DESCRIPTION
- `getUsedCells`: should close #344
- `ratio`: should close #345
- `getUsedInstances`: should close #346
- `cellsPerInstance`: should close #347
- Normalize function definitions: should close #351 