### PR TITLE
Fix `stepInstruction` method in core with unit tests

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -3,6 +3,7 @@ const ProgramJson = @import("vm/types/programjson.zig").ProgramJson;
 const Program = @import("vm/types/program.zig").Program;
 const CairoVM = @import("vm/core.zig").CairoVM;
 const CairoRunner = @import("vm/runners/cairo_runner.zig").CairoRunner;
+const HintProcessor = @import("./hint_processor/hint_processor_def.zig").CairoVMHintProcessor;
 
 pub fn main() void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -97,6 +98,7 @@ pub fn cairo_run(allocator: std.mem.Allocator, pathname: []const u8, layout: []c
     errdefer std.debug.print("failed on step: {}\n", .{runner.vm.current_step});
 
     // then
-    try runner.runUntilPC(end, extensive_hints);
+    var hint_processor: HintProcessor = .{};
+    try runner.runUntilPC(end, extensive_hints, &hint_processor);
     try runner.endRun();
 }

--- a/src/vm/cairo_run.zig
+++ b/src/vm/cairo_run.zig
@@ -8,6 +8,7 @@ const Config = @import("./config.zig").Config;
 const Felt252 = @import("../math/fields/starknet.zig").Felt252;
 const Program = @import("./types/program.zig").Program;
 const ProgramJson = @import("./types/programjson.zig").ProgramJson;
+const HintProcessor = @import("../hint_processor/hint_processor_def.zig").CairoVMHintProcessor;
 
 const trace_context = @import("./trace_context.zig");
 const RelocatedTraceEntry = trace_context.TraceContext.RelocatedTraceEntry;
