### PR TITLE
Add `writeOutput` for CairoVM and unit tests

### DIFF
--- a/src/vm/error.zig
+++ b/src/vm/error.zig
@@ -68,6 +68,7 @@ pub const CairoVMError = error{
     /// getBuiltin by name, if not exist error
     NotFoundBuiltin,
     ReferenceNotFound,
+    FailedToWriteOutput,
 };
 
 /// Represents different error conditions that are memory-related.


### PR DESCRIPTION
This pull request introduces the `writeOutput` method for the `CairoVM` module, allowing writing output from a program to a specified buffer. Additionally, it includes unit tests to ensure the correctness of the `writeOutput` functionality.

### Changes Made
- Implemented the `writeOutput` method in the `CairoVM` module to enable writing program output.
- Added unit tests to cover various scenarios of writing output from programs, including cases with preset memory and gaps.

### Motivation
The `writeOutput` functionality enhances the capabilities of the `CairoVM` by providing a mechanism to extract program output. This is crucial for debugging, testing, and monitoring program execution, contributing to a more robust development process.
