### PR TITLE
Implement `getRelocatedInstructionLocations` for `Program`

### DIFF
--- a/src/vm/types/programjson.zig
+++ b/src/vm/types/programjson.zig
@@ -149,7 +149,7 @@ pub const Instruction = struct {
 ///
 /// This structure defines a hint location, incorporating location information
 /// and the count of newlines following the "%{" symbol.
-const HintLocation = struct {
+pub const HintLocation = struct {
     /// Location details of the hint.
     location: Instruction,
     /// Number of newlines following the "%{" symbol.


### PR DESCRIPTION
### Description
This pull request implements the `getRelocatedInstructionLocations` method for the `Program` struct. The method is responsible for retrieving relocated instruction locations based on a provided relocation table. This functionality enhances the capability of the `Program` struct to handle relocated instructions efficiently.

### Changes Made
- Added the `getRelocatedInstructionLocations` method to the `Program` struct.
- Implemented the logic to retrieve relocated instruction locations based on a given relocation table.
- Added unit tests to verify the correctness of the implemented functionality.
- Documented the new method and associated unit tests for better understanding and maintainability.