@@ -71,7 +72,8 @@ pub fn runConfig(allocator: Allocator, config: Config) !void {
     defer runner.deinit(allocator);
     const end = try runner.setupExecutionState(config.allow_missing_builtins orelse config.proof_mode);
     // TODO: make flag for extensive_hints
-    try runner.runUntilPC(end, false);
+    var hint_processor: HintProcessor = .{};
+    try runner.runUntilPC(end, false, &hint_processor);
     try runner.endRun();
     // TODO readReturnValues necessary for builtins
 

--- a/src/vm/core.zig
+++ b/src/vm/core.zig
@@ -58,6 +58,7 @@ pub const CairoVM = struct {
     current_step: usize = 0,
     /// Rc limits
     rc_limits: ?struct { isize, isize } = null,
+    skip_instruction_execution: bool = false,
     /// Relocation table
     relocation_table: ?std.ArrayList(usize) = null,
     /// ArrayList containing instructions. May hold null elements.
@@ -301,58 +302,108 @@ pub const CairoVM = struct {
         }
     }
 
+    /// Executes the next instruction in the Cairo VM.
+    ///
+    /// This function retrieves the next instruction based on the program counter (PC) in the run context.
+    /// It checks whether the instruction cache contains the instruction corresponding to the PC.
+    /// If not, it decodes the current instruction and adds it to the cache.
+    /// Then, it executes the instruction using the `runInstruction` function.
+    /// If `skip_instruction_execution` is set to true, it advances the program counter accordingly.
+    ///
+    /// # Parameters
+    /// - `self`: A pointer to the Cairo VM instance.
+    /// - `allocator`: The allocator used for memory operations.
+    /// # Errors
+    /// - If accessing an unknown memory cell occurs.
     pub fn stepInstruction(self: *Self, allocator: Allocator) !void {
-        std.log.debug(
-            "Running instruction at pc: {}\n",
-            .{self.run_context.pc.*},
-        );
-        std.log.debug(
-            "Running instruction, ap: {}\n",
-            .{self.run_context.ap.*},
-        );
-        std.log.debug(
-            "Running instruction, fp: {}\n",
-            .{self.run_context.fp.*},
-        );
-        // ************************************************************
-        // *                    FETCH                                 *
-        // ************************************************************
+        if (self.run_context.pc.segment_index == 0) {
+            // Run instructions from the program segment, using the instruction cache.
+            const pc = self.run_context.pc.offset;
 
-        const encoded_instruction = self.segments.memory.get(self.run_context.pc.*);
+            // Ensure PC is within the bounds of the memory segment.
+            if (self.segments.memory.data.items[0].items.len <= pc)
+                return MemoryError.UnknownMemoryCell;
 
-        // ************************************************************
-        // *                    DECODE                                *
-        // ************************************************************
+            // Copy the instruction cache.
+            var inst_cache = try self.instruction_cache.clone();
+            defer inst_cache.deinit();
 
-        // First, we convert the encoded instruction to a u64.
-        // If the MaybeRelocatable is not a felt, this operation will fail.
-        // If the MaybeRelocatable is a felt but the value does not fit into a u64, this operation will fail.
-        const encoded_instruction_u64 = encoded_instruction.?.intoU64() catch {
-            return CairoVMError.InstructionEncodingError;
-        };
+            // Clear the old instruction cache.
+            self.instruction_cache.clearAndFree();
 
-        // Then, we decode the instruction.
-        const instruction = try decoder.decodeInstructions(encoded_instruction_u64);
+            // Resize the instruction cache if necessary.
+            const new_cache_len = @max(pc + 1, inst_cache.items.len);
+            if (inst_cache.items.len < new_cache_len) {
+                for (0..new_cache_len - inst_cache.items.len) |_| try inst_cache.append(null);
+            }
 
-        // ************************************************************
-        // *                    EXECUTE                               *
-        // ************************************************************
-        return self.runInstruction(allocator, &instruction);
+            // Get the instruction related to the PC.
+            const instruction = &inst_cache.items[pc];
+
+            // If the instruction does not exist in the cache, decode the current instruction.
+            if (instruction.* == null) instruction.* = try self.decodeCurrentInstruction();
+
+            // Execute the instruction if skip_instruction_execution is false.
+            if (!self.skip_instruction_execution) {
+                try self.runInstruction(allocator, &instruction.*.?);
+            } else {
+                // Advance the program counter if skip_instruction_execution is true.
+                self.run_context.pc.* = try self.run_context.pc.addUint(instruction.*.?.size());
+                self.skip_instruction_execution = false;
+            }
+            try self.instruction_cache.appendSlice(inst_cache.items);
+        } else {
+            // Decode and execute the current instruction if the program counter is not in the program segment.
+            const instruction = try self.decodeCurrentInstruction();
+
+            if (!self.skip_instruction_execution) {
+                try self.runInstruction(allocator, &instruction);
+            } else {
+                self.run_context.pc.* = try self.run_context.pc.addUint(instruction.size());
+                self.skip_instruction_execution = false;
+            }
+        }
     }
 
     /// Do a single step of the VM with not extensive hints.
     /// Process an instruction cycle using the typical fetch-decode-execute cycle.
-    pub fn stepNotExtensive(self: *Self, allocator: Allocator, hint_processor: HintProcessor, exec_scopes: *ExecutionScopes, hint_datas: []HintData, constants: *std.StringHashMap(Felt252)) !void {
-        try self.stepHintNotExtensive(allocator, hint_processor, exec_scopes, hint_datas, constants);
-
+    pub fn stepNotExtensive(
+        self: *Self,
+        allocator: Allocator,
+        hint_processor: HintProcessor,
+        exec_scopes: *ExecutionScopes,
+        hint_datas: []HintData,
+        constants: *std.StringHashMap(Felt252),
+    ) !void {
+        try self.stepHintNotExtensive(
+            allocator,
+            hint_processor,
+            exec_scopes,
+            hint_datas,
+            constants,
+        );
         try self.stepInstruction(allocator);
     }
 
     /// Do a single step of the VM with extensive hints.
     /// Process an instruction cycle using the typical fetch-decode-execute cycle.
-    pub fn stepExtensive(self: *Self, allocator: Allocator, hint_processor: HintProcessor, exec_scopes: *ExecutionScopes, hint_datas: *std.ArrayList(HintData), hint_ranges: *std.AutoHashMap(Relocatable, HintRange), constants: *std.StringHashMap(Felt252)) !void {
-        try self.stepHintExtensive(allocator, hint_processor, exec_scopes, hint_datas, hint_ranges, constants);
-
+    pub fn stepExtensive(
+        self: *Self,
+        allocator: Allocator,
+        hint_processor: HintProcessor,
+        exec_scopes: *ExecutionScopes,
+        hint_datas: *std.ArrayList(HintData),
+        hint_ranges: *std.AutoHashMap(Relocatable, HintRange),
+        constants: *std.StringHashMap(Felt252),
+    ) !void {
+        try self.stepHintExtensive(
+            allocator,
+            hint_processor,
+            exec_scopes,
+            hint_datas,
+            hint_ranges,
+            constants,
+        );
         try self.stepInstruction(allocator);
     }
 
@@ -1529,24 +1580,12 @@ test "Core: test step for preset memory alloc hint not extensive" {
     }
 
     const expected_trace = [_][3][2]u64{
-        .{
-            .{ 0, 3 }, .{ 1, 2 }, .{ 1, 2 },
-        },
-        .{
-            .{ 0, 0 }, .{ 1, 4 }, .{ 1, 4 },
-        },
-        .{
-            .{ 0, 2 }, .{ 1, 5 }, .{ 1, 4 },
-        },
-        .{
-            .{ 0, 5 }, .{ 1, 5 }, .{ 1, 2 },
-        },
-        .{
-            .{ 0, 7 }, .{ 1, 6 }, .{ 1, 2 },
-        },
-        .{
-            .{ 0, 8 }, .{ 1, 6 }, .{ 1, 2 },
-        },
+        .{ .{ 0, 3 }, .{ 1, 2 }, .{ 1, 2 } },
+        .{ .{ 0, 0 }, .{ 1, 4 }, .{ 1, 4 } },
+        .{ .{ 0, 2 }, .{ 1, 5 }, .{ 1, 4 } },
+        .{ .{ 0, 5 }, .{ 1, 5 }, .{ 1, 2 } },
+        .{ .{ 0, 7 }, .{ 1, 6 }, .{ 1, 2 } },
+        .{ .{ 0, 8 }, .{ 1, 6 }, .{ 1, 2 } },
     };
 
     try std.testing.expectEqual(expected_trace.len, vm.trace_context.state.enabled.entries.items.len);

--- a/src/vm/core_test.zig
+++ b/src/vm/core_test.zig
@@ -34,6 +34,10 @@ const CairoVM = @import("core.zig").CairoVM;
 const computeRes = @import("core.zig").computeRes;
 const OperandsResult = @import("core.zig").OperandsResult;
 const deduceOp1 = @import("core.zig").deduceOp1;
+const HintData = @import("../hint_processor/hint_processor_def.zig").HintData;
+const HintRange = @import("./types/program.zig").HintRange;
+const ExecutionScopes = @import("./types/execution_scopes.zig").ExecutionScopes;
+const HintProcessor = @import("../hint_processor/hint_processor_def.zig").CairoVMHintProcessor;
 
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
@@ -979,16 +983,100 @@ test "CairoVM: relocateTrace and trace comparison (simple use case)" {
     defer allocator.free(relocation_table);
     try vm.relocateTrace(relocation_table);
 
-    const relocated_trace = TraceContext.RelocatedTraceEntry{
-        .pc = Felt252.fromInt(u8, 1),
-        .ap = Felt252.fromInt(u8, 4),
-        .fp = Felt252.fromInt(u8, 4),
-    };
-    const expected_relocated_trace = [_]TraceContext.RelocatedTraceEntry{relocated_trace};
-    const actual_relocated_trace = try vm.getRelocatedTrace();
-    for (expected_relocated_trace, actual_relocated_trace) |expected_trace, actual_trace| {
-        try expectEqual(expected_trace, actual_trace);
-    }
+    try expectEqualSlices(
+        TraceContext.RelocatedTraceEntry,
+        &[_]TraceContext.RelocatedTraceEntry{
+            .{
+                .pc = Felt252.fromInt(u8, 1),
+                .ap = Felt252.fromInt(u8, 4),
+                .fp = Felt252.fromInt(u8, 4),
+            },
+        },
+        try vm.getRelocatedTrace(),
+    );
+}
+
+test "CairoVM: test step for preset memory" {
+    // Test for a simple program execution
+    // Used program code:
+    // func main():
+    //     let a = 1
+    //     let b = 2
+    //     let c = a + b
+    //     return()
+    // end
+    // Memory taken from original vm
+    // {RelocatableValue(segment_index=0, offset=0): 2345108766317314046,
+    //  RelocatableValue(segment_index=1, offset=0): RelocatableValue(segment_index=2, offset=0),
+    //  RelocatableValue(segment_index=1, offset=1): RelocatableValue(segment_index=3, offset=0)}
+    // Current register values:
+    // AP 1:2
+    // FP 1:2
+    // PC 0:0
+
+    // Test setup
+    const allocator = std.testing.allocator;
+
+    // Create a new VM instance.
+    var vm = try CairoVM.init(
+        allocator,
+        .{ .proof_mode = false, .enable_trace = true },
+    );
+    defer vm.deinit();
+
+    vm.run_context.ap.* = Relocatable.init(1, 2);
+    vm.run_context.fp.* = Relocatable.init(1, 2);
+
+    try vm.segments.memory.setUpMemory(
+        std.testing.allocator,
+        .{
+            .{ .{ 0, 0 }, .{2345108766317314046} },
+            .{ .{ 1, 0 }, .{ 2, 0 } },
+            .{ .{ 1, 1 }, .{ 3, 0 } },
+        },
+    );
+    defer vm.segments.memory.deinitData(std.testing.allocator);
+
+    var exec_scopes = try ExecutionScopes.init(allocator);
+    defer exec_scopes.deinit();
+
+    var hint_datas = std.ArrayList(HintData).init(std.testing.allocator);
+    defer hint_datas.deinit();
+
+    var hint_ranges = std.AutoHashMap(Relocatable, HintRange).init(std.testing.allocator);
+    defer hint_ranges.deinit();
+
+    var constants = std.StringHashMap(Felt252).init(std.testing.allocator);
+    defer constants.deinit();
+
+    try vm.stepExtensive(
+        std.testing.allocator,
+        .{},
+        &exec_scopes,
+        &hint_datas,
+        &hint_ranges,
+        &constants,
+    );
+
+    try expectEqual(Relocatable.init(3, 0), vm.run_context.pc.*);
+    try expectEqual(Relocatable.init(1, 2), vm.run_context.ap.*);
+    try expectEqual(Relocatable.init(1, 0), vm.run_context.fp.*);
+
+    try expectEqualSlices(
+        TraceContext.Entry,
+        &[_]TraceContext.Entry{
+            .{
+                .pc = Relocatable.init(0, 0),
+                .ap = Relocatable.init(1, 2),
+                .fp = Relocatable.init(1, 2),
+            },
+        },
+        vm.trace_context.state.enabled.entries.items,
+    );
+
+    // Check that the following addresses have been accessed
+    try expect(vm.segments.memory.data.items[1].items[0].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[1].?.is_accessed);
 }
 
 test "CairoVM: relocateTrace and trace comparison (more complex use case)" {
@@ -1943,8 +2031,6 @@ test "CairoVM: compute operands JNZ" {
     var vm = try CairoVM.init(allocator, .{});
     defer vm.deinit();
 
-    vm.run_context.ap.* = Relocatable.init(1, 0);
-
     // Test body
     try vm.segments.memory.setUpMemory(
         std.testing.allocator,
@@ -1985,10 +2071,30 @@ test "CairoVM: compute operands JNZ" {
     );
 
     // Test checks
-    try expectEqual(
-        expected_operands,
-        actual_operands,
+    try expectEqual(expected_operands, actual_operands);
+
+    var exec_scopes = try ExecutionScopes.init(allocator);
+    defer exec_scopes.deinit();
+
+    var hint_datas = std.ArrayList(HintData).init(std.testing.allocator);
+    defer hint_datas.deinit();
+
+    var hint_ranges = std.AutoHashMap(Relocatable, HintRange).init(std.testing.allocator);
+    defer hint_ranges.deinit();
+
+    var constants = std.StringHashMap(Felt252).init(std.testing.allocator);
+    defer constants.deinit();
+
+    try vm.stepExtensive(
+        std.testing.allocator,
+        .{},
+        &exec_scopes,
+        &hint_datas,
+        &hint_ranges,
+        &constants,
     );
+
+    try expectEqual(Relocatable.init(0, 4), vm.run_context.*.pc.*);
 }
 
 test "CairoVM: compute operands deduce dst none" {
@@ -4193,4 +4299,500 @@ test "CairoVM: runInstruction with Op0 being deduced" {
             try expect(cell.?.eql(expected_memory.data.items[i].items[j].?));
         }
     }
+}
+
+test "CairoVM: test step for preset memory 1" {
+    //Test for a simple program execution
+    //Used program code:
+    //    func myfunc(a: felt) -> (r: felt):
+    //        let b = a * 2
+    //        return(b)
+    //    end
+    //    func main():
+    //        let a = 1
+    //        let b = myfunc(a)
+    //        return()
+    //    end
+    //Memory taken from original vm:
+    //{RelocatableValue(segment_index=0, offset=0): 5207990763031199744,
+    //RelocatableValue(segment_index=0, offset=1): 2,
+    //RelocatableValue(segment_index=0, offset=2): 2345108766317314046,
+    //RelocatableValue(segment_index=0, offset=3): 5189976364521848832,
+    //RelocatableValue(segment_index=0, offset=4): 1,
+    //RelocatableValue(segment_index=0, offset=5): 1226245742482522112,
+    //RelocatableValue(segment_index=0, offset=6): 3618502788666131213697322783095070105623107215331596699973092056135872020476,
+    //RelocatableValue(segment_index=0, offset=7): 2345108766317314046,
+    //RelocatableValue(segment_index=1, offset=0): RelocatableValue(segment_index=2, offset=0),
+    //RelocatableValue(segment_index=1, offset=1): RelocatableValue(segment_index=3, offset=0)}
+    //Current register values:
+    //AP 1:2
+    //FP 1:2
+    //PC 0:3
+    //Final Pc (not executed): 3:0
+    //This program consists of 5 steps
+
+    // Test setup
+    const allocator = std.testing.allocator;
+
+    // Create a new VM instance.
+    var vm = try CairoVM.init(
+        allocator,
+        .{ .proof_mode = false, .enable_trace = true },
+    );
+    defer vm.deinit();
+
+    vm.run_context.pc.* = Relocatable.init(0, 3);
+    vm.run_context.ap.* = Relocatable.init(1, 2);
+    vm.run_context.fp.* = Relocatable.init(1, 2);
+
+    try vm.segments.memory.setUpMemory(
+        std.testing.allocator,
+        .{
+            .{ .{ 0, 0 }, .{5207990763031199744} },
+            .{ .{ 0, 1 }, .{2} },
+            .{ .{ 0, 2 }, .{2345108766317314046} },
+            .{ .{ 0, 3 }, .{5189976364521848832} },
+            .{ .{ 0, 4 }, .{1} },
+            .{ .{ 0, 5 }, .{1226245742482522112} },
+            .{ .{ 0, 6 }, .{3618502788666131213697322783095070105623107215331596699973092056135872020476} },
+            .{ .{ 0, 7 }, .{2345108766317314046} },
+            .{ .{ 1, 0 }, .{ 2, 0 } },
+            .{ .{ 1, 1 }, .{ 3, 0 } },
+        },
+    );
+    defer vm.segments.memory.deinitData(std.testing.allocator);
+
+    const final_pc = Relocatable.init(3, 0);
+
+    while (!vm.run_context.pc.eq(final_pc)) {
+        var exec_scopes = try ExecutionScopes.init(allocator);
+        defer exec_scopes.deinit();
+
+        var hint_datas = std.ArrayList(HintData).init(std.testing.allocator);
+        defer hint_datas.deinit();
+
+        var hint_ranges = std.AutoHashMap(Relocatable, HintRange).init(std.testing.allocator);
+        defer hint_ranges.deinit();
+
+        var constants = std.StringHashMap(Felt252).init(std.testing.allocator);
+        defer constants.deinit();
+
+        try vm.stepExtensive(
+            std.testing.allocator,
+            .{},
+            &exec_scopes,
+            &hint_datas,
+            &hint_ranges,
+            &constants,
+        );
+    }
+
+    try expectEqual(Relocatable.init(3, 0), vm.run_context.pc.*);
+    try expectEqual(Relocatable.init(1, 6), vm.run_context.ap.*);
+    try expectEqual(Relocatable.init(1, 0), vm.run_context.fp.*);
+
+    try expectEqualSlices(
+        TraceContext.Entry,
+        &[_]TraceContext.Entry{
+            .{
+                .pc = Relocatable.init(0, 3),
+                .ap = Relocatable.init(1, 2),
+                .fp = Relocatable.init(1, 2),
+            },
+            .{
+                .pc = Relocatable.init(0, 5),
+                .ap = Relocatable.init(1, 3),
+                .fp = Relocatable.init(1, 2),
+            },
+            .{
+                .pc = Relocatable.init(0, 0),
+                .ap = Relocatable.init(1, 5),
+                .fp = Relocatable.init(1, 5),
+            },
+            .{
+                .pc = Relocatable.init(0, 2),
+                .ap = Relocatable.init(1, 6),
+                .fp = Relocatable.init(1, 5),
+            },
+            .{
+                .pc = Relocatable.init(0, 7),
+                .ap = Relocatable.init(1, 6),
+                .fp = Relocatable.init(1, 2),
+            },
+        },
+        vm.trace_context.state.enabled.entries.items,
+    );
+
+    // Check that the following addresses have been accessed
+    try expect(vm.segments.memory.data.items[0].items[1].?.is_accessed);
+    try expect(vm.segments.memory.data.items[0].items[4].?.is_accessed);
+    try expect(vm.segments.memory.data.items[0].items[6].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[0].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[2].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[3].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[4].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[5].?.is_accessed);
+
+    try expectEqual(
+        @as(usize, 3),
+        vm.segments.memory.countAccessedAddressesInSegment(0),
+    );
+    try expectEqual(
+        @as(usize, 6),
+        vm.segments.memory.countAccessedAddressesInSegment(1),
+    );
+}
+
+test "CairoVM: test step for preset memory program loaded into user segment" {
+    // Test for a simple program execution
+    // Used program code:
+    // func main():
+    //     let a = 1
+    //     let b = 2
+    //     let c = a + b
+    //     return()
+    // end
+    // Memory taken from original vm
+    // {RelocatableValue(segment_index=0, offset=0): 2345108766317314046,
+    //  RelocatableValue(segment_index=1, offset=0): RelocatableValue(segment_index=2, offset=0),
+    //  RelocatableValue(segment_index=1, offset=1): RelocatableValue(segment_index=3, offset=0)}
+    // Current register values:
+    // AP 1:2
+    // FP 1:2
+    // PC 0:0
+
+    // Test setup
+    const allocator = std.testing.allocator;
+
+    // Create a new VM instance.
+    var vm = try CairoVM.init(
+        allocator,
+        .{ .proof_mode = false, .enable_trace = true },
+    );
+    defer vm.deinit();
+
+    vm.run_context.ap.* = Relocatable.init(1, 2);
+    vm.run_context.fp.* = Relocatable.init(1, 2);
+
+    try vm.segments.memory.setUpMemory(
+        std.testing.allocator,
+        .{
+            .{ .{ 2, 0 }, .{2345108766317314046} },
+            .{ .{ 1, 0 }, .{ 2, 0 } },
+            .{ .{ 1, 1 }, .{ 3, 0 } },
+        },
+    );
+    defer vm.segments.memory.deinitData(std.testing.allocator);
+
+    vm.run_context.pc.segment_index = 2;
+
+    var exec_scopes = try ExecutionScopes.init(allocator);
+    defer exec_scopes.deinit();
+
+    var hint_datas = std.ArrayList(HintData).init(std.testing.allocator);
+    defer hint_datas.deinit();
+
+    var hint_ranges = std.AutoHashMap(Relocatable, HintRange).init(std.testing.allocator);
+    defer hint_ranges.deinit();
+
+    var constants = std.StringHashMap(Felt252).init(std.testing.allocator);
+    defer constants.deinit();
+
+    try vm.stepExtensive(
+        std.testing.allocator,
+        .{},
+        &exec_scopes,
+        &hint_datas,
+        &hint_ranges,
+        &constants,
+    );
+
+    try expectEqual(Relocatable.init(3, 0), vm.run_context.pc.*);
+    try expectEqual(Relocatable.init(1, 2), vm.run_context.ap.*);
+    try expectEqual(Relocatable.init(1, 0), vm.run_context.fp.*);
+
+    try expectEqualSlices(
+        TraceContext.Entry,
+        &[_]TraceContext.Entry{
+            .{
+                .pc = Relocatable.init(2, 0),
+                .ap = Relocatable.init(1, 2),
+                .fp = Relocatable.init(1, 2),
+            },
+        },
+        vm.trace_context.state.enabled.entries.items,
+    );
+
+    // Check that the following addresses have been accessed
+    try expect(vm.segments.memory.data.items[1].items[0].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[1].?.is_accessed);
+}
+
+test "CairoVM: test step for preset memory program loaded into user segment 1" {
+    //Test for a simple program execution
+    //Used program code:
+    //    func myfunc(a: felt) -> (r: felt):
+    //        let b = a * 2
+    //        return(b)
+    //    end
+    //    func main():
+    //        let a = 1
+    //        let b = myfunc(a)
+    //        return()
+    //    end
+    //Memory taken from original vm:
+    //{RelocatableValue(segment_index=0, offset=0): 5207990763031199744,
+    //RelocatableValue(segment_index=0, offset=1): 2,
+    //RelocatableValue(segment_index=0, offset=2): 2345108766317314046,
+    //RelocatableValue(segment_index=0, offset=3): 5189976364521848832,
+    //RelocatableValue(segment_index=0, offset=4): 1,
+    //RelocatableValue(segment_index=0, offset=5): 1226245742482522112,
+    //RelocatableValue(segment_index=0, offset=6): 3618502788666131213697322783095070105623107215331596699973092056135872020476,
+    //RelocatableValue(segment_index=0, offset=7): 2345108766317314046,
+    //RelocatableValue(segment_index=1, offset=0): RelocatableValue(segment_index=2, offset=0),
+    //RelocatableValue(segment_index=1, offset=1): RelocatableValue(segment_index=3, offset=0)}
+    //Current register values:
+    //AP 1:2
+    //FP 1:2
+    //PC 0:3
+    //Final Pc (not executed): 3:0
+    //This program consists of 5 steps
+
+    // Test setup
+    const allocator = std.testing.allocator;
+
+    // Create a new VM instance.
+    var vm = try CairoVM.init(
+        allocator,
+        .{ .proof_mode = false, .enable_trace = true },
+    );
+    defer vm.deinit();
+
+    vm.run_context.pc.* = Relocatable.init(0, 3);
+    vm.run_context.ap.* = Relocatable.init(1, 2);
+    vm.run_context.fp.* = Relocatable.init(1, 2);
+
+    vm.run_context.pc.segment_index = 4;
+
+    try vm.segments.memory.setUpMemory(
+        std.testing.allocator,
+        .{
+            .{ .{ 4, 0 }, .{5207990763031199744} },
+            .{ .{ 4, 1 }, .{2} },
+            .{ .{ 4, 2 }, .{2345108766317314046} },
+            .{ .{ 4, 3 }, .{5189976364521848832} },
+            .{ .{ 4, 4 }, .{1} },
+            .{ .{ 4, 5 }, .{1226245742482522112} },
+            .{ .{ 4, 6 }, .{3618502788666131213697322783095070105623107215331596699973092056135872020476} },
+            .{ .{ 4, 7 }, .{2345108766317314046} },
+            .{ .{ 1, 0 }, .{ 2, 0 } },
+            .{ .{ 1, 1 }, .{ 3, 0 } },
+        },
+    );
+    defer vm.segments.memory.deinitData(std.testing.allocator);
+
+    const final_pc = Relocatable.init(3, 0);
+
+    while (!vm.run_context.pc.eq(final_pc)) {
+        var exec_scopes = try ExecutionScopes.init(allocator);
+        defer exec_scopes.deinit();
+
+        var hint_datas = std.ArrayList(HintData).init(std.testing.allocator);
+        defer hint_datas.deinit();
+
+        var hint_ranges = std.AutoHashMap(Relocatable, HintRange).init(std.testing.allocator);
+        defer hint_ranges.deinit();
+
+        var constants = std.StringHashMap(Felt252).init(std.testing.allocator);
+        defer constants.deinit();
+
+        try vm.stepExtensive(
+            std.testing.allocator,
+            .{},
+            &exec_scopes,
+            &hint_datas,
+            &hint_ranges,
+            &constants,
+        );
+    }
+
+    try expectEqual(Relocatable.init(3, 0), vm.run_context.pc.*);
+    try expectEqual(Relocatable.init(1, 6), vm.run_context.ap.*);
+    try expectEqual(Relocatable.init(1, 0), vm.run_context.fp.*);
+
+    try expectEqualSlices(
+        TraceContext.Entry,
+        &[_]TraceContext.Entry{
+            .{
+                .pc = Relocatable.init(4, 3),
+                .ap = Relocatable.init(1, 2),
+                .fp = Relocatable.init(1, 2),
+            },
+            .{
+                .pc = Relocatable.init(4, 5),
+                .ap = Relocatable.init(1, 3),
+                .fp = Relocatable.init(1, 2),
+            },
+            .{
+                .pc = Relocatable.init(4, 0),
+                .ap = Relocatable.init(1, 5),
+                .fp = Relocatable.init(1, 5),
+            },
+            .{
+                .pc = Relocatable.init(4, 2),
+                .ap = Relocatable.init(1, 6),
+                .fp = Relocatable.init(1, 5),
+            },
+            .{
+                .pc = Relocatable.init(4, 7),
+                .ap = Relocatable.init(1, 6),
+                .fp = Relocatable.init(1, 2),
+            },
+        },
+        vm.trace_context.state.enabled.entries.items,
+    );
+
+    // Check that the following addresses have been accessed
+    try expect(vm.segments.memory.data.items[4].items[1].?.is_accessed);
+    try expect(vm.segments.memory.data.items[4].items[4].?.is_accessed);
+    try expect(vm.segments.memory.data.items[4].items[6].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[0].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[2].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[3].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[4].?.is_accessed);
+    try expect(vm.segments.memory.data.items[1].items[5].?.is_accessed);
+
+    try expectEqual(
+        @as(usize, 3),
+        vm.segments.memory.countAccessedAddressesInSegment(4),
+    );
+    try expectEqual(
+        @as(usize, 6),
+        vm.segments.memory.countAccessedAddressesInSegment(1),
+    );
+}
+
+test "CairoVM: multiplication and different ap increase" {
+    // Test the following program:
+    // ...
+    // [ap] = 4
+    // ap += 1
+    // [ap] = 5; ap++
+    // [ap] = [ap - 1] * [ap - 2]
+    // ...
+    // Original vm memory:
+    // RelocatableValue(segment_index=0, offset=0): '0x400680017fff8000',
+    // RelocatableValue(segment_index=0, offset=1): '0x4',
+    // RelocatableValue(segment_index=0, offset=2): '0x40780017fff7fff',
+    // RelocatableValue(segment_index=0, offset=3): '0x1',
+    // RelocatableValue(segment_index=0, offset=4): '0x480680017fff8000',
+    // RelocatableValue(segment_index=0, offset=5): '0x5',
+    // RelocatableValue(segment_index=0, offset=6): '0x40507ffe7fff8000',
+    // RelocatableValue(segment_index=0, offset=7): '0x208b7fff7fff7ffe',
+    // RelocatableValue(segment_index=1, offset=0): RelocatableValue(segment_index=2, offset=0),
+    // RelocatableValue(segment_index=1, offset=1): RelocatableValue(segment_index=3, offset=0),
+    // RelocatableValue(segment_index=1, offset=2): '0x4',
+    // RelocatableValue(segment_index=1, offset=3): '0x5',
+    // RelocatableValue(segment_index=1, offset=4): '0x14'
+
+    // Test setup
+    const allocator = std.testing.allocator;
+
+    // Create a new VM instance.
+    var vm = try CairoVM.init(
+        allocator,
+        .{ .proof_mode = false, .enable_trace = true },
+    );
+    defer vm.deinit();
+
+    vm.run_context.ap.* = Relocatable.init(1, 2);
+    vm.run_context.fp.* = Relocatable.init(1, 2);
+
+    try expectEqual(Relocatable.init(0, 0), vm.run_context.pc.*);
+    try expectEqual(Relocatable.init(1, 2), vm.run_context.ap.*);
+
+    try vm.segments.memory.setUpMemory(
+        std.testing.allocator,
+        .{
+            .{ .{ 0, 0 }, .{0x400680017fff8000} },
+            .{ .{ 0, 1 }, .{0x4} },
+            .{ .{ 0, 2 }, .{0x40780017fff7fff} },
+            .{ .{ 0, 3 }, .{0x1} },
+            .{ .{ 0, 4 }, .{0x480680017fff8000} },
+            .{ .{ 0, 5 }, .{0x5} },
+            .{ .{ 0, 6 }, .{0x40507ffe7fff8000} },
+            .{ .{ 0, 7 }, .{0x208b7fff7fff7ffe} },
+            .{ .{ 1, 0 }, .{ 2, 0 } },
+            .{ .{ 1, 1 }, .{ 3, 0 } },
+            .{ .{ 1, 2 }, .{0x4} },
+            .{ .{ 1, 3 }, .{0x5} },
+            .{ .{ 1, 4 }, .{0x14} },
+        },
+    );
+    defer vm.segments.memory.deinitData(std.testing.allocator);
+
+    try expectEqual(
+        MaybeRelocatable.fromInt(u256, 0x4),
+        vm.segments.memory.get(vm.run_context.getAP()).?,
+    );
+
+    var exec_scopes = try ExecutionScopes.init(allocator);
+    defer exec_scopes.deinit();
+
+    var hint_datas = std.ArrayList(HintData).init(std.testing.allocator);
+    defer hint_datas.deinit();
+
+    var hint_ranges = std.AutoHashMap(Relocatable, HintRange).init(std.testing.allocator);
+    defer hint_ranges.deinit();
+
+    var constants = std.StringHashMap(Felt252).init(std.testing.allocator);
+    defer constants.deinit();
+
+    try vm.stepExtensive(
+        std.testing.allocator,
+        .{},
+        &exec_scopes,
+        &hint_datas,
+        &hint_ranges,
+        &constants,
+    );
+
+    try expectEqual(Relocatable.init(0, 2), vm.run_context.pc.*);
+    try expectEqual(Relocatable.init(1, 2), vm.run_context.ap.*);
+    try expectEqual(
+        MaybeRelocatable.fromInt(u256, 0x4),
+        vm.segments.memory.get(vm.run_context.getAP()).?,
+    );
+
+    try vm.stepExtensive(
+        std.testing.allocator,
+        .{},
+        &exec_scopes,
+        &hint_datas,
+        &hint_ranges,
+        &constants,
+    );
+
+    try expectEqual(Relocatable.init(0, 4), vm.run_context.pc.*);
+    try expectEqual(Relocatable.init(1, 3), vm.run_context.ap.*);
+    try expectEqual(
+        MaybeRelocatable.fromInt(u256, 0x5),
+        vm.segments.memory.get(vm.run_context.getAP()).?,
+    );
+
+    try vm.stepExtensive(
+        std.testing.allocator,
+        .{},
+        &exec_scopes,
+        &hint_datas,
+        &hint_ranges,
+        &constants,
+    );
+
+    try expectEqual(Relocatable.init(0, 6), vm.run_context.pc.*);
+    try expectEqual(Relocatable.init(1, 4), vm.run_context.ap.*);
+    try expectEqual(
+        MaybeRelocatable.fromInt(u256, 0x14),
+        vm.segments.memory.get(vm.run_context.getAP()).?,
+    );
 }


### PR DESCRIPTION

### Description
This pull request addresses an issue with the `stepInstruction` method in the core of our project. The `stepInstruction` method is responsible for executing the next instruction in the Cairo VM. However, there were some issues related to memory access and instruction caching that needed to be fixed. Additionally, unit tests have been added to ensure the correctness of the method.

### Changes Made
- Fixed memory access boundary check to prevent accessing unknown memory cells.
- Improved handling of the instruction cache to ensure the correct instruction is retrieved.
- Added unit tests to cover various scenarios and edge cases.

